### PR TITLE
fix(models): thread Mask1D/Mask2D through every model

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "diffrax>=0.6.0",
     "lineax>=0.0.6",
     "einops>=0.8.0",
-    "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.39",
+    "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.40",
     "spectraldiffx>=0.0.10",
 ]
 

--- a/somax/_src/models/pde1d/burgers.py
+++ b/somax/_src/models/pde1d/burgers.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import Advection1D, ArakawaCGrid1D, Difference1D
+from finitevolx import Advection1D, CartesianGrid1D, Difference1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -53,14 +53,16 @@ class Burgers1D(SomaxModel):
         grid: 1D Arakawa C-grid.
         diff: Difference operators (for diffusion).
         advection: Advection operator (for nonlinear convection).
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
         periodic: Whether to use periodic boundary conditions.
         method: Reconstruction method for advection (default ``"upwind1"``).
     """
 
     params: Burgers1DParams
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    diff: Difference1D = eqx.field(static=True)
-    advection: Advection1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    diff: Difference1D
+    advection: Advection1D
+    mask: Mask1D | None
     periodic: bool = eqx.field(static=True, default=True)
     method: str = eqx.field(static=True, default="upwind1")
 
@@ -95,6 +97,7 @@ class Burgers1D(SomaxModel):
         nu: float = 0.01,
         periodic: bool = True,
         method: str = "upwind1",
+        mask: Mask1D | None = None,
     ) -> Burgers1D:
         """Convenience factory.
 
@@ -104,19 +107,21 @@ class Burgers1D(SomaxModel):
             nu: Kinematic viscosity.
             periodic: Use periodic BCs if True, Dirichlet if False.
             method: Advection reconstruction method.
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``Burgers1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
         params = Burgers1DParams(nu=jnp.array(nu))
-        diff = Difference1D(grid=grid)
-        advection = Advection1D(grid=grid)
+        diff = Difference1D(grid=grid, mask=mask)
+        advection = Advection1D(grid=grid, mask=mask)
         return Burgers1D(
             params=params,
             grid=grid,
             diff=diff,
             advection=advection,
+            mask=mask,
             periodic=periodic,
             method=method,
         )

--- a/somax/_src/models/pde1d/diffusion.py
+++ b/somax/_src/models/pde1d/diffusion.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid1D, Difference1D
+from finitevolx import CartesianGrid1D, Difference1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -51,12 +51,14 @@ class Diffusion1D(SomaxModel):
         params: Differentiable parameters (viscosity ``nu``).
         grid: 1D Arakawa C-grid.
         diff: Difference operators.
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
         periodic: Whether to use periodic boundary conditions.
     """
 
     params: Diffusion1DParams
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    diff: Difference1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    diff: Difference1D
+    mask: Mask1D | None
     periodic: bool = eqx.field(static=True, default=True)
 
     def vector_field(
@@ -89,6 +91,7 @@ class Diffusion1D(SomaxModel):
         Lx: float = 2.0,
         nu: float = 0.01,
         periodic: bool = True,
+        mask: Mask1D | None = None,
     ) -> Diffusion1D:
         """Convenience factory.
 
@@ -97,16 +100,18 @@ class Diffusion1D(SomaxModel):
             Lx: Domain length.
             nu: Kinematic viscosity.
             periodic: Use periodic BCs if True, Dirichlet if False.
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``Diffusion1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
         params = Diffusion1DParams(nu=jnp.array(nu))
-        diff = Difference1D(grid=grid)
+        diff = Difference1D(grid=grid, mask=mask)
         return Diffusion1D(
             params=params,
             grid=grid,
             diff=diff,
+            mask=mask,
             periodic=periodic,
         )

--- a/somax/_src/models/pde1d/linear_convection.py
+++ b/somax/_src/models/pde1d/linear_convection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid1D, Difference1D, Interpolation1D
+from finitevolx import CartesianGrid1D, Difference1D, Interpolation1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -52,13 +52,15 @@ class LinearConvection1D(SomaxModel):
         grid: 1D Arakawa C-grid.
         diff: Difference operators.
         interp: Interpolation operators.
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
         periodic: Whether to use periodic boundary conditions.
     """
 
     params: LinearConvection1DParams
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    diff: Difference1D = eqx.field(static=True)
-    interp: Interpolation1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    diff: Difference1D
+    interp: Interpolation1D
+    mask: Mask1D | None
     periodic: bool = eqx.field(static=True, default=True)
 
     def vector_field(
@@ -95,6 +97,7 @@ class LinearConvection1D(SomaxModel):
         Lx: float = 2.0,
         c: float = 1.0,
         periodic: bool = True,
+        mask: Mask1D | None = None,
     ) -> LinearConvection1D:
         """Convenience factory.
 
@@ -103,18 +106,20 @@ class LinearConvection1D(SomaxModel):
             Lx: Domain length.
             c: Wave speed.
             periodic: Use periodic BCs if True, Dirichlet if False.
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``LinearConvection1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
         params = LinearConvection1DParams(c=jnp.array(c))
-        diff = Difference1D(grid=grid)
-        interp = Interpolation1D(grid=grid)
+        diff = Difference1D(grid=grid, mask=mask)
+        interp = Interpolation1D(grid=grid, mask=mask)
         return LinearConvection1D(
             params=params,
             grid=grid,
             diff=diff,
             interp=interp,
+            mask=mask,
             periodic=periodic,
         )

--- a/somax/_src/models/pde1d/nonlinear_convection.py
+++ b/somax/_src/models/pde1d/nonlinear_convection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import Advection1D, ArakawaCGrid1D
+from finitevolx import Advection1D, CartesianGrid1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -39,12 +39,14 @@ class NonlinearConvection1D(SomaxModel):
     Args:
         grid: 1D Arakawa C-grid.
         advection: Advection operator.
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
         periodic: Whether to use periodic boundary conditions.
         method: Reconstruction method for advection (default ``"upwind1"``).
     """
 
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    advection: Advection1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    advection: Advection1D
+    mask: Mask1D | None
     periodic: bool = eqx.field(static=True, default=True)
     method: str = eqx.field(static=True, default="upwind1")
 
@@ -77,6 +79,7 @@ class NonlinearConvection1D(SomaxModel):
         Lx: float = 2.0,
         periodic: bool = True,
         method: str = "upwind1",
+        mask: Mask1D | None = None,
     ) -> NonlinearConvection1D:
         """Convenience factory.
 
@@ -85,15 +88,17 @@ class NonlinearConvection1D(SomaxModel):
             Lx: Domain length.
             periodic: Use periodic BCs if True, Dirichlet if False.
             method: Advection reconstruction method.
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``NonlinearConvection1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
-        advection = Advection1D(grid=grid)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
+        advection = Advection1D(grid=grid, mask=mask)
         return NonlinearConvection1D(
             grid=grid,
             advection=advection,
+            mask=mask,
             periodic=periodic,
             method=method,
         )

--- a/somax/_src/models/pde2d/burgers.py
+++ b/somax/_src/models/pde2d/burgers.py
@@ -6,9 +6,10 @@ import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
     Advection2D as FVXAdvection2D,
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     enforce_periodic,
 )
 from jaxtyping import Array, PyTree
@@ -63,14 +64,16 @@ class Burgers2D(SomaxModel):
         diff: Difference operators.
         advection: Advection operator.
         interp: Interpolation operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         method: Reconstruction method for advection (default ``"upwind1"``).
     """
 
     params: Burgers2DParams
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    advection: FVXAdvection2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    advection: FVXAdvection2D
+    interp: Interpolation2D
+    mask: Mask2D | None
     method: str = eqx.field(static=True, default="upwind1")
 
     def vector_field(
@@ -109,6 +112,7 @@ class Burgers2D(SomaxModel):
         Ly: float = 2.0,
         nu: float = 0.01,
         method: str = "upwind1",
+        mask: Mask2D | None = None,
     ) -> Burgers2D:
         """Convenience factory.
 
@@ -119,20 +123,22 @@ class Burgers2D(SomaxModel):
             Ly: Domain length in y.
             nu: Kinematic viscosity.
             method: Advection reconstruction method.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``Burgers2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = Burgers2DParams(nu=jnp.array(nu))
-        diff = Difference2D(grid=grid)
-        advection = FVXAdvection2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        advection = FVXAdvection2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
         return Burgers2D(
             params=params,
             grid=grid,
             diff=diff,
             advection=advection,
             interp=interp,
+            mask=mask,
             method=method,
         )

--- a/somax/_src/models/pde2d/diffusion.py
+++ b/somax/_src/models/pde2d/diffusion.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid2D, Difference2D, enforce_periodic
+from finitevolx import CartesianGrid2D, Difference2D, Mask2D, enforce_periodic
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -50,11 +50,13 @@ class Diffusion2D(SomaxModel):
         params: Differentiable parameters (viscosity ``nu``).
         grid: 2D Arakawa C-grid.
         diff: Difference operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
     """
 
     params: Diffusion2DParams
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    mask: Mask2D | None
 
     def vector_field(
         self, t: float, state: PyTree, args: PyTree | None = None
@@ -80,6 +82,7 @@ class Diffusion2D(SomaxModel):
         Lx: float = 2.0,
         Ly: float = 2.0,
         nu: float = 0.01,
+        mask: Mask2D | None = None,
     ) -> Diffusion2D:
         """Convenience factory.
 
@@ -89,11 +92,12 @@ class Diffusion2D(SomaxModel):
             Lx: Domain length in x.
             Ly: Domain length in y.
             nu: Kinematic viscosity.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``Diffusion2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = Diffusion2DParams(nu=jnp.array(nu))
-        diff = Difference2D(grid=grid)
-        return Diffusion2D(params=params, grid=grid, diff=diff)
+        diff = Difference2D(grid=grid, mask=mask)
+        return Diffusion2D(params=params, grid=grid, diff=diff, mask=mask)

--- a/somax/_src/models/pde2d/linear_convection.py
+++ b/somax/_src/models/pde2d/linear_convection.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid2D, Difference2D, Interpolation2D, enforce_periodic
+from finitevolx import (
+    CartesianGrid2D,
+    Difference2D,
+    Interpolation2D,
+    Mask2D,
+    enforce_periodic,
+)
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -53,12 +59,14 @@ class LinearConvection2D(SomaxModel):
         grid: 2D Arakawa C-grid.
         diff: Difference operators.
         interp: Interpolation operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
     """
 
     params: LinearConvection2DParams
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    mask: Mask2D | None
 
     def vector_field(
         self, t: float, state: PyTree, args: PyTree | None = None
@@ -89,6 +97,7 @@ class LinearConvection2D(SomaxModel):
         Ly: float = 2.0,
         cx: float = 1.0,
         cy: float = 1.0,
+        mask: Mask2D | None = None,
     ) -> LinearConvection2D:
         """Convenience factory.
 
@@ -99,12 +108,15 @@ class LinearConvection2D(SomaxModel):
             Ly: Domain length in y.
             cx: Wave speed in x.
             cy: Wave speed in y.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``LinearConvection2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = LinearConvection2DParams(cx=jnp.array(cx), cy=jnp.array(cy))
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
-        return LinearConvection2D(params=params, grid=grid, diff=diff, interp=interp)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
+        return LinearConvection2D(
+            params=params, grid=grid, diff=diff, interp=interp, mask=mask
+        )

--- a/somax/_src/models/pde2d/navier_stokes.py
+++ b/somax/_src/models/pde2d/navier_stokes.py
@@ -6,9 +6,10 @@ import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
     Advection2D as FVXAdvection2D,
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     enforce_periodic,
     streamfunction_from_vorticity,
 )
@@ -172,6 +173,7 @@ class IncompressibleNS2D(SomaxModel):
         diff: Difference operators.
         interp: Interpolation operators.
         advection: Advection operator.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         problem: Problem type (``"cavity"`` or ``"channel"``).
         poisson_bc: Spectral solver BC type for Poisson inversion.
         u_lid: Lid velocity for cavity flow (default 1.0).
@@ -180,10 +182,11 @@ class IncompressibleNS2D(SomaxModel):
     """
 
     params: NSParams
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
-    advection: FVXAdvection2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    advection: FVXAdvection2D
+    mask: Mask2D | None
     problem: str = eqx.field(static=True, default="cavity")
     poisson_bc: str = eqx.field(static=True, default="dst")
     u_lid: float = eqx.field(static=True, default=1.0)
@@ -288,6 +291,7 @@ class IncompressibleNS2D(SomaxModel):
         u_lid: float = 1.0,
         body_force: float = 0.0,
         method: str = "upwind1",
+        mask: Mask2D | None = None,
     ) -> IncompressibleNS2D:
         """Convenience factory.
 
@@ -301,15 +305,16 @@ class IncompressibleNS2D(SomaxModel):
             u_lid: Lid velocity for cavity flow.
             body_force: Constant vorticity source for channel flow.
             method: Advection reconstruction method.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             An ``IncompressibleNS2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = NSParams(nu=jnp.array(nu))
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
-        advection = FVXAdvection2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
+        advection = FVXAdvection2D(grid=grid, mask=mask)
         # Both cavity and channel use DST (Dirichlet psi=0 at walls).
         # Channel periodicity in x is enforced via vorticity BCs.
         poisson_bc = "dst"
@@ -319,6 +324,7 @@ class IncompressibleNS2D(SomaxModel):
             diff=diff,
             interp=interp,
             advection=advection,
+            mask=mask,
             problem=problem,
             poisson_bc=poisson_bc,
             u_lid=u_lid,

--- a/somax/_src/models/pde2d/nonlinear_convection.py
+++ b/somax/_src/models/pde2d/nonlinear_convection.py
@@ -6,8 +6,9 @@ import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
     Advection2D as FVXAdvection2D,
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Interpolation2D,
+    Mask2D,
     enforce_periodic,
 )
 from jaxtyping import Array, PyTree
@@ -52,12 +53,14 @@ class NonlinearConvection2D(SomaxModel):
         grid: 2D Arakawa C-grid.
         advection: Advection operator.
         interp: Interpolation operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         method: Reconstruction method (default ``"upwind1"``).
     """
 
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    advection: FVXAdvection2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    advection: FVXAdvection2D
+    interp: Interpolation2D
+    mask: Mask2D | None
     method: str = eqx.field(static=True, default="upwind1")
 
     def vector_field(
@@ -92,6 +95,7 @@ class NonlinearConvection2D(SomaxModel):
         Lx: float = 2.0,
         Ly: float = 2.0,
         method: str = "upwind1",
+        mask: Mask2D | None = None,
     ) -> NonlinearConvection2D:
         """Convenience factory.
 
@@ -101,13 +105,14 @@ class NonlinearConvection2D(SomaxModel):
             Lx: Domain length in x.
             Ly: Domain length in y.
             method: Advection reconstruction method.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``NonlinearConvection2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
-        advection = FVXAdvection2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
+        advection = FVXAdvection2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
         return NonlinearConvection2D(
-            grid=grid, advection=advection, interp=interp, method=method
+            grid=grid, advection=advection, interp=interp, mask=mask, method=method
         )

--- a/somax/_src/models/pde2d/poisson.py
+++ b/somax/_src/models/pde2d/poisson.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid2D, streamfunction_from_vorticity
+from finitevolx import CartesianGrid2D, streamfunction_from_vorticity
 from jaxtyping import Array, Float
 
 
@@ -21,7 +21,7 @@ class PoissonSolver2D(eqx.Module):
             or ``"periodic"``).
     """
 
-    grid: ArakawaCGrid2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
     bc_type: str = eqx.field(static=True, default="dirichlet")
 
     def solve(self, rhs: Float[Array, "Ny Nx"]) -> Float[Array, "Ny Nx"]:
@@ -57,7 +57,7 @@ class PoissonSolver2D(eqx.Module):
         Returns:
             A ``PoissonSolver2D`` instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         return PoissonSolver2D(grid=grid, bc_type=bc)
 
 
@@ -72,7 +72,7 @@ class LaplaceSolver2D(eqx.Module):
         bc_type: Boundary condition type.
     """
 
-    grid: ArakawaCGrid2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
     bc_type: str = eqx.field(static=True, default="dirichlet")
 
     def solve(self) -> Float[Array, "Ny Nx"]:
@@ -95,7 +95,7 @@ class LaplaceSolver2D(eqx.Module):
         bc: str = "dirichlet",
     ) -> LaplaceSolver2D:
         """Convenience factory."""
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         return LaplaceSolver2D(grid=grid, bc_type=bc)
 
 
@@ -113,7 +113,7 @@ class HelmholtzSolver2D(eqx.Module):
         lambda_: Helmholtz parameter (screening coefficient).
     """
 
-    grid: ArakawaCGrid2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
     bc_type: str = eqx.field(static=True, default="dirichlet")
     lambda_: float = eqx.field(static=True, default=1.0)
 
@@ -154,5 +154,5 @@ class HelmholtzSolver2D(eqx.Module):
         Returns:
             A ``HelmholtzSolver2D`` instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         return HelmholtzSolver2D(grid=grid, bc_type=bc, lambda_=lambda_)

--- a/somax/_src/models/qg/baroclinic.py
+++ b/somax/_src/models/qg/baroclinic.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     arakawa_jacobian,
     multilayer,
     pv_inversion,
@@ -112,6 +113,7 @@ class BaroclinicQG(SomaxModel):
         grid: 2D Arakawa C-grid.
         diff: Difference operators.
         interp: Interpolation operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         modal: Precomputed modal transform.
         strat: Stratification profile.
         beta_y: Precomputed beta*(y - y0) field.
@@ -122,9 +124,10 @@ class BaroclinicQG(SomaxModel):
 
     params: BaroclinicQGParams
     consts: BaroclinicQGPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    mask: Mask2D | None
     modal: ModalTransform
     strat: StratificationProfile
     beta_y: Float[Array, "Ny Nx"]
@@ -244,6 +247,7 @@ class BaroclinicQG(SomaxModel):
         wind_amplitude: float = 0.0,
         wind_profile: str = "doublegyre",
         poisson_bc: str = "dst",
+        mask: Mask2D | None = None,
     ) -> BaroclinicQG:
         """Convenience factory for the multilayer QG model.
 
@@ -267,6 +271,7 @@ class BaroclinicQG(SomaxModel):
             wind_profile: Wind stress curl profile. ``"doublegyre"`` gives
                 ``-sin(2*pi*y/Ly)``, ``"single"`` gives ``sin(pi*y/Ly)``.
             poisson_bc: Spectral solver BC type for PV inversion.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``BaroclinicQG`` model instance.
@@ -275,7 +280,7 @@ class BaroclinicQG(SomaxModel):
             ValueError: If ``n_layers``, ``H``, and ``g_prime`` have
                 inconsistent lengths (when ``stratification`` is None).
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
 
         # Stratification
         if stratification is not None:
@@ -301,8 +306,8 @@ class BaroclinicQG(SomaxModel):
             wind_amplitude=jnp.array(wind_amplitude),
         )
         consts = BaroclinicQGPhysConsts(f0=f0, beta=beta, n_layers=nl)
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
 
         # Precompute beta*y field
         y = jnp.arange(grid.Ny) * grid.dy
@@ -323,6 +328,7 @@ class BaroclinicQG(SomaxModel):
             grid=grid,
             diff=diff,
             interp=interp,
+            mask=mask,
             modal=modal,
             strat=strat,
             beta_y=beta_y,

--- a/somax/_src/models/qg/barotropic.py
+++ b/somax/_src/models/qg/barotropic.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     arakawa_jacobian,
     streamfunction_from_vorticity,
     zero_boundaries,
@@ -96,6 +97,7 @@ class BarotropicQG(SomaxModel):
         grid: 2D Arakawa C-grid.
         diff: Difference operators.
         interp: Interpolation operators.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         beta_y: Precomputed β·y field.
         wind_forcing: Precomputed wind stress curl pattern (normalised).
         poisson_bc: Spectral solver BC type for PV inversion.
@@ -103,9 +105,10 @@ class BarotropicQG(SomaxModel):
 
     params: BarotropicQGParams
     consts: BarotropicQGPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    mask: Mask2D | None
     beta_y: Float[Array, "Ny Nx"]
     wind_forcing: Float[Array, "Ny Nx"]
     poisson_bc: str = eqx.field(static=True, default="dst")
@@ -194,6 +197,7 @@ class BarotropicQG(SomaxModel):
         bottom_drag: float = 0.0,
         wind_amplitude: float = 0.0,
         wind_profile: str = "doublegyre",
+        mask: Mask2D | None = None,
     ) -> BarotropicQG:
         """Convenience factory.
 
@@ -209,19 +213,20 @@ class BarotropicQG(SomaxModel):
             wind_amplitude: Wind forcing amplitude.
             wind_profile: Wind stress curl profile. ``"doublegyre"``
                 gives sin(2πy/Ly), ``"single"`` gives sin(πy/Ly).
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``BarotropicQG`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = BarotropicQGParams(
             lateral_viscosity=jnp.array(lateral_viscosity),
             bottom_drag=jnp.array(bottom_drag),
             wind_amplitude=jnp.array(wind_amplitude),
         )
         consts = BarotropicQGPhysConsts(f0=f0, beta=beta)
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
 
         # Precompute β·y field
         y = jnp.arange(grid.Ny) * grid.dy
@@ -242,6 +247,7 @@ class BarotropicQG(SomaxModel):
             grid=grid,
             diff=diff,
             interp=interp,
+            mask=mask,
             beta_y=beta_y,
             wind_forcing=wind_forcing,
             poisson_bc="dst",

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -13,9 +13,10 @@ from __future__ import annotations
 
 import equinox as eqx
 from finitevolx import (
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     Vorticity2D,
     multilayer,
     pv_inversion,
@@ -99,8 +100,12 @@ class ReparameterizedQG(SomaxModel):
         return self.swm.consts
 
     @property
-    def grid(self) -> ArakawaCGrid2D:
+    def grid(self) -> CartesianGrid2D:
         return self.swm.grid
+
+    @property
+    def mask(self) -> Mask2D | None:
+        return self.swm.mask
 
     @property
     def diff(self) -> Difference2D:
@@ -241,6 +246,7 @@ class ReparameterizedQG(SomaxModel):
         bc: str = "wall",
         method: str = "upwind1",
         poisson_bc: str = "dst",
+        mask: Mask2D | None = None,
     ) -> ReparameterizedQG:
         """Convenience factory for the reparameterized QG model.
 
@@ -271,6 +277,7 @@ class ReparameterizedQG(SomaxModel):
             bc: Boundary condition type (must be ``"wall"``).
             method: Advection reconstruction method.
             poisson_bc: Spectral solver BC type for Helmholtz.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``ReparameterizedQG`` model instance.
@@ -304,6 +311,7 @@ class ReparameterizedQG(SomaxModel):
             wind_profile=wind_profile,
             bc=bc,
             method=method,
+            mask=mask,
         )
 
         helmholtz_lambdas = f0**2 * swm.modal.eigenvalues

--- a/somax/_src/models/swm/linear_1d.py
+++ b/somax/_src/models/swm/linear_1d.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import ArakawaCGrid1D, Difference1D, Interpolation1D
+from finitevolx import CartesianGrid1D, Difference1D, Interpolation1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -81,13 +81,15 @@ class LinearShallowWater1D(SomaxModel):
         grid: 1D Arakawa C-grid.
         diff: Difference operators.
         interp: Interpolation operators.
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
     """
 
     params: LinearSW1DParams
     consts: LinearSW1DPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    diff: Difference1D = eqx.field(static=True)
-    interp: Interpolation1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    diff: Difference1D
+    interp: Interpolation1D
+    mask: Mask1D | None
 
     def vector_field(
         self, t: float, state: PyTree, args: PyTree | None = None
@@ -157,6 +159,7 @@ class LinearShallowWater1D(SomaxModel):
         H0: float = 100.0,
         lateral_viscosity: float = 0.0,
         bottom_drag: float = 0.0,
+        mask: Mask1D | None = None,
     ) -> LinearShallowWater1D:
         """Convenience factory.
 
@@ -168,18 +171,24 @@ class LinearShallowWater1D(SomaxModel):
             H0: Mean layer depth (m).
             lateral_viscosity: Harmonic viscosity (m²/s).
             bottom_drag: Linear bottom drag (1/s).
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``LinearShallowWater1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
         params = LinearSW1DParams(
             lateral_viscosity=jnp.array(lateral_viscosity),
             bottom_drag=jnp.array(bottom_drag),
         )
         consts = LinearSW1DPhysConsts(gravity=g, f0=f0, H0=H0)
-        diff = Difference1D(grid=grid)
-        interp = Interpolation1D(grid=grid)
+        diff = Difference1D(grid=grid, mask=mask)
+        interp = Interpolation1D(grid=grid, mask=mask)
         return LinearShallowWater1D(
-            params=params, consts=consts, grid=grid, diff=diff, interp=interp
+            params=params,
+            consts=consts,
+            grid=grid,
+            diff=diff,
+            interp=interp,
+            mask=mask,
         )

--- a/somax/_src/models/swm/linear_2d.py
+++ b/somax/_src/models/swm/linear_2d.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Coriolis2D,
     Difference2D,
     Interpolation2D,
+    Mask2D,
     coriolis_fn,
     enforce_periodic,
 )
@@ -90,16 +91,18 @@ class LinearShallowWater2D(SomaxModel):
         diff: Difference operators.
         interp: Interpolation operators.
         coriolis: Coriolis operator.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         f_field: Precomputed Coriolis parameter field f(y).
         bc_type: Boundary condition type (``"periodic"`` or ``"wall"``).
     """
 
     params: LinearSW2DParams
     consts: LinearSW2DPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
-    coriolis: Coriolis2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    coriolis: Coriolis2D
+    mask: Mask2D | None
     f_field: Float[Array, "Ny Nx"]
     bc_type: str = eqx.field(static=True, default="periodic")
 
@@ -178,6 +181,7 @@ class LinearShallowWater2D(SomaxModel):
         lateral_viscosity: float = 0.0,
         bottom_drag: float = 0.0,
         bc: str = "periodic",
+        mask: Mask2D | None = None,
     ) -> LinearShallowWater2D:
         """Convenience factory.
 
@@ -193,19 +197,20 @@ class LinearShallowWater2D(SomaxModel):
             lateral_viscosity: Harmonic viscosity (m²/s).
             bottom_drag: Linear bottom drag (1/s).
             bc: Boundary condition type (``"periodic"`` or ``"wall"``).
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``LinearShallowWater2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = LinearSW2DParams(
             lateral_viscosity=jnp.array(lateral_viscosity),
             bottom_drag=jnp.array(bottom_drag),
         )
         consts = LinearSW2DPhysConsts(gravity=g, f0=f0, beta=beta, H0=H0)
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
-        coriolis = Coriolis2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
+        coriolis = Coriolis2D(grid=grid, mask=mask)
 
         # Build f(y) = f0 + beta * (y - y0) on full grid
         y = jnp.arange(grid.Ny) * grid.dy
@@ -220,6 +225,7 @@ class LinearShallowWater2D(SomaxModel):
             diff=diff,
             interp=interp,
             coriolis=coriolis,
+            mask=mask,
             f_field=f_field,
             bc_type=bc,
         )

--- a/somax/_src/models/swm/multilayer.py
+++ b/somax/_src/models/swm/multilayer.py
@@ -8,11 +8,12 @@ import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
     Advection2D as FVXAdvection2D,
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Coriolis2D,
     Difference2D,
     Diffusion2D as FVXDiffusion2D,
     Interpolation2D,
+    Mask2D,
     Vorticity2D,
     coriolis_fn,
     enforce_periodic,
@@ -119,6 +120,7 @@ class MultilayerShallowWater2D(SomaxModel):
         vorticity: Vorticity/PV operator.
         advection: Scalar advection operator (for mass).
         diffusion: Diffusion operator.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         strat: Stratification profile (layer depths and reduced gravities).
         modal: Precomputed modal transform.
         f_field: Precomputed Coriolis field f(y) at T-points.
@@ -131,13 +133,14 @@ class MultilayerShallowWater2D(SomaxModel):
 
     params: MultilayerSW2DParams
     consts: MultilayerSW2DPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
-    coriolis: Coriolis2D = eqx.field(static=True)
-    vorticity: Vorticity2D = eqx.field(static=True)
-    advection: FVXAdvection2D = eqx.field(static=True)
-    diffusion: FVXDiffusion2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    coriolis: Coriolis2D
+    vorticity: Vorticity2D
+    advection: FVXAdvection2D
+    diffusion: FVXDiffusion2D
+    mask: Mask2D | None
     strat: StratificationProfile
     modal: ModalTransform
     f_field: Float[Array, "Ny Nx"]
@@ -274,6 +277,7 @@ class MultilayerShallowWater2D(SomaxModel):
         wind_profile: str = "doublegyre",
         bc: str = "periodic",
         method: str = "upwind1",
+        mask: Mask2D | None = None,
     ) -> MultilayerShallowWater2D:
         """Convenience factory for the multilayer shallow water model.
 
@@ -302,6 +306,7 @@ class MultilayerShallowWater2D(SomaxModel):
                 tau_x = -cos(pi*y/Ly).
             bc: Boundary condition type.
             method: Advection reconstruction method for mass.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``MultilayerShallowWater2D`` model instance.
@@ -310,7 +315,7 @@ class MultilayerShallowWater2D(SomaxModel):
             ValueError: If ``n_layers``, ``H``, and ``g_prime`` have
                 inconsistent lengths (when ``stratification`` is None).
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
 
         # Stratification
         if stratification is not None:
@@ -335,12 +340,12 @@ class MultilayerShallowWater2D(SomaxModel):
             wind_amplitude=jnp.array(wind_amplitude),
         )
         consts = MultilayerSW2DPhysConsts(gravity=g, f0=f0, beta=beta, n_layers=nl)
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
-        coriolis = Coriolis2D(grid=grid)
-        vorticity_op = Vorticity2D(grid=grid)
-        advection = FVXAdvection2D(grid=grid)
-        diffusion = FVXDiffusion2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
+        coriolis = Coriolis2D(grid=grid, mask=mask)
+        vorticity_op = Vorticity2D(grid=grid, mask=mask)
+        advection = FVXAdvection2D(grid=grid, mask=mask)
+        diffusion = FVXDiffusion2D(grid=grid, mask=mask)
 
         # Precompute Coriolis field
         y = jnp.arange(grid.Ny) * grid.dy
@@ -366,6 +371,7 @@ class MultilayerShallowWater2D(SomaxModel):
             vorticity=vorticity_op,
             advection=advection,
             diffusion=diffusion,
+            mask=mask,
             strat=strat,
             modal=modal,
             f_field=f_field,

--- a/somax/_src/models/swm/nonlinear_1d.py
+++ b/somax/_src/models/swm/nonlinear_1d.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import equinox as eqx
 import jax.numpy as jnp
-from finitevolx import Advection1D, ArakawaCGrid1D, Difference1D, Interpolation1D
+from finitevolx import (
+    Advection1D,
+    CartesianGrid1D,
+    Difference1D,
+    Interpolation1D,
+    Mask1D,
+)
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
@@ -79,15 +85,17 @@ class NonlinearShallowWater1D(SomaxModel):
         diff: Difference operators.
         interp: Interpolation operators.
         advection: Advection operator.
+        mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
         method: Advection reconstruction method.
     """
 
     params: NonlinearSW1DParams
     consts: NonlinearSW1DPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid1D = eqx.field(static=True)
-    diff: Difference1D = eqx.field(static=True)
-    interp: Interpolation1D = eqx.field(static=True)
-    advection: Advection1D = eqx.field(static=True)
+    grid: CartesianGrid1D = eqx.field(static=True)
+    diff: Difference1D
+    interp: Interpolation1D
+    advection: Advection1D
+    mask: Mask1D | None
     method: str = eqx.field(static=True, default="upwind1")
 
     def vector_field(
@@ -161,6 +169,7 @@ class NonlinearShallowWater1D(SomaxModel):
         lateral_viscosity: float = 0.0,
         bottom_drag: float = 0.0,
         method: str = "upwind1",
+        mask: Mask1D | None = None,
     ) -> NonlinearShallowWater1D:
         """Convenience factory.
 
@@ -173,19 +182,20 @@ class NonlinearShallowWater1D(SomaxModel):
             lateral_viscosity: Harmonic viscosity (m²/s).
             bottom_drag: Linear bottom drag (1/s).
             method: Advection reconstruction method.
+            mask: Optional 1-D Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``NonlinearShallowWater1D`` model instance.
         """
-        grid = ArakawaCGrid1D.from_interior(nx, Lx)
+        grid = CartesianGrid1D.from_interior(nx, Lx)
         params = NonlinearSW1DParams(
             lateral_viscosity=jnp.array(lateral_viscosity),
             bottom_drag=jnp.array(bottom_drag),
         )
         consts = NonlinearSW1DPhysConsts(gravity=g, f0=f0, H0=H0)
-        diff = Difference1D(grid=grid)
-        interp = Interpolation1D(grid=grid)
-        advection = Advection1D(grid=grid)
+        diff = Difference1D(grid=grid, mask=mask)
+        interp = Interpolation1D(grid=grid, mask=mask)
+        advection = Advection1D(grid=grid, mask=mask)
         return NonlinearShallowWater1D(
             params=params,
             consts=consts,
@@ -193,5 +203,6 @@ class NonlinearShallowWater1D(SomaxModel):
             diff=diff,
             interp=interp,
             advection=advection,
+            mask=mask,
             method=method,
         )

--- a/somax/_src/models/swm/nonlinear_2d.py
+++ b/somax/_src/models/swm/nonlinear_2d.py
@@ -6,11 +6,12 @@ import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
     Advection2D as FVXAdvection2D,
-    ArakawaCGrid2D,
+    CartesianGrid2D,
     Coriolis2D,
     Difference2D,
     Diffusion2D as FVXDiffusion2D,
     Interpolation2D,
+    Mask2D,
     Vorticity2D,
     coriolis_fn,
     enforce_periodic,
@@ -107,6 +108,7 @@ class NonlinearShallowWater2D(SomaxModel):
         vorticity: Vorticity/PV operator.
         advection: Scalar advection operator (for mass).
         diffusion: Diffusion operator.
+        mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
         f_field: Precomputed Coriolis field f(y).
         wind_stress_x: Precomputed x-wind stress pattern (normalised).
         wind_stress_y: Precomputed y-wind stress pattern (normalised).
@@ -116,13 +118,14 @@ class NonlinearShallowWater2D(SomaxModel):
 
     params: NonlinearSW2DParams
     consts: NonlinearSW2DPhysConsts = eqx.field(static=True)
-    grid: ArakawaCGrid2D = eqx.field(static=True)
-    diff: Difference2D = eqx.field(static=True)
-    interp: Interpolation2D = eqx.field(static=True)
-    coriolis: Coriolis2D = eqx.field(static=True)
-    vorticity: Vorticity2D = eqx.field(static=True)
-    advection: FVXAdvection2D = eqx.field(static=True)
-    diffusion: FVXDiffusion2D = eqx.field(static=True)
+    grid: CartesianGrid2D = eqx.field(static=True)
+    diff: Difference2D
+    interp: Interpolation2D
+    coriolis: Coriolis2D
+    vorticity: Vorticity2D
+    advection: FVXAdvection2D
+    diffusion: FVXDiffusion2D
+    mask: Mask2D | None
     f_field: Float[Array, "Ny Nx"]
     wind_stress_x: Float[Array, "Ny Nx"]
     wind_stress_y: Float[Array, "Ny Nx"]
@@ -249,6 +252,7 @@ class NonlinearShallowWater2D(SomaxModel):
         wind_profile: str = "doublegyre",
         bc: str = "periodic",
         method: str = "upwind1",
+        mask: Mask2D | None = None,
     ) -> NonlinearShallowWater2D:
         """Convenience factory.
 
@@ -269,23 +273,24 @@ class NonlinearShallowWater2D(SomaxModel):
                 tau_x = -cos(pi*y/Ly).
             bc: Boundary condition type.
             method: Advection reconstruction method for mass.
+            mask: Optional Arakawa C-grid mask (``None`` = all-ocean).
 
         Returns:
             A ``NonlinearShallowWater2D`` model instance.
         """
-        grid = ArakawaCGrid2D.from_interior(nx, ny, Lx, Ly)
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
         params = NonlinearSW2DParams(
             lateral_viscosity=jnp.array(lateral_viscosity),
             bottom_drag=jnp.array(bottom_drag),
             wind_amplitude=jnp.array(wind_amplitude),
         )
         consts = NonlinearSW2DPhysConsts(gravity=g, f0=f0, beta=beta, H0=H0)
-        diff = Difference2D(grid=grid)
-        interp = Interpolation2D(grid=grid)
-        coriolis = Coriolis2D(grid=grid)
-        vorticity_op = Vorticity2D(grid=grid)
-        advection = FVXAdvection2D(grid=grid)
-        diffusion = FVXDiffusion2D(grid=grid)
+        diff = Difference2D(grid=grid, mask=mask)
+        interp = Interpolation2D(grid=grid, mask=mask)
+        coriolis = Coriolis2D(grid=grid, mask=mask)
+        vorticity_op = Vorticity2D(grid=grid, mask=mask)
+        advection = FVXAdvection2D(grid=grid, mask=mask)
+        diffusion = FVXDiffusion2D(grid=grid, mask=mask)
 
         y = jnp.arange(grid.Ny) * grid.dy
         y0 = Ly / 2.0
@@ -310,6 +315,7 @@ class NonlinearShallowWater2D(SomaxModel):
             vorticity=vorticity_op,
             advection=advection,
             diffusion=diffusion,
+            mask=mask,
             f_field=f_field,
             wind_stress_x=wind_stress_x,
             wind_stress_y=wind_stress_y,

--- a/tests/models/test_masks.py
+++ b/tests/models/test_masks.py
@@ -104,10 +104,13 @@ class TestCoastalMaskNonlinearSWM2D:
             nx=nx - 2, ny=ny - 2, bc="wall", mask=mask
         )
         rng = np.random.default_rng(0)
-        h0 = jnp.asarray(0.1 * rng.standard_normal((ny, nx)))
+        # h is layer thickness in PV q = (ζ+f)/h, so keep wet-cell
+        # thickness strictly positive (baseline ~1 + small perturbation)
+        # to avoid division blow-ups; mask is applied on top to enforce
+        # the dry-cell invariant.
+        h0 = jnp.ones((ny, nx)) + jnp.asarray(0.01 * rng.standard_normal((ny, nx)))
         u0 = jnp.asarray(0.01 * rng.standard_normal((ny, nx)))
         v0 = jnp.asarray(0.01 * rng.standard_normal((ny, nx)))
-        # Apply mask to enforce the dry-cell invariant on the initial state
         h0 = h0 * mask.h
         u0 = u0 * mask.u
         v0 = v0 * mask.v

--- a/tests/models/test_masks.py
+++ b/tests/models/test_masks.py
@@ -1,0 +1,147 @@
+"""End-to-end smoke tests that models accept a mask.
+
+These pin the threading of the finitevolX ``Mask1D`` / ``Mask2D`` API
+through every family: the models are constructed with an all-ocean mask
+and then, for the canonical 2-D SWM, with a coastal mask that carves a
+small island.  The tests assert the models build, their RHS is finite,
+and — for the coastal case — dry T-cells stay at zero after a few steps.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from finitevolx import Mask1D, Mask2D
+
+from somax.models import (
+    BarotropicQG,
+    Burgers1D,
+    Burgers2D,
+    LinearShallowWater1D,
+    LinearShallowWater2D,
+    NonlinearShallowWater1D,
+    NonlinearShallowWater2D,
+    NonlinearSW2DState,
+)
+
+
+def _island_mask(ny: int, nx: int) -> Mask2D:
+    """Rectangular basin with a small interior island."""
+    h = np.ones((ny, nx), dtype=bool)
+    h[0, :] = h[-1, :] = False
+    h[:, 0] = h[:, -1] = False
+    j0, j1 = ny // 2 - 1, ny // 2 + 2
+    i0, i1 = nx // 2 - 1, nx // 2 + 2
+    h[j0:j1, i0:i1] = False
+    return Mask2D.from_mask(jnp.asarray(h))
+
+
+# ---------------------------------------------------------------------------
+# All-ocean smoke tests: model builds and RHS evaluates without errors
+# ---------------------------------------------------------------------------
+
+
+class TestAllOceanMaskSmoke:
+    def test_swm_linear_2d(self):
+        mask = Mask2D.from_dimensions(ny=16, nx=16)
+        model = LinearShallowWater2D.create(nx=14, ny=14, mask=mask)
+        assert model.mask is mask
+        assert model.diff.mask is mask
+
+    def test_swm_nonlinear_2d(self):
+        mask = Mask2D.from_dimensions(ny=16, nx=16)
+        model = NonlinearShallowWater2D.create(nx=14, ny=14, mask=mask)
+        h0 = jnp.ones((model.grid.Ny, model.grid.Nx))
+        u0 = jnp.zeros_like(h0)
+        state = NonlinearSW2DState(h=h0, u=u0, v=u0)
+        state = model.apply_boundary_conditions(state)
+        tend = model.vector_field(0.0, state)
+        assert jnp.all(jnp.isfinite(tend.h))
+        assert jnp.all(jnp.isfinite(tend.u))
+        assert jnp.all(jnp.isfinite(tend.v))
+
+    def test_qg_barotropic(self):
+        mask = Mask2D.from_dimensions(ny=16, nx=16)
+        model = BarotropicQG.create(nx=14, ny=14, mask=mask)
+        assert model.diff.mask is mask
+
+    def test_pde2d_burgers(self):
+        mask = Mask2D.from_dimensions(ny=16, nx=16)
+        model = Burgers2D.create(nx=14, ny=14, mask=mask)
+        assert model.advection.mask is mask
+
+    def test_pde1d_burgers(self):
+        mask = Mask1D.from_dimensions(nx=32)
+        model = Burgers1D.create(nx=30, mask=mask)
+        assert model.diff.mask is mask
+        assert model.advection.mask is mask
+
+    def test_swm_linear_1d(self):
+        mask = Mask1D.from_dimensions(nx=32)
+        model = LinearShallowWater1D.create(nx=30, mask=mask)
+        assert model.mask is mask
+        assert model.interp.mask is mask
+
+    def test_swm_nonlinear_1d(self):
+        mask = Mask1D.from_dimensions(nx=32)
+        model = NonlinearShallowWater1D.create(nx=30, mask=mask)
+        assert model.advection.mask is mask
+
+
+# ---------------------------------------------------------------------------
+# Coastal mask: dry cells stay zero in the integrated state
+# ---------------------------------------------------------------------------
+
+
+class TestCoastalMaskNonlinearSWM2D:
+    @pytest.fixture
+    def model_and_state(self):
+        ny, nx = 20, 20
+        mask = _island_mask(ny, nx)
+        model = NonlinearShallowWater2D.create(
+            nx=nx - 2, ny=ny - 2, bc="wall", mask=mask
+        )
+        rng = np.random.default_rng(0)
+        h0 = jnp.asarray(0.1 * rng.standard_normal((ny, nx)))
+        u0 = jnp.asarray(0.01 * rng.standard_normal((ny, nx)))
+        v0 = jnp.asarray(0.01 * rng.standard_normal((ny, nx)))
+        # Apply mask to enforce the dry-cell invariant on the initial state
+        h0 = h0 * mask.h
+        u0 = u0 * mask.u
+        v0 = v0 * mask.v
+        state = NonlinearSW2DState(h=h0, u=u0, v=v0)
+        state = model.apply_boundary_conditions(state)
+        return model, state, mask
+
+    def test_dry_cells_stay_zero_after_one_rhs(self, model_and_state):
+        """One RHS evaluation must not inject non-zero into dry T-cells."""
+        model, state, mask = model_and_state
+        tend = model.vector_field(0.0, state)
+        # dh/dt comes through advection → T-point output → mask.h applies
+        dry_T = ~mask.h
+        assert float(jnp.max(jnp.abs(tend.h[dry_T]))) == 0.0
+
+    def test_integrate_short_finite(self, model_and_state):
+        """A few Euler steps remain finite with the coastal mask threaded."""
+        model, state, _mask = model_and_state
+        dt = 1.0
+
+        @eqx.filter_jit
+        def step(s):
+            tend = model.vector_field(0.0, s)
+            new = NonlinearSW2DState(
+                h=s.h + dt * tend.h,
+                u=s.u + dt * tend.u,
+                v=s.v + dt * tend.v,
+            )
+            return model.apply_boundary_conditions(new)
+
+        s = state
+        for _ in range(3):
+            s = step(s)
+
+        assert jnp.all(jnp.isfinite(s.h))
+        assert jnp.all(jnp.isfinite(s.u))
+        assert jnp.all(jnp.isfinite(s.v))


### PR DESCRIPTION
## Summary

Somax-side companion to finitevolX's operator-attribute mask API (jejjohnson/finitevolX#211, released as v0.0.40). Every model now carries a first-class `mask` field — even when `None` — matching somax v2 design rule D2.

Closes #82.

## What changed

- **Dependency pin**: `finitevolx` bumped `v0.0.39 → v0.0.40`; `uv.lock` refreshed.
- **Every model gains a `mask` field** of the correct dimension (`Mask1D` for 1-D, `Mask2D` for 2-D) and threads it into every finitevolX class operator at construction time:
  ```python
  Difference2D(grid=g, mask=mask)
  Interpolation2D(grid=g, mask=mask)
  Advection2D(grid=g, mask=mask)
  Coriolis2D(grid=g, mask=mask)
  Vorticity2D(grid=g, mask=mask)
  Diffusion2D(grid=g, mask=mask)
  ```
- Operator fields are no longer `eqx.field(static=True)` — masks carry array leaves so the operator cannot be hashed. Grid fields stay static (int/float only).
- `ArakawaCGrid*.from_interior` → `CartesianGrid*.from_interior` (grid restructure jejjohnson/finitevolX#207 put `from_interior` on the concrete Cartesian subclass).

## Models updated

| Family | Files |
|---|---|
| **SWM** (5) | `linear_1d.py`, `linear_2d.py`, `nonlinear_1d.py`, `nonlinear_2d.py`, `multilayer.py` |
| **QG** (3) | `barotropic.py`, `baroclinic.py`, `reparameterized.py` |
| **PDE 1-D** (4) | `burgers.py`, `diffusion.py`, `linear_convection.py`, `nonlinear_convection.py` |
| **PDE 2-D** (6) | `burgers.py`, `diffusion.py`, `linear_convection.py`, `nonlinear_convection.py`, `navier_stokes.py`, `poisson.py`* |

\* `poisson.py` only took the `ArakawaCGrid2D → CartesianGrid2D` rename — it has no mask-aware operators.

## Note on the API that shipped vs. what #82 described

Issue #82 was drafted against an earlier finitevolX design (#204) where `mask=` was a per-call kwarg. The API that actually landed (#211) moved the mask to operator **construction** (class field), so the mechanical pass is:

```python
# old (per-call, never existed in somax)
self._diff.laplacian(h, mask=self.mask)

# new (class field, what this PR uses)
self._diff = Difference2D(grid=g, mask=self.mask)
...
self._diff.laplacian(h)   # mask baked in; no threading per call needed
```

The `vector_field` bodies therefore did not change — only the operator constructors in `create()` and the model field declarations.

## Tests

- **New** `tests/models/test_masks.py`:
  - `TestAllOceanMaskSmoke` — 7 families build with an all-ocean `Mask1D` / `Mask2D` and their operators carry `self.mask`.
  - `TestCoastalMaskNonlinearSWM2D` — island geometry end-to-end for the canonical 2-D nonlinear SWM: pins dry-T-cell-is-zero after one RHS call and finiteness after 3 Euler steps.
- **Full suite**: 383 passed (9 new + 374 regression). `ruff check`, `ruff format --check`, and `ty check somax` all clean.

## Out of scope (follow-ups)

- CLI `TestCaseSpec.mask` block (Step 6 of #82, deliberately deferred).
- Realistic mask sourcing from external data (tracked in jejjohnson/finitevolX#185 and #74).

## Test plan

- [x] `uv run pytest -v` — 383 passed
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check somax` — clean
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)