### PR TITLE
refactor(cli): scaffold scenarios/ + models_registry/ + compatibility (Phase 2)

### DIFF
--- a/somax/_src/cli/_compatibility.py
+++ b/somax/_src/cli/_compatibility.py
@@ -1,0 +1,123 @@
+"""Scenario x model compatibility checks.
+
+Per decision 3 of epic #72: compatibility is **inferred** from
+``Geometry.kind`` x model ``coordinates`` plus ``SupportFlags.masks``,
+with explicit overrides for nonsense pairs held in
+:data:`INCOMPATIBLE_PAIRS`.
+
+The checker operates on registry entries rather than on a built
+:class:`ScenarioBundle`, so a stubbed entry (Phase-2 state) is enough
+for compatibility dispatch to work.
+"""
+
+from __future__ import annotations
+
+from somax._src.cli.models_registry import ModelEntry, get_model
+from somax._src.cli.scenarios import ScenarioEntry, get_scenario
+
+
+# ---------------------------------------------------------------------------
+# Explicit incompatibility overrides
+# ---------------------------------------------------------------------------
+#
+# Each entry is ``(scenario_name, model_name)``. Use this set only when
+# the inferred compatibility (geometry x coordinates + masks) gives the
+# wrong answer for a genuinely nonsensical combination — prefer fixing
+# the metadata on the registry entry first.
+INCOMPATIBLE_PAIRS: set[tuple[str, str]] = set()
+
+
+class IncompatiblePairError(ValueError):
+    """Raised by :func:`check_compatible` when a pair is rejected.
+
+    The message explains the reason so the CLI can surface a
+    user-readable error — for example, a masked scenario paired with
+    a model whose ``SupportFlags.masks`` is ``False``.
+    """
+
+
+def _geometry_matches(scenario: ScenarioEntry, model: ModelEntry) -> bool:
+    """Geometry x coordinates rule.
+
+    - ``rectangular``  → ``cartesian`` model
+    - ``real_basin``   → ``cartesian`` model (mask support checked separately)
+    - ``spherical_cap``→ ``spherical`` model
+    """
+    if scenario.geometry_kind == "rectangular":
+        return model.coordinates == "cartesian"
+    if scenario.geometry_kind == "real_basin":
+        return model.coordinates == "cartesian"
+    if scenario.geometry_kind == "spherical_cap":
+        return model.coordinates == "spherical"
+    return False
+
+
+def _requires_masks(scenario: ScenarioEntry) -> bool:
+    """Which geometries carry a land/coastline mask the model must handle."""
+    return scenario.geometry_kind in ("real_basin", "spherical_cap")
+
+
+def _reason_for_rejection(scenario: ScenarioEntry, model: ModelEntry) -> str | None:
+    """Return ``None`` if the pair is compatible, else an explanation string."""
+    if (scenario.name, model.name) in INCOMPATIBLE_PAIRS:
+        return (
+            f"{scenario.name!r} x {model.name!r} is explicitly marked "
+            "incompatible in INCOMPATIBLE_PAIRS."
+        )
+    if not _geometry_matches(scenario, model):
+        return (
+            f"geometry kind {scenario.geometry_kind!r} is incompatible "
+            f"with model coordinates {model.coordinates!r}."
+        )
+    if _requires_masks(scenario) and not model.supports.masks:
+        return (
+            f"scenario {scenario.name!r} has a land mask but model "
+            f"{model.name!r} does not set SupportFlags.masks=True."
+        )
+    return None
+
+
+def is_compatible(scenario_name: str, model_name: str) -> bool:
+    """Return ``True`` iff the pair is accepted by the compatibility rules."""
+    return (
+        _reason_for_rejection(get_scenario(scenario_name), get_model(model_name))
+        is None
+    )
+
+
+def check_compatible(scenario_name: str, model_name: str) -> None:
+    """Raise :class:`IncompatiblePairError` if the pair is rejected.
+
+    Args:
+        scenario_name: Key in the scenarios registry.
+        model_name: Key in the models registry.
+
+    Raises:
+        KeyError: If either name is not registered.
+        IncompatiblePairError: If the pair fails the geometry / mask /
+            explicit-override checks.
+    """
+    scenario = get_scenario(scenario_name)
+    model = get_model(model_name)
+    reason = _reason_for_rejection(scenario, model)
+    if reason is not None:
+        raise IncompatiblePairError(
+            f"scenario {scenario_name!r} and model {model_name!r} are "
+            f"incompatible: {reason}"
+        )
+
+
+def compatibility_matrix() -> dict[str, dict[str, bool]]:
+    """Compute the full compatibility matrix over registered pairs.
+
+    Returns:
+        Nested dict ``{scenario_name: {model_name: bool}}`` with one
+        entry per registered scenario x model. Useful for rendering
+        the ``list-pairs`` subcommand.
+    """
+    from somax._src.cli.models_registry import list_models as _list_models
+    from somax._src.cli.scenarios import list_scenarios as _list_scenarios
+
+    return {
+        s: {m: is_compatible(s, m) for m in _list_models()} for s in _list_scenarios()
+    }

--- a/somax/_src/cli/_factories.py
+++ b/somax/_src/cli/_factories.py
@@ -170,3 +170,54 @@ def get_adapter(name: str) -> Adapter:
     except KeyError as exc:
         available = ", ".join(list_test_cases())
         raise KeyError(f"unknown test case {name!r}; available: {available}") from exc
+
+
+# ----------------------------------------------------------------------
+# Phase-2 addition (#76): scenario x model build dispatcher
+#
+# Thin wrapper over the scenarios / models_registry; runs the
+# compatibility check first, then dispatches to the registered ``build``
+# callables. The runner doesn't call this yet (Phase 3 does the
+# cutover); the dispatcher lands here so tests and future phases have a
+# single entry point.
+# ----------------------------------------------------------------------
+
+
+def build(
+    scenario_name: str,
+    model_name: str,
+    *,
+    scenario_params: dict[str, Any] | None = None,
+    model_params: dict[str, Any] | None = None,
+) -> tuple[Any, Any]:
+    """Build ``(model, state0)`` from a scenario x model pair.
+
+    Args:
+        scenario_name: Key in the scenarios registry.
+        model_name: Key in the models registry.
+        scenario_params: YAML ``scenario:`` side knobs (grid, consts,
+            forcing, initial_condition).
+        model_params: YAML ``model:`` side knobs (stratification,
+            differentiable params).
+
+    Returns:
+        ``(model, state0)`` — the same shape as the legacy
+        ``TEST_CASES[name](...)`` adapters. During Phase 2 all registered
+        entries raise :class:`NotImplementedError`; this function still
+        resolves the pair and runs the compatibility check first.
+
+    Raises:
+        KeyError: Unknown scenario or model name.
+        IncompatiblePairError: Pair rejected by the compatibility rules.
+        NotImplementedError: Registered but stubbed entry.
+    """
+    from somax._src.cli._compatibility import check_compatible
+    from somax._src.cli.models_registry import get_model
+    from somax._src.cli.scenarios import get_scenario
+
+    check_compatible(scenario_name, model_name)
+    scenario_entry = get_scenario(scenario_name)
+    model_entry = get_model(model_name)
+    bundle = scenario_entry.build(scenario_params or {})
+    built = model_entry.build(bundle, model_params or {})
+    return built.model, built.state0

--- a/somax/_src/cli/app.py
+++ b/somax/_src/cli/app.py
@@ -243,15 +243,25 @@ def list_testcases() -> None:
         print(f"  - {name}")
 
 
+_PHASE2_NOTE = (
+    "Note: Phase-2 scaffold (#76). Every entry below is a stub — none are "
+    "runnable via `somax-sim run` yet (the runner still dispatches on "
+    "`testcase.name`; Phase 3 cuts over). For currently-runnable entries, "
+    "see `somax-sim list-testcases`."
+)
+
+
 @app.command(name="list-scenarios")
 def list_scenarios() -> None:
     """List scenarios in the Phase-2 registry (``scenario:`` schema)."""
     from somax._src.cli.scenarios import SCENARIOS, list_scenarios as _list
 
+    print(_PHASE2_NOTE)
+    print()
     print("Registered scenarios:")
     for name in _list():
         entry = SCENARIOS[name]
-        print(f"  - {name}  (geometry: {entry.geometry_kind})")
+        print(f"  - {name}  (geometry: {entry.geometry_kind})  [stub]")
 
 
 @app.command(name="list-models")
@@ -259,12 +269,38 @@ def list_models() -> None:
     """List models in the Phase-2 registry (``model:`` schema)."""
     from somax._src.cli.models_registry import MODELS, list_models as _list
 
+    print(_PHASE2_NOTE)
+    print()
     print("Registered models:")
     for name in _list():
         entry = MODELS[name]
         layers = entry.layers if entry.layers == "multi" else f"{entry.layers}-layer"
         masks = "masks=yes" if entry.supports.masks else "masks=no"
-        print(f"  - {name}  ({entry.family}, {layers}, {entry.coordinates}, {masks})")
+        print(
+            f"  - {name}  ({entry.family}, {layers}, {entry.coordinates}, {masks})"
+            "  [stub]"
+        )
+
+
+@app.command(name="list-model-classes")
+def list_model_classes() -> None:
+    """List the importable model classes in ``somax.models`` (library discovery).
+
+    Complements ``list-models`` (which lists Phase-2 registry entries by name
+    for the upcoming ``scenario:`` + ``model:`` YAML schema). Use this when
+    you want to see which ``somax.models.*`` classes are actually importable
+    today from Python.
+    """
+    from somax import models
+
+    names = sorted(
+        n
+        for n in dir(models)
+        if not n.startswith("_") and isinstance(getattr(models, n), type)
+    )
+    print("Model classes in `somax.models`:")
+    for n in names:
+        print(f"  - {n}")
 
 
 @app.command(name="list-pairs")

--- a/somax/_src/cli/app.py
+++ b/somax/_src/cli/app.py
@@ -237,25 +237,64 @@ def restart(
 
 @app.command(name="list-testcases")
 def list_testcases() -> None:
-    """List all registered test cases."""
+    """List all registered test cases (legacy ``testcase:`` schema)."""
     print("Registered test cases:")
     for name in _factories.list_test_cases():
         print(f"  - {name}")
 
 
+@app.command(name="list-scenarios")
+def list_scenarios() -> None:
+    """List scenarios in the Phase-2 registry (``scenario:`` schema)."""
+    from somax._src.cli.scenarios import SCENARIOS, list_scenarios as _list
+
+    print("Registered scenarios:")
+    for name in _list():
+        entry = SCENARIOS[name]
+        print(f"  - {name}  (geometry: {entry.geometry_kind})")
+
+
 @app.command(name="list-models")
 def list_models() -> None:
-    """List the model classes available in somax."""
-    from somax import models
+    """List models in the Phase-2 registry (``model:`` schema)."""
+    from somax._src.cli.models_registry import MODELS, list_models as _list
 
-    names = sorted(
-        n
-        for n in dir(models)
-        if not n.startswith("_") and isinstance(getattr(models, n), type)
+    print("Registered models:")
+    for name in _list():
+        entry = MODELS[name]
+        layers = entry.layers if entry.layers == "multi" else f"{entry.layers}-layer"
+        masks = "masks=yes" if entry.supports.masks else "masks=no"
+        print(f"  - {name}  ({entry.family}, {layers}, {entry.coordinates}, {masks})")
+
+
+@app.command(name="list-pairs")
+def list_pairs() -> None:
+    """Print the scenario x model compatibility matrix."""
+    from somax._src.cli._compatibility import compatibility_matrix
+    from somax._src.cli.models_registry import list_models as _list_models
+    from somax._src.cli.scenarios import list_scenarios as _list_scenarios
+
+    matrix = compatibility_matrix()
+    models = _list_models()
+    scenarios = _list_scenarios()
+
+    name_col = max(len("scenario"), *(len(s) for s in scenarios))
+    widths = [max(len(m), 3) for m in models]
+    header = "  ".join(
+        [
+            f"{'scenario':<{name_col}}",
+            *(f"{m:<{w}}" for m, w in zip(models, widths, strict=True)),
+        ]
     )
-    print("Available model classes:")
-    for n in names:
-        print(f"  - {n}")
+    print(header)
+    print("-" * len(header))
+    for s in scenarios:
+        row = [f"{s:<{name_col}}"]
+        for m, w in zip(models, widths, strict=True):
+            mark = "x" if matrix[s][m] else "."
+            row.append(f"{mark:<{w}}")
+        print("  ".join(row))
+    print("\nLegend: x = compatible, . = incompatible")
 
 
 @app.command(name="show-config")

--- a/somax/_src/cli/models_registry/__init__.py
+++ b/somax/_src/cli/models_registry/__init__.py
@@ -1,0 +1,71 @@
+"""Model registry — how we simulate (equations + integration).
+
+Phase 2 (#76) ships this module with all eight models registered as
+:class:`ModelEntry` instances whose ``build`` raises
+:class:`NotImplementedError`. Phases 3 / 5 populate the stubs.
+
+Public API
+----------
+- :data:`MODELS` — registry dict, keyed by model name.
+- :func:`list_models` — sorted names.
+- :func:`get_model` — lookup by name with a helpful error.
+- Types re-exported from :mod:`._types`.
+"""
+
+from __future__ import annotations
+
+from ._types import (
+    BuiltModel,
+    Coordinates,
+    Family,
+    Layers,
+    ModelEntry,
+    SupportFlags,
+)
+from .barotropic_qg import BAROTROPIC_QG
+from .linear_swm import LINEAR_SWM
+from .multilayer_nonlinear_swm import MULTILAYER_NONLINEAR_SWM
+from .multilayer_qg import MULTILAYER_QG
+from .nonlinear_swm import NONLINEAR_SWM
+from .reparam_multilayer_qg import REPARAM_MULTILAYER_QG
+from .spherical_qg import SPHERICAL_QG
+from .spherical_swm import SPHERICAL_SWM
+
+
+MODELS: dict[str, ModelEntry] = {
+    "linear_swm": LINEAR_SWM,
+    "nonlinear_swm": NONLINEAR_SWM,
+    "barotropic_qg": BAROTROPIC_QG,
+    "multilayer_nonlinear_swm": MULTILAYER_NONLINEAR_SWM,
+    "multilayer_qg": MULTILAYER_QG,
+    "reparam_multilayer_qg": REPARAM_MULTILAYER_QG,
+    "spherical_swm": SPHERICAL_SWM,
+    "spherical_qg": SPHERICAL_QG,
+}
+
+
+def list_models() -> list[str]:
+    """Return registered model names, sorted alphabetically."""
+    return sorted(MODELS)
+
+
+def get_model(name: str) -> ModelEntry:
+    """Look up a model by name. Raises :class:`KeyError` with a helpful message."""
+    try:
+        return MODELS[name]
+    except KeyError as exc:
+        available = ", ".join(list_models())
+        raise KeyError(f"unknown model {name!r}; available: {available}") from exc
+
+
+__all__ = [
+    "MODELS",
+    "BuiltModel",
+    "Coordinates",
+    "Family",
+    "Layers",
+    "ModelEntry",
+    "SupportFlags",
+    "get_model",
+    "list_models",
+]

--- a/somax/_src/cli/models_registry/_types.py
+++ b/somax/_src/cli/models_registry/_types.py
@@ -1,0 +1,90 @@
+"""Structured types for the model registry.
+
+A *model* owns how we simulate — equations of motion, state pytree,
+integration wiring. It consumes a :class:`ScenarioBundle` (see
+:mod:`somax._src.cli.scenarios`) plus per-model parameters and
+produces a :class:`BuiltModel` ready for the runner.
+
+Phase 2 (#76) ships these types and the empty registry. Phases 3-5
+populate the stubs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+
+Family = Literal["swm", "qg"]
+Layers = Literal[1, "multi"]
+Coordinates = Literal["cartesian", "spherical"]
+
+
+@dataclass(frozen=True)
+class SupportFlags:
+    """Capability flags a model advertises for compatibility checking.
+
+    Args:
+        masks: ``True`` iff the model's operators thread an
+            Arakawa C-grid mask (``Mask1D`` / ``Mask2D``) through
+            ``self.mask`` — required to pair the model with any masked
+            scenario (real basins, spherical caps with bathymetry).
+        spherical: ``True`` iff the model is built on spherical
+            operators. Should track ``coordinates == "spherical"``.
+        forcing: Tuple of :class:`ForcingFields` field names the model
+            actually consumes (e.g. ``("tau_x", "tau_y")``). Empty
+            means the model doesn't read any forcing.
+    """
+
+    masks: bool
+    spherical: bool
+    forcing: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BuiltModel:
+    """Runner-ready output of a model build.
+
+    Args:
+        model: The somax model instance (an ``eqx.Module`` subclass).
+        state0: The initial state, already post-applied with the
+            model's boundary conditions.
+    """
+
+    model: Any
+    state0: Any
+
+
+@dataclass(frozen=True)
+class ModelEntry:
+    """Registry entry for a model.
+
+    Exposes enough metadata for the compatibility checker to decide
+    whether a ``(scenario, model)`` pair is valid without calling
+    ``build`` — this lets stubbed Phase-2 entries participate in
+    compatibility logic ahead of their Phase-3/4/5 implementations.
+
+    Args:
+        name: Unique registry key.
+        family: ``"swm"`` (shallow water) or ``"qg"``
+            (quasi-geostrophic).
+        layers: ``1`` for single-layer models, ``"multi"`` for
+            vertically stratified multilayer models.
+        coordinates: ``"cartesian"`` or ``"spherical"``. Must match the
+            :data:`SupportFlags.spherical` bit.
+        supports: Capability flags — masks, spherical, consumed
+            forcing fields.
+        build: Callable that takes a :class:`ScenarioBundle` plus a
+            model-parameter dict and returns a :class:`BuiltModel`.
+            Stubs in Phase 2 raise :class:`NotImplementedError`.
+    """
+
+    name: str
+    family: Family
+    layers: Layers
+    coordinates: Coordinates
+    supports: SupportFlags
+    build: Callable[[ScenarioBundle, dict[str, Any]], BuiltModel] = field(repr=False)

--- a/somax/_src/cli/models_registry/barotropic_qg.py
+++ b/somax/_src/cli/models_registry/barotropic_qg.py
@@ -1,0 +1,30 @@
+"""Barotropic quasi-geostrophic model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.BarotropicQG`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "barotropic_qg.build is stubbed; blocked on Phase 3 (port "
+        "BarotropicQG adapter — see epic #72)."
+    )
+
+
+BAROTROPIC_QG = ModelEntry(
+    name="barotropic_qg",
+    family="qg",
+    layers=1,
+    coordinates="cartesian",
+    supports=SupportFlags(masks=True, spherical=False, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/linear_swm.py
+++ b/somax/_src/cli/models_registry/linear_swm.py
@@ -1,0 +1,34 @@
+"""Linear shallow water model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.LinearShallowWater2D`.
+
+Note: ``supports.masks = False`` — the linear SWM is deliberately
+unmasked; the compatibility checker routes this model to
+``double_gyre`` only (the sole rectangular-unmasked scenario).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "linear_swm.build is stubbed; blocked on Phase 3 (port "
+        "LinearShallowWater2D adapter — see epic #72)."
+    )
+
+
+LINEAR_SWM = ModelEntry(
+    name="linear_swm",
+    family="swm",
+    layers=1,
+    coordinates="cartesian",
+    supports=SupportFlags(masks=False, spherical=False, forcing=()),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/multilayer_nonlinear_swm.py
+++ b/somax/_src/cli/models_registry/multilayer_nonlinear_swm.py
@@ -1,0 +1,30 @@
+"""Multilayer nonlinear shallow water model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.MultilayerShallowWater2D`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "multilayer_nonlinear_swm.build is stubbed; blocked on Phase 3 "
+        "(port MultilayerShallowWater2D adapter — see epic #72)."
+    )
+
+
+MULTILAYER_NONLINEAR_SWM = ModelEntry(
+    name="multilayer_nonlinear_swm",
+    family="swm",
+    layers="multi",
+    coordinates="cartesian",
+    supports=SupportFlags(masks=True, spherical=False, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/multilayer_qg.py
+++ b/somax/_src/cli/models_registry/multilayer_qg.py
@@ -1,0 +1,30 @@
+"""Multilayer baroclinic quasi-geostrophic model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.BaroclinicQG`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "multilayer_qg.build is stubbed; blocked on Phase 3 (port "
+        "BaroclinicQG adapter — see epic #72)."
+    )
+
+
+MULTILAYER_QG = ModelEntry(
+    name="multilayer_qg",
+    family="qg",
+    layers="multi",
+    coordinates="cartesian",
+    supports=SupportFlags(masks=True, spherical=False, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/nonlinear_swm.py
+++ b/somax/_src/cli/models_registry/nonlinear_swm.py
@@ -1,0 +1,30 @@
+"""Nonlinear shallow water model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.NonlinearShallowWater2D`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "nonlinear_swm.build is stubbed; blocked on Phase 3 (port "
+        "NonlinearShallowWater2D adapter — see epic #72)."
+    )
+
+
+NONLINEAR_SWM = ModelEntry(
+    name="nonlinear_swm",
+    family="swm",
+    layers=1,
+    coordinates="cartesian",
+    supports=SupportFlags(masks=True, spherical=False, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/reparam_multilayer_qg.py
+++ b/somax/_src/cli/models_registry/reparam_multilayer_qg.py
@@ -1,0 +1,34 @@
+"""Reparameterized multilayer quasi-geostrophic model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 using
+:class:`somax.models.ReparameterizedQG`.
+
+The underlying class (``ReparameterizedQG``) already exists
+(upstream dependency D5 is satisfied per epic #72); the stub only
+covers the scenario-facing adapter glue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "reparam_multilayer_qg.build is stubbed; blocked on Phase 3 "
+        "(port ReparameterizedQG adapter — see epic #72)."
+    )
+
+
+REPARAM_MULTILAYER_QG = ModelEntry(
+    name="reparam_multilayer_qg",
+    family="qg",
+    layers="multi",
+    coordinates="cartesian",
+    supports=SupportFlags(masks=True, spherical=False, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/spherical_qg.py
+++ b/somax/_src/cli/models_registry/spherical_qg.py
@@ -1,0 +1,32 @@
+"""Spherical quasi-geostrophic model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 5 after the spherical
+operators land in finitevolX (#165) and the somax-side spherical
+QG class exists (D4 in epic #72).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "spherical_qg.build is stubbed; blocked on Phase 5 "
+        "(spherical models in somax — requires finitevolX#165 and "
+        "D4 in epic #72)."
+    )
+
+
+SPHERICAL_QG = ModelEntry(
+    name="spherical_qg",
+    family="qg",
+    layers=1,
+    coordinates="spherical",
+    supports=SupportFlags(masks=True, spherical=True, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/models_registry/spherical_swm.py
+++ b/somax/_src/cli/models_registry/spherical_swm.py
@@ -1,0 +1,32 @@
+"""Spherical shallow water model entry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 5 after the spherical
+operators land in finitevolX (#165) and the somax-side spherical
+SWM class exists (D4 in epic #72).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.cli.scenarios import ScenarioBundle
+
+from ._types import BuiltModel, ModelEntry, SupportFlags
+
+
+def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
+    raise NotImplementedError(
+        "spherical_swm.build is stubbed; blocked on Phase 5 "
+        "(spherical models in somax — requires finitevolX#165 and "
+        "D4 in epic #72)."
+    )
+
+
+SPHERICAL_SWM = ModelEntry(
+    name="spherical_swm",
+    family="swm",
+    layers=1,
+    coordinates="spherical",
+    supports=SupportFlags(masks=True, spherical=True, forcing=("tau_x", "tau_y")),
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/__init__.py
+++ b/somax/_src/cli/scenarios/__init__.py
@@ -1,0 +1,72 @@
+"""Scenario registry — what we simulate (geometry + forcing + IC).
+
+Phase 2 (#76) ships this module with all five scenarios registered as
+:class:`ScenarioEntry` instances whose ``build`` raises
+:class:`NotImplementedError`. Phases 3-5 populate the stubs without
+touching the registry plumbing.
+
+Public API
+----------
+- :data:`SCENARIOS` — the registry dict, keyed by scenario name.
+- :func:`list_scenarios` — sorted names.
+- :func:`get_scenario` — lookup by name with a helpful error.
+- Types re-exported from :mod:`._types`.
+"""
+
+from __future__ import annotations
+
+from ._types import (
+    Constants,
+    ForcingFields,
+    Geometry,
+    GeometryKind,
+    InitialConditionKind,
+    InitialConditionSpec,
+    ScenarioBundle,
+    ScenarioEntry,
+)
+from .double_gyre import DOUBLE_GYRE
+from .global_ocean import GLOBAL_OCEAN
+from .gulf_stream import GULF_STREAM
+from .med_sea import MED_SEA
+from .north_atlantic import NORTH_ATLANTIC
+from .southern_ocean import SOUTHERN_OCEAN
+
+
+SCENARIOS: dict[str, ScenarioEntry] = {
+    "double_gyre": DOUBLE_GYRE,
+    "north_atlantic": NORTH_ATLANTIC,
+    "med_sea": MED_SEA,
+    "gulf_stream": GULF_STREAM,
+    "southern_ocean": SOUTHERN_OCEAN,
+    "global_ocean": GLOBAL_OCEAN,
+}
+
+
+def list_scenarios() -> list[str]:
+    """Return registered scenario names, sorted alphabetically."""
+    return sorted(SCENARIOS)
+
+
+def get_scenario(name: str) -> ScenarioEntry:
+    """Look up a scenario by name. Raises :class:`KeyError` with a helpful message."""
+    try:
+        return SCENARIOS[name]
+    except KeyError as exc:
+        available = ", ".join(list_scenarios())
+        raise KeyError(f"unknown scenario {name!r}; available: {available}") from exc
+
+
+__all__ = [
+    "SCENARIOS",
+    "Constants",
+    "ForcingFields",
+    "Geometry",
+    "GeometryKind",
+    "InitialConditionKind",
+    "InitialConditionSpec",
+    "ScenarioBundle",
+    "ScenarioEntry",
+    "get_scenario",
+    "list_scenarios",
+]

--- a/somax/_src/cli/scenarios/__init__.py
+++ b/somax/_src/cli/scenarios/__init__.py
@@ -1,6 +1,6 @@
 """Scenario registry — what we simulate (geometry + forcing + IC).
 
-Phase 2 (#76) ships this module with all five scenarios registered as
+Phase 2 (#76) ships this module with all scenarios registered as
 :class:`ScenarioEntry` instances whose ``build`` raises
 :class:`NotImplementedError`. Phases 3-5 populate the stubs without
 touching the registry plumbing.

--- a/somax/_src/cli/scenarios/_types.py
+++ b/somax/_src/cli/scenarios/_types.py
@@ -1,0 +1,167 @@
+"""Structured types that every scenario produces.
+
+A *scenario* owns what we simulate — geometry (grid / basin shape),
+basin constants (``f0``, ``beta``, …), forcing fields, and the initial
+condition shape. A *model* (see :mod:`somax._src.cli.models_registry`)
+owns how we simulate it (equations of motion, integration). The
+scenario x model decomposition is tracked by epic #72; this module
+contains the dataclasses they exchange.
+
+Phase 2 (#76) introduces these types and the empty registries.
+Phases 3-5 populate the registries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from jaxtyping import Array, Float
+
+
+GeometryKind = Literal["rectangular", "spherical_cap", "real_basin"]
+
+
+@dataclass(frozen=True)
+class Geometry:
+    """Domain geometry.
+
+    ``kind`` is the compatibility-dispatch key — models expose a
+    matching ``coordinates`` flag plus a ``supports.masks`` bit and the
+    compatibility checker pairs them (see
+    :mod:`somax._src.cli._compatibility`).
+
+    Args:
+        kind: ``"rectangular"`` for unmasked Cartesian basins,
+            ``"real_basin"`` for masked Cartesian basins (coastlines),
+            or ``"spherical_cap"`` for spherical-geometry sectors.
+        nx: Number of interior cells in x.
+        ny: Number of interior cells in y.
+        Lx: Domain length in x (m). Required for Cartesian geometries.
+        Ly: Domain length in y (m). Required for Cartesian geometries.
+        lon_bounds: ``(lon_min, lon_max)`` in degrees. Required for
+            ``spherical_cap``.
+        lat_bounds: ``(lat_min, lat_max)`` in degrees. Required for
+            ``spherical_cap``.
+        mask: Optional wet/dry mask on the T-grid. Required when
+            ``kind`` is ``"real_basin"`` or a masked spherical cap.
+        bathymetry: Optional bottom topography on the T-grid.
+    """
+
+    kind: GeometryKind
+    nx: int
+    ny: int
+    Lx: float | None = None
+    Ly: float | None = None
+    lon_bounds: tuple[float, float] | None = None
+    lat_bounds: tuple[float, float] | None = None
+    mask: Float[Array, "ny nx"] | None = None
+    bathymetry: Float[Array, "ny nx"] | None = None
+
+
+@dataclass(frozen=True)
+class Constants:
+    """Frozen basin constants that the model consumes.
+
+    Args:
+        f0: Reference Coriolis parameter (1/s).
+        beta: Meridional gradient of ``f`` (1/(m·s)).
+        rho0: Reference density (kg/m³).
+        g: Gravitational acceleration (m/s²).
+    """
+
+    f0: float
+    beta: float
+    rho0: float = 1025.0
+    g: float = 9.81
+
+
+@dataclass(frozen=True)
+class ForcingFields:
+    """Precomputed forcing fields, per scenario.
+
+    All fields are optional so each scenario only fills the ones that
+    are physically meaningful. Models declare which fields they consume
+    via :class:`SupportFlags.forcing`.
+
+    Args:
+        tau_x: Zonal wind stress pattern on the T-grid (Pa or normalised).
+        tau_y: Meridional wind stress pattern on the T-grid.
+        heat: Surface heat-flux pattern on the T-grid.
+    """
+
+    tau_x: Float[Array, "ny nx"] | None = None
+    tau_y: Float[Array, "ny nx"] | None = None
+    heat: Float[Array, "ny nx"] | None = None
+
+
+InitialConditionKind = Literal["at_rest", "jet", "gaussian_eddy", "prescribed"]
+
+
+@dataclass(frozen=True)
+class InitialConditionSpec:
+    """Initial-condition shape for a scenario.
+
+    The ``type`` is a registry key; the model's ``build`` uses it to
+    pick an appropriate initial state (every model has to support at
+    least ``"at_rest"``). Shape-specific numbers live in ``params``.
+
+    Args:
+        type: One of the registered initial-condition shapes.
+        params: Keyword arguments for that shape (e.g. ``jet_speed``,
+            ``jet_width``). Empty dict when the shape is parameter-free.
+    """
+
+    type: InitialConditionKind
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ScenarioBundle:
+    """Everything a model needs from a scenario.
+
+    Produced by ``ScenarioEntry.build(params)`` at dispatch time;
+    consumed by ``ModelEntry.build(bundle, model_params)``.
+
+    Args:
+        name: Scenario registry key (informational — the registry is the
+            authoritative source).
+        geometry: Grid / basin shape.
+        constants: Frozen basin constants.
+        forcing: Precomputed forcing fields.
+        initial_condition: Shape + parameters for the initial state.
+    """
+
+    name: str
+    geometry: Geometry
+    constants: Constants
+    forcing: ForcingFields
+    initial_condition: InitialConditionSpec
+
+
+@dataclass(frozen=True)
+class ScenarioEntry:
+    """Registry entry for a scenario.
+
+    Every registered scenario exposes its ``geometry_kind`` (consumed by
+    the compatibility checker) and a ``build`` callable that produces a
+    :class:`ScenarioBundle` from a parameter dict. Phase-2 stubs raise
+    :class:`NotImplementedError` from ``build`` until the later phases
+    populate them.
+
+    Args:
+        name: Unique registry key. Must match the key in
+            :data:`somax._src.cli.scenarios.SCENARIOS`.
+        geometry_kind: The :data:`Geometry.kind` the built bundle will
+            carry. Exposed ahead of ``build`` so the compatibility
+            checker can work against a stub entry.
+        build: Callable that turns a parameter dict into a fully built
+            :class:`ScenarioBundle`. Parameters are the scenario-side
+            knobs in a YAML ``scenario:`` block (``wind_amplitude``,
+            ``jet_speed``, …).
+    """
+
+    name: str
+    geometry_kind: GeometryKind
+    build: Callable[[dict[str, Any]], ScenarioBundle]

--- a/somax/_src/cli/scenarios/double_gyre.py
+++ b/somax/_src/cli/scenarios/double_gyre.py
@@ -1,0 +1,27 @@
+"""Idealised wind-driven double-gyre on a rectangular basin.
+
+Stubbed in Phase 2 (#76). Populated in Phase 3 (port of the existing
+``doublegyre_qg`` + ``doublegyre_baroclinic_qg`` test cases into the
+scenario x model decomposition).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "double_gyre.build is stubbed; blocked on Phase 3 (port of "
+        "existing double-gyre test cases into the scenario x model "
+        "decomposition — see epic #72)."
+    )
+
+
+DOUBLE_GYRE = ScenarioEntry(
+    name="double_gyre",
+    geometry_kind="rectangular",
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/global_ocean.py
+++ b/somax/_src/cli/scenarios/global_ocean.py
@@ -1,0 +1,33 @@
+"""Global ocean — full-sphere geometry with continental masks.
+
+Stubbed in Phase 2 (#76). Populated in Phase 5 after the spherical
+operators land in finitevolX (#165), somax-side spherical models
+(D4) exist, and a global bathymetry / coastline data source is
+picked (D6/D7 in epic #72).
+
+Geometry kind is ``spherical_cap`` — a "cap" spanning the full sphere
+is the same type as a regional cap; the continental distribution
+enters as the ``Mask2D`` on the T-grid, not as a new geometry kind.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "global_ocean.build is stubbed; blocked on Phase 5 (spherical "
+        "scenario + plumbing — requires finitevolX#165 for spherical "
+        "operators, D4 for spherical somax models, and D6/D7 for a "
+        "global bathymetry data source — see epic #72)."
+    )
+
+
+GLOBAL_OCEAN = ScenarioEntry(
+    name="global_ocean",
+    geometry_kind="spherical_cap",
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/gulf_stream.py
+++ b/somax/_src/cli/scenarios/gulf_stream.py
@@ -1,0 +1,26 @@
+"""Gulf Stream region — masked Cartesian geometry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 4 (real-basin scenarios;
+see ``north_atlantic`` for the same dependency notes).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "gulf_stream.build is stubbed; blocked on Phase 4 (real-basin "
+        "scenarios — requires masks (#29 / finitevolX#185) and a "
+        "basin-geometry data source (D6/D7 in epic #72))."
+    )
+
+
+GULF_STREAM = ScenarioEntry(
+    name="gulf_stream",
+    geometry_kind="real_basin",
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/med_sea.py
+++ b/somax/_src/cli/scenarios/med_sea.py
@@ -1,0 +1,26 @@
+"""Mediterranean Sea basin — masked Cartesian geometry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 4 (real-basin scenarios;
+see ``north_atlantic`` for the same dependency notes).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "med_sea.build is stubbed; blocked on Phase 4 (real-basin "
+        "scenarios — requires masks (#29 / finitevolX#185) and a "
+        "basin-geometry data source (D6/D7 in epic #72))."
+    )
+
+
+MED_SEA = ScenarioEntry(
+    name="med_sea",
+    geometry_kind="real_basin",
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/north_atlantic.py
+++ b/somax/_src/cli/scenarios/north_atlantic.py
@@ -1,0 +1,27 @@
+"""North Atlantic basin — masked Cartesian geometry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 4 after the mask
+plumbing lands (#29 / finitevolX#185) and a real-basin data source
+is picked (D6 / D7 in epic #72).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "north_atlantic.build is stubbed; blocked on Phase 4 "
+        "(real-basin scenarios — requires masks (#29 / finitevolX#185) "
+        "and a basin-geometry data source (D6/D7 in epic #72))."
+    )
+
+
+NORTH_ATLANTIC = ScenarioEntry(
+    name="north_atlantic",
+    geometry_kind="real_basin",
+    build=_build,
+)

--- a/somax/_src/cli/scenarios/southern_ocean.py
+++ b/somax/_src/cli/scenarios/southern_ocean.py
@@ -1,0 +1,27 @@
+"""Southern Ocean — masked spherical-cap geometry.
+
+Stubbed in Phase 2 (#76). Populated in Phase 5 after the spherical
+operators land in finitevolX (#165) and the spherical somax models
+are written (D4 in epic #72).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ._types import ScenarioBundle, ScenarioEntry
+
+
+def _build(params: dict[str, Any]) -> ScenarioBundle:
+    raise NotImplementedError(
+        "southern_ocean.build is stubbed; blocked on Phase 5 "
+        "(spherical scenario + plumbing — requires finitevolX#165 for "
+        "spherical operators and D4 for spherical models in somax)."
+    )
+
+
+SOUTHERN_OCEAN = ScenarioEntry(
+    name="southern_ocean",
+    geometry_kind="spherical_cap",
+    build=_build,
+)

--- a/somax/_src/cli/spec.py
+++ b/somax/_src/cli/spec.py
@@ -40,6 +40,60 @@ class TestCaseSpec:
     params: dict[str, Any] = field(default_factory=dict)
 
 
+# -----------------------------------------------------------------------
+# Phase-2 additions (#76): scenario x model YAML block shapes.
+#
+# These coexist with ``TestCaseSpec`` for the whole refactor — Phase 3
+# (#72) does the cutover where runs start authoring ``scenario:`` +
+# ``model:`` blocks instead of ``testcase:``. Nothing in the runner
+# consumes these types yet; they only need to exist so the YAML loader
+# can be extended incrementally.
+# -----------------------------------------------------------------------
+
+
+@dataclass
+class ScenarioSpec:
+    """YAML ``scenario:`` block — what we simulate.
+
+    Args:
+        name: Registry key in
+            :data:`somax._src.cli.scenarios.SCENARIOS`.
+        grid: Grid block — typically ``nx``, ``ny`` (plus ``Lx``,
+            ``Ly`` for Cartesian scenarios or ``lon_bounds`` /
+            ``lat_bounds`` for spherical ones).
+        consts: Frozen basin constants — ``f0``, ``beta``, ``rho0``,
+            ``g``.
+        forcing: Scenario-level forcing knobs (e.g. ``wind_amplitude``
+            that the scenario uses to build ``ForcingFields``).
+        initial_condition: ``{"type": "...", "params": {...}}`` — IC
+            shape and its parameters.
+    """
+
+    name: str
+    grid: dict[str, Any] = field(default_factory=dict)
+    consts: dict[str, Any] = field(default_factory=dict)
+    forcing: dict[str, Any] = field(default_factory=dict)
+    initial_condition: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ModelSpec:
+    """YAML ``model:`` block — how we simulate.
+
+    Args:
+        name: Registry key in
+            :data:`somax._src.cli.models_registry.MODELS`.
+        stratification: Vertical structure — layer thicknesses ``H``
+            and reduced gravities ``g_prime``. Empty for single-layer
+            models.
+        params: Differentiable parameters — viscosity, drag, etc.
+    """
+
+    name: str
+    stratification: dict[str, Any] = field(default_factory=dict)
+    params: dict[str, Any] = field(default_factory=dict)
+
+
 @dataclass
 class TimesteppingSpec:
     """Time integration window and snapshot cadence.

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,169 @@
+"""Pure-logic tests for the scenario x model compatibility checker (#76).
+
+Tests operate against the stubbed Phase-2 registries; they don't build
+models. The compatibility layer is decoupled from ``build``, which is
+what lets Phase 2 ship a compatibility matrix before the models are
+populated (Phases 3-5).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from somax._src.cli._compatibility import (
+    INCOMPATIBLE_PAIRS,
+    IncompatiblePairError,
+    check_compatible,
+    compatibility_matrix,
+    is_compatible,
+)
+from somax._src.cli.models_registry import list_models
+from somax._src.cli.scenarios import list_scenarios
+
+
+# ---------------------------------------------------------------------------
+# Geometry x coordinates rule
+# ---------------------------------------------------------------------------
+
+
+class TestRectangularScenario:
+    """``double_gyre`` is unmasked rectangular → every Cartesian model."""
+
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "linear_swm",
+            "nonlinear_swm",
+            "barotropic_qg",
+            "multilayer_nonlinear_swm",
+            "multilayer_qg",
+            "reparam_multilayer_qg",
+        ],
+    )
+    def test_double_gyre_accepts_cartesian_models(self, model):
+        assert is_compatible("double_gyre", model)
+
+    @pytest.mark.parametrize("model", ["spherical_swm", "spherical_qg"])
+    def test_double_gyre_rejects_spherical_models(self, model):
+        assert not is_compatible("double_gyre", model)
+        with pytest.raises(IncompatiblePairError, match="coordinates"):
+            check_compatible("double_gyre", model)
+
+
+class TestRealBasinScenario:
+    """Masked Cartesian basins need a Cartesian mask-aware model."""
+
+    @pytest.mark.parametrize("scenario", ["north_atlantic", "med_sea", "gulf_stream"])
+    def test_linear_swm_rejected_because_no_masks(self, scenario):
+        # linear_swm is cartesian but supports.masks=False.
+        assert not is_compatible(scenario, "linear_swm")
+        with pytest.raises(IncompatiblePairError, match="mask"):
+            check_compatible(scenario, "linear_swm")
+
+    @pytest.mark.parametrize("scenario", ["north_atlantic", "med_sea", "gulf_stream"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "nonlinear_swm",
+            "barotropic_qg",
+            "multilayer_nonlinear_swm",
+            "multilayer_qg",
+            "reparam_multilayer_qg",
+        ],
+    )
+    def test_mask_aware_cartesian_models_accepted(self, scenario, model):
+        assert is_compatible(scenario, model)
+
+    @pytest.mark.parametrize("scenario", ["north_atlantic", "med_sea", "gulf_stream"])
+    @pytest.mark.parametrize("model", ["spherical_swm", "spherical_qg"])
+    def test_spherical_models_rejected_by_geometry(self, scenario, model):
+        assert not is_compatible(scenario, model)
+        with pytest.raises(IncompatiblePairError, match="coordinates"):
+            check_compatible(scenario, model)
+
+
+class TestSphericalCapScenario:
+    """Masked spherical scenarios → spherical mask-aware models only."""
+
+    @pytest.mark.parametrize("scenario", ["southern_ocean", "global_ocean"])
+    @pytest.mark.parametrize("model", ["spherical_swm", "spherical_qg"])
+    def test_spherical_models_accepted(self, scenario, model):
+        assert is_compatible(scenario, model)
+
+    @pytest.mark.parametrize("scenario", ["southern_ocean", "global_ocean"])
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "linear_swm",
+            "nonlinear_swm",
+            "barotropic_qg",
+            "multilayer_nonlinear_swm",
+            "multilayer_qg",
+            "reparam_multilayer_qg",
+        ],
+    )
+    def test_cartesian_models_rejected_by_geometry(self, scenario, model):
+        assert not is_compatible(scenario, model)
+
+
+# ---------------------------------------------------------------------------
+# Compatibility matrix shape matches the epic (#72)
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibilityMatrix:
+    def test_matrix_covers_all_pairs(self):
+        matrix = compatibility_matrix()
+        scenarios = list_scenarios()
+        models = list_models()
+        assert set(matrix) == set(scenarios)
+        for s, row in matrix.items():
+            assert set(row) == set(models), (
+                f"compatibility_matrix row {s!r} is missing models"
+            )
+
+    def test_expected_pair_counts(self):
+        """Sanity-check the matrix against the scenario/model taxonomy.
+
+        - ``double_gyre`` (unmasked rectangular): 6 Cartesian ✓, 2 spherical ✗
+        - 3 real-basin Cartesian x 5 mask-aware Cartesian = 15 ✓
+          (``linear_swm`` excluded because it doesn't support masks)
+        - ``southern_ocean`` + ``global_ocean`` (spherical-cap):
+          2 x 2 spherical ✓ = 4
+        Total ✓ pairs = 6 + 15 + 4 = 25.
+        """
+        matrix = compatibility_matrix()
+        true_count = sum(v for row in matrix.values() for v in row.values())
+        assert true_count == 25, (
+            f"compatibility matrix has {true_count} compatible pairs; "
+            "expected 25 (6 + 15 + 4) from the scenario/model taxonomy"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit-override set shape
+# ---------------------------------------------------------------------------
+
+
+class TestIncompatiblePairs:
+    def test_is_a_set(self):
+        assert isinstance(INCOMPATIBLE_PAIRS, set)
+
+    def test_empty_by_default(self):
+        """Phase 2 doesn't need any explicit overrides yet."""
+        assert set() == INCOMPATIBLE_PAIRS
+
+
+# ---------------------------------------------------------------------------
+# Unknown names surface a helpful error
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownNames:
+    def test_unknown_scenario_raises_keyerror(self):
+        with pytest.raises(KeyError):
+            check_compatible("no_such_scenario", "linear_swm")
+
+    def test_unknown_model_raises_keyerror(self):
+        with pytest.raises(KeyError):
+            check_compatible("double_gyre", "no_such_model")

--- a/tests/test_models_registry.py
+++ b/tests/test_models_registry.py
@@ -1,0 +1,143 @@
+"""Registry integrity tests for the Phase-2 models registry (#76).
+
+Mirror of ``tests/test_scenarios_registry.py`` for the models side.
+No simulations — only metadata and stub integrity.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from somax._src.cli.models_registry import (
+    MODELS,
+    ModelEntry,
+    SupportFlags,
+    get_model,
+    list_models,
+)
+
+
+EXPECTED_MODELS = {
+    "linear_swm",
+    "nonlinear_swm",
+    "barotropic_qg",
+    "multilayer_nonlinear_swm",
+    "multilayer_qg",
+    "reparam_multilayer_qg",
+    "spherical_swm",
+    "spherical_qg",
+}
+
+
+class TestModelsRegistryIntegrity:
+    def test_eight_models_registered(self):
+        assert set(MODELS) == EXPECTED_MODELS
+
+    def test_list_models_is_sorted(self):
+        assert list_models() == sorted(EXPECTED_MODELS)
+
+    def test_every_entry_is_modelentry(self):
+        for name, entry in MODELS.items():
+            assert isinstance(entry, ModelEntry), (
+                f"MODELS[{name!r}] is not a ModelEntry"
+            )
+
+    def test_entry_name_matches_key(self):
+        for name, entry in MODELS.items():
+            assert entry.name == name
+
+    def test_entry_has_callable_build(self):
+        for entry in MODELS.values():
+            assert callable(entry.build)
+
+    def test_entry_supports_is_supportflags(self):
+        for name, entry in MODELS.items():
+            assert isinstance(entry.supports, SupportFlags), (
+                f"{name!r}.supports is not a SupportFlags"
+            )
+
+    def test_entry_family_is_valid(self):
+        for name, entry in MODELS.items():
+            assert entry.family in {"swm", "qg"}, (
+                f"{name!r} has unknown family {entry.family!r}"
+            )
+
+    def test_entry_coordinates_is_valid(self):
+        for entry in MODELS.values():
+            assert entry.coordinates in {"cartesian", "spherical"}
+
+    def test_entry_layers_is_valid(self):
+        for entry in MODELS.values():
+            assert entry.layers in {1, "multi"}
+
+    def test_spherical_flag_tracks_coordinates(self):
+        """``SupportFlags.spherical`` should mirror ``coordinates``."""
+        for name, entry in MODELS.items():
+            expected = entry.coordinates == "spherical"
+            assert entry.supports.spherical is expected, (
+                f"{name!r}.supports.spherical ({entry.supports.spherical}) "
+                f"doesn't track coordinates ({entry.coordinates!r})"
+            )
+
+
+class TestMaskSupport:
+    """Decision D2 in epic #72: linear SWM is deliberately unmasked."""
+
+    def test_linear_swm_does_not_support_masks(self):
+        assert MODELS["linear_swm"].supports.masks is False
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "nonlinear_swm",
+            "barotropic_qg",
+            "multilayer_nonlinear_swm",
+            "multilayer_qg",
+            "reparam_multilayer_qg",
+            "spherical_swm",
+            "spherical_qg",
+        ],
+    )
+    def test_other_models_support_masks(self, name):
+        assert MODELS[name].supports.masks is True, (
+            f"{name!r} should set supports.masks=True (see epic #72)"
+        )
+
+
+class TestStubsRaiseWithMeaningfulMessage:
+    @pytest.mark.parametrize("name", sorted(EXPECTED_MODELS))
+    def test_build_raises_not_implemented(self, name):
+        entry = MODELS[name]
+        # The stub build takes (bundle, params); we can pass ``None, {}``
+        # because it raises before touching either.
+        with pytest.raises(NotImplementedError) as exc_info:
+            entry.build(None, {})
+        msg = str(exc_info.value)
+        assert name in msg, f"stub message for {name!r} lacks its own name"
+        assert "phase" in msg.lower() or "blocked" in msg.lower(), (
+            f"stub message for {name!r} doesn't mention phase/blocker"
+        )
+
+
+class TestGetModelLookup:
+    def test_unknown_model_raises_keyerror_with_available(self):
+        with pytest.raises(KeyError) as exc_info:
+            get_model("no_such_model")
+        msg = str(exc_info.value)
+        assert "no_such_model" in msg
+        for name in EXPECTED_MODELS:
+            assert name in msg
+
+
+class TestBuildSignatureIsUniform:
+    """Every model build takes ``(scenario_bundle, params_dict)``."""
+
+    @pytest.mark.parametrize("name", sorted(EXPECTED_MODELS))
+    def test_build_signature_has_two_parameters(self, name):
+        entry = MODELS[name]
+        sig = inspect.signature(entry.build)
+        assert len(sig.parameters) == 2, (
+            f"{name!r}.build should take (bundle, params) — two args"
+        )

--- a/tests/test_scenarios_registry.py
+++ b/tests/test_scenarios_registry.py
@@ -1,0 +1,111 @@
+"""Registry integrity tests for the Phase-2 scenarios registry (#76).
+
+These are pure-logic checks — no model builds, no simulations. They
+pin the scaffold so the registry stays structurally valid as
+Phases 3-5 populate the stubs.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from somax._src.cli.scenarios import (
+    SCENARIOS,
+    ScenarioEntry,
+    get_scenario,
+    list_scenarios,
+)
+
+
+EXPECTED_SCENARIOS = {
+    "double_gyre",
+    "north_atlantic",
+    "med_sea",
+    "gulf_stream",
+    "southern_ocean",
+    "global_ocean",
+}
+
+
+class TestScenariosRegistryIntegrity:
+    def test_all_scenarios_registered(self):
+        assert set(SCENARIOS) == EXPECTED_SCENARIOS
+
+    def test_list_scenarios_is_sorted(self):
+        assert list_scenarios() == sorted(EXPECTED_SCENARIOS)
+
+    def test_every_entry_is_scenarioentry(self):
+        for name, entry in SCENARIOS.items():
+            assert isinstance(entry, ScenarioEntry), (
+                f"SCENARIOS[{name!r}] is not a ScenarioEntry"
+            )
+
+    def test_entry_name_matches_key(self):
+        for name, entry in SCENARIOS.items():
+            assert entry.name == name
+
+    def test_entry_has_callable_build(self):
+        for name, entry in SCENARIOS.items():
+            assert callable(entry.build), f"{name!r} has non-callable build"
+
+    def test_entry_geometry_kind_is_valid(self):
+        valid = {"rectangular", "real_basin", "spherical_cap"}
+        for name, entry in SCENARIOS.items():
+            assert entry.geometry_kind in valid, (
+                f"{name!r} has unknown geometry_kind {entry.geometry_kind!r}"
+            )
+
+
+class TestGeometryKindAssignments:
+    """Guard the Phase-2 geometry-kind assignments against silent drift."""
+
+    def test_double_gyre_is_rectangular(self):
+        assert SCENARIOS["double_gyre"].geometry_kind == "rectangular"
+
+    @pytest.mark.parametrize("name", ["north_atlantic", "med_sea", "gulf_stream"])
+    def test_real_basins_are_real_basin(self, name):
+        assert SCENARIOS[name].geometry_kind == "real_basin"
+
+    @pytest.mark.parametrize("name", ["southern_ocean", "global_ocean"])
+    def test_spherical_scenarios_are_spherical_cap(self, name):
+        assert SCENARIOS[name].geometry_kind == "spherical_cap"
+
+
+class TestStubsRaiseWithMeaningfulMessage:
+    @pytest.mark.parametrize("name", sorted(EXPECTED_SCENARIOS))
+    def test_build_raises_not_implemented(self, name):
+        entry = SCENARIOS[name]
+        with pytest.raises(NotImplementedError) as exc_info:
+            entry.build({})
+        msg = str(exc_info.value)
+        # Message must reference the scenario and the blocker/phase so a
+        # future reader can trace why the stub is still there.
+        assert name in msg, f"stub message for {name!r} lacks its own name"
+        assert "phase" in msg.lower() or "blocked" in msg.lower(), (
+            f"stub message for {name!r} doesn't mention phase/blocker"
+        )
+
+
+class TestGetScenarioLookup:
+    def test_unknown_scenario_raises_keyerror_with_available(self):
+        with pytest.raises(KeyError) as exc_info:
+            get_scenario("no_such_scenario")
+        msg = str(exc_info.value)
+        assert "no_such_scenario" in msg
+        # Every registered name should appear in the "available" hint.
+        for name in EXPECTED_SCENARIOS:
+            assert name in msg, f"error message missing registered scenario {name!r}"
+
+
+class TestBuildSignatureIsUniform:
+    """Every scenario's build callable takes a single dict argument."""
+
+    @pytest.mark.parametrize("name", sorted(EXPECTED_SCENARIOS))
+    def test_build_signature_has_single_dict_parameter(self, name):
+        entry = SCENARIOS[name]
+        sig = inspect.signature(entry.build)
+        assert len(sig.parameters) == 1, (
+            f"{name!r}.build should take exactly one argument (params dict)"
+        )


### PR DESCRIPTION
## Summary

Part of the scenario × model decomposition epic (#72). Closes #76.

This is **Phase 2** — the only phase with no upstream blockers. It stands up the empty registries, the dataclass types, and the compatibility checker. Phases 3–5 populate the stubs without touching the registry plumbing.

## What's new

### Registries

- `somax/_src/cli/scenarios/` — `SCENARIOS` registry (6 entries) + shared types.
- `somax/_src/cli/models_registry/` — `MODELS` registry (8 entries) + shared types.
- `somax/_src/cli/_compatibility.py` — inferred compatibility check + empty `INCOMPATIBLE_PAIRS`.

All `build` callables raise `NotImplementedError` with messages that name the blocking phase or upstream dependency, so the registry plumbing can be exercised immediately.

### Scenarios (6)

| Name | `geometry_kind` | Stub blocker |
|---|---|---|
| `double_gyre` | `rectangular` | Phase 3 (port existing test cases) |
| `north_atlantic` | `real_basin` | Phase 4 (masks #29, data D6/D7) |
| `med_sea` | `real_basin` | Phase 4 |
| `gulf_stream` | `real_basin` | Phase 4 |
| `southern_ocean` | `spherical_cap` | Phase 5 (finitevolX#165, D4) |
| `global_ocean` | `spherical_cap` | Phase 5 (finitevolX#165, D4, D6/D7) |

### Models (8)

| Name | family | layers | coords | `supports.masks` | Stub blocker |
|---|---|---|---|---|---|
| `linear_swm` | swm | 1 | cartesian | **false** | Phase 3 |
| `nonlinear_swm` | swm | 1 | cartesian | true | Phase 3 |
| `barotropic_qg` | qg | 1 | cartesian | true | Phase 3 |
| `multilayer_nonlinear_swm` | swm | multi | cartesian | true | Phase 3 |
| `multilayer_qg` | qg | multi | cartesian | true | Phase 3 |
| `reparam_multilayer_qg` | qg | multi | cartesian | true | Phase 3 |
| `spherical_swm` | swm | 1 | spherical | true | Phase 5 (D4) |
| `spherical_qg` | qg | 1 | spherical | true | Phase 5 (D4) |

### Modifications (additive — no runner behavior change)

- `_factories.py` gains a `build(scenario, model, ...)` dispatcher that runs the compatibility check first and delegates to the registered `build` callables. Legacy `TEST_CASES` adapters stay alongside for Phase 3 cutover.
- `spec.py` adds `ScenarioSpec` + `ModelSpec` dataclasses next to `TestCaseSpec`.
- `app.py` adds `list-scenarios`, `list-pairs`; repurposes `list-models` to list registry entries (no tests pinned the old class-listing behavior).

### CLI output

```
$ somax-sim list-scenarios
Registered scenarios:
  - double_gyre  (geometry: rectangular)
  - global_ocean  (geometry: spherical_cap)
  - gulf_stream  (geometry: real_basin)
  - med_sea  (geometry: real_basin)
  - north_atlantic  (geometry: real_basin)
  - southern_ocean  (geometry: spherical_cap)

$ somax-sim list-models
Registered models:
  - barotropic_qg  (qg, 1-layer, cartesian, masks=yes)
  - linear_swm  (swm, 1-layer, cartesian, masks=no)
  - multilayer_nonlinear_swm  (swm, multi, cartesian, masks=yes)
  - multilayer_qg  (qg, multi, cartesian, masks=yes)
  - nonlinear_swm  (swm, 1-layer, cartesian, masks=yes)
  - reparam_multilayer_qg  (qg, multi, cartesian, masks=yes)
  - spherical_qg  (qg, 1-layer, spherical, masks=yes)
  - spherical_swm  (swm, 1-layer, spherical, masks=yes)

$ somax-sim list-pairs
scenario        barotropic_qg  linear_swm  multilayer_nonlinear_swm  multilayer_qg  nonlinear_swm  reparam_multilayer_qg  spherical_qg  spherical_swm
-----------------------------------------------------------------------------------------------------------------------------------------------------
double_gyre     x              x           x                         x              x              x                      .             .
global_ocean    .              .           .                         .              .              .                      x             x
gulf_stream     x              .           x                         x              x              x                      .             .
med_sea         x              .           x                         x              x              x                      .             .
north_atlantic  x              .           x                         x              x              x                      .             .
southern_ocean  .              .           .                         .              .              .                      x             x

Legend: x = compatible, . = incompatible
```

## Note on scenario count vs. issue

The issue text mentions 5 scenarios; this PR ships 6 — adds `global_ocean` (same `spherical_cap` kind as `southern_ocean`). Easy to drop if you'd rather defer.

## Tests

- `tests/test_scenarios_registry.py` — registry integrity (names, geometry kinds, stub messages, build signature).
- `tests/test_models_registry.py` — same for models + the `linear_swm.supports.masks=False` guard and `spherical flag tracks coordinates`.
- `tests/test_compatibility.py` — pure-logic dispatch tests covering every geometry × coordinates × mask combination, plus an expected-matrix total (25 compatible pairs).

**Full suite:** 488 passed (114 new + 374 regression). `ruff check`, `ruff format --check`, `ty check somax` all clean.

## Acceptance criteria

- [x] All existing tests still pass (no runner behavior change)
- [x] `somax-sim list-scenarios` lists 6 entries
- [x] `somax-sim list-models` lists 8 entries
- [x] `somax-sim list-pairs` prints the compatibility matrix
- [x] Lint, format, typecheck clean

## Test plan

- [x] `uv run pytest -v` — 488 passed
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check somax` — clean
- [ ] CI green on GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)