### PR TITLE
feat(cli): crash-recovery checkpointing for long simulations

### DIFF
--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -206,6 +206,7 @@ def _integrate_and_write(
     mode: str,
     initial_state: Any | None,
     diagnostics_per_save: int = 1,
+    checkpoint_every_n_chunks: int = 0,
 ) -> SimulationResult:
     """Build the model, integrate, write artifacts, return summary.
 
@@ -226,6 +227,10 @@ def _integrate_and_write(
             interval. ``1`` = one diagnostic per snapshot (default).
             ``4`` = four diagnostics per snapshot (finer monitoring).
             Snapshot cadence is unaffected.
+        checkpoint_every_n_chunks: Crash-recovery cadence (#70). ``0``
+            (default) disables crash-recovery checkpoints; any positive
+            ``N`` writes ``<output_dir>/checkpoint.zarr`` after every
+            Nth snapshot-aligned chunk.
     """
     output_dir = Path(output_dir)
     _ensure_clean_dir(output_dir)
@@ -297,6 +302,9 @@ def _integrate_and_write(
             max_steps_per_chunk=per_chunk_max,
             run_log=run_log,
             mode=mode,
+            checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+            checkpoint_dir=output_dir if checkpoint_every_n_chunks > 0 else None,
+            checkpoint_label=spec.testcase.name,
         )
     except Exception as exc:
         stop_run_log(
@@ -547,6 +555,9 @@ def _chunked_integrate_with_diagnostics(
     max_steps_per_chunk: int,
     run_log: RunLogContext,
     mode: str,
+    checkpoint_every_n_chunks: int = 0,
+    checkpoint_dir: Path | None = None,
+    checkpoint_label: str | None = None,
 ) -> Any:
     """Run a multi-chunk integration that emits diagnostics between chunks.
 
@@ -580,6 +591,16 @@ def _chunked_integrate_with_diagnostics(
         max_steps_per_chunk: Per-chunk diffrax max_steps.
         run_log: RunLogContext supplying the bound logger.
         mode: ``"run"`` / ``"spinup"`` / ``"restart"`` for error messages.
+        checkpoint_every_n_chunks: Crash-recovery cadence (#70). If
+            ``> 0`` and ``checkpoint_dir`` is provided, the current
+            state is written to ``<checkpoint_dir>/checkpoint.zarr``
+            after every Nth *diagnostic* chunk endpoint that is also a
+            snapshot boundary (so ``save_states`` and the on-disk
+            checkpoint stay aligned). ``0`` disables checkpointing.
+        checkpoint_dir: Directory for the rolling ``checkpoint.zarr``
+            store. Ignored when ``checkpoint_every_n_chunks == 0``.
+        checkpoint_label: Optional label (e.g. testcase name) stored in
+            the checkpoint's attrs for debugging.
 
     Raises:
         IntegrationDivergedError: If any chunk produces non-finite state.
@@ -683,8 +704,43 @@ def _chunked_integrate_with_diagnostics(
             )
 
         # Only retain states at snapshot boundaries.
-        if (i + 1) in save_indices:
+        is_snapshot_boundary = (i + 1) in save_indices
+        if is_snapshot_boundary:
             save_states.append(new_state)
+
+        # Crash-recovery checkpoint (#70): write the current state to a
+        # rolling ``checkpoint.zarr`` every N snapshot-aligned chunk
+        # endpoints. Aligning to snapshot boundaries keeps the on-disk
+        # checkpoint consistent with the saved snapshots up to that
+        # point. We write AFTER the non-finite guard so a bad state
+        # never lands on disk.
+        if (
+            checkpoint_every_n_chunks > 0
+            and checkpoint_dir is not None
+            and is_snapshot_boundary
+        ):
+            snapshot_ordinal = len(save_states) - 1  # 1-based: first == index 1
+            due = (
+                snapshot_ordinal > 0
+                and snapshot_ordinal % checkpoint_every_n_chunks == 0
+            )
+            if due:
+                ckpt_path = Path(checkpoint_dir) / "checkpoint.zarr"
+                ckpt_attrs: dict[str, Any] = {
+                    "somax_sim_t": float(chunk_t1),
+                    "somax_snapshot_ordinal": int(snapshot_ordinal),
+                }
+                if checkpoint_label:
+                    ckpt_attrs["somax_checkpoint_of"] = str(checkpoint_label)
+                ckpt_ds = io.state_to_dataset(
+                    new_state, time=float(chunk_t1), attrs=ckpt_attrs
+                )
+                io.save_dataset(ckpt_ds, ckpt_path, mode="w")
+                log.debug(
+                    f"checkpoint written at snapshot {snapshot_ordinal} "
+                    f"(sim_t={format_time_seconds(chunk_t1)}) → {ckpt_path.name}"
+                )
+
         state = new_state
 
     total_chunks_wall = time.perf_counter() - t_chunks_start
@@ -777,6 +833,7 @@ def simulate(
     output_dir: str | Path,
     *,
     diagnostics_per_save: int = 1,
+    checkpoint_every_n_chunks: int = 0,
 ) -> SimulationResult:
     """Run a fresh simulation from factory-built initial conditions.
 
@@ -790,6 +847,8 @@ def simulate(
         output_dir: Directory for written artifacts.
         diagnostics_per_save: Diagnostic sub-chunks per save interval
             (default 1). Higher = more lines per snapshot in run.log.
+        checkpoint_every_n_chunks: Crash-recovery cadence (#70). ``0``
+            (default) disables crash checkpoints.
     """
     return _integrate_and_write(
         spec,
@@ -797,6 +856,7 @@ def simulate(
         mode="run",
         initial_state=None,
         diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
     )
 
 
@@ -805,6 +865,7 @@ def spinup(
     output_dir: str | Path,
     *,
     diagnostics_per_save: int = 1,
+    checkpoint_every_n_chunks: int = 0,
 ) -> SimulationResult:
     """Run a spinup integration. Saves only the endpoint.
 
@@ -818,7 +879,58 @@ def spinup(
         mode="spinup",
         initial_state=None,
         diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
     )
+
+
+def _maybe_override_t0_from_checkpoint(spec: RunSpec, ds: Any) -> RunSpec:
+    """Pick up ``somax_sim_t`` from a restart dataset and rebase ``t0``.
+
+    Crash-recovery checkpoints (#70) record the sim-time of the last
+    safe chunk endpoint in the ``somax_sim_t`` attr. When present, we
+    resume from there rather than restarting the spec's window from
+    scratch. Legacy ``final_state.zarr`` stores written before the
+    checkpointing work have no such attr and fall through unchanged.
+    """
+    sim_t_raw = ds.attrs.get("somax_sim_t")
+    if sim_t_raw is None:
+        return spec
+    sim_t = float(sim_t_raw)
+    if sim_t <= spec.timestepping.t0:
+        logger.info(
+            "restart artifact has somax_sim_t={} <= spec.t0={}; "
+            "integrating from spec.t0 unchanged.",
+            sim_t,
+            spec.timestepping.t0,
+        )
+        return spec
+    if sim_t >= spec.timestepping.t1:
+        raise ValueError(
+            f"restart artifact has somax_sim_t={sim_t} which is >= "
+            f"spec.timestepping.t1={spec.timestepping.t1}; the integration "
+            f"window has nothing left to run. Extend t1 in the config or "
+            f"restart from an earlier checkpoint."
+        )
+
+    # Rebase the window. Shallow-copy the spec so the caller's spec is
+    # not mutated.
+    from somax._src.cli.spec import TimesteppingSpec
+
+    logger.info(
+        "restart: resuming from checkpoint at sim_t={} (overriding spec.t0)",
+        sim_t,
+    )
+    new_ts = TimesteppingSpec(
+        t0=sim_t,
+        t1=spec.timestepping.t1,
+        dt=spec.timestepping.dt,
+        save_interval=min(
+            spec.timestepping.save_interval, spec.timestepping.t1 - sim_t
+        ),
+    )
+    new_spec = dataclasses.replace(spec, timestepping=new_ts)
+    new_spec.validate()
+    return new_spec
 
 
 def restart(
@@ -827,6 +939,7 @@ def restart(
     *,
     restart_from: str | Path,
     diagnostics_per_save: int = 1,
+    checkpoint_every_n_chunks: int = 0,
 ) -> SimulationResult:
     """Resume a simulation from a previously saved state.
 
@@ -834,13 +947,23 @@ def restart(
     forcing, etc. between runs); only the *state* is loaded from the
     restart file.
 
+    If the restart artifact is a crash-recovery checkpoint (#70) — i.e.
+    it carries a ``somax_sim_t`` attr — the integration window's
+    ``t0`` is automatically rebased to that sim-time so the run picks
+    up exactly where the checkpoint left off. Legacy
+    ``final_state.zarr`` stores without the attr are honoured as-is
+    (integration starts at ``spec.timestepping.t0`` as before).
+
     Args:
         spec: Run specification (model construction comes from here).
         output_dir: Directory for written artifacts.
         restart_from: Path to a zarr store containing a saved state
-            (typically a previous run's ``final_state.zarr``).
+            (typically a previous run's ``final_state.zarr`` or a
+            crash ``checkpoint.zarr``).
         diagnostics_per_save: Diagnostic sub-chunks per save interval
             (default 1).
+        checkpoint_every_n_chunks: Crash-recovery cadence for the
+            *new* run (the one we're about to start). ``0`` = off.
     """
     restart_path = Path(restart_from)
     logger.info("restart loading state from {}", restart_path)
@@ -869,10 +992,13 @@ def restart(
             f"compatible run."
         )
 
+    spec = _maybe_override_t0_from_checkpoint(spec, ds)
+
     return _integrate_and_write(
         spec,
         Path(output_dir),
         mode="restart",
         initial_state=state0,
         diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
     )

--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -231,9 +231,34 @@ def _integrate_and_write(
             (default) disables crash-recovery checkpoints; any positive
             ``N`` writes ``<output_dir>/checkpoint.zarr`` after every
             Nth snapshot-aligned chunk.
+
+    Raises:
+        ValueError: If ``checkpoint_every_n_chunks`` is negative.
     """
+    if checkpoint_every_n_chunks < 0:
+        raise ValueError(
+            f"checkpoint_every_n_chunks must be >= 0, got "
+            f"{checkpoint_every_n_chunks!r}. Use 0 to disable checkpointing "
+            f"or a positive integer to enable it."
+        )
+
     output_dir = Path(output_dir)
     _ensure_clean_dir(output_dir)
+
+    # Delete any stale checkpoint.zarr from a prior run. With
+    # checkpointing enabled, the chunked loop overwrites this atomically
+    # from chunk 1 onwards, but a crash before chunk 1 would leave the
+    # previous run's state visible to ``somax-sim restart``. With
+    # checkpointing disabled, we still want to prevent the
+    # "run-into-a-dirty-dir" footgun Codex flagged on PR #98: subsequent
+    # ``restart --from <output_dir>/checkpoint.zarr`` could otherwise
+    # silently resume from an unrelated prior run.
+    stale_ckpt = output_dir / "checkpoint.zarr"
+    if stale_ckpt.exists():
+        import shutil
+
+        shutil.rmtree(stale_ckpt)
+        logger.info("removed stale checkpoint.zarr from output_dir before {} run", mode)
 
     logger.info("somax-sim mode={} testcase={}", mode, spec.testcase.name)
     logger.info("output_dir={}", output_dir)
@@ -895,7 +920,15 @@ def _maybe_override_t0_from_checkpoint(spec: RunSpec, ds: Any) -> RunSpec:
     sim_t_raw = ds.attrs.get("somax_sim_t")
     if sim_t_raw is None:
         return spec
-    sim_t = float(sim_t_raw)
+    try:
+        sim_t = float(sim_t_raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"restart artifact has non-numeric somax_sim_t={sim_t_raw!r} "
+            f"(type {type(sim_t_raw).__name__}); this attribute must be a "
+            f"number of seconds. If this is a hand-edited zarr store, fix "
+            f"or remove the attribute."
+        ) from exc
     if sim_t <= spec.timestepping.t0:
         logger.info(
             "restart artifact has somax_sim_t={} <= spec.t0={}; "

--- a/somax/_src/cli/app.py
+++ b/somax/_src/cli/app.py
@@ -102,6 +102,18 @@ def run(
             ),
         ),
     ] = False,
+    checkpoint_every_n_chunks: Annotated[
+        int,
+        Parameter(
+            help=(
+                "Crash-recovery cadence (#70). When > 0, writes the current "
+                "state to <output_dir>/checkpoint.zarr after every Nth "
+                "snapshot-aligned chunk. The new run can be resumed via "
+                "`somax-sim restart --from <output_dir>/checkpoint.zarr` — "
+                "integration picks up at the checkpoint's sim-time. 0 = off."
+            ),
+        ),
+    ] = 0,
 ) -> None:
     """Run a fresh simulation from factory-built initial conditions.
 
@@ -111,7 +123,12 @@ def run(
     """
     _configure_logging(verbose)
     spec = _load_and_prepare(config, debug=debug)
-    _run.simulate(spec, output_dir, diagnostics_per_save=diagnostics_per_save)
+    _run.simulate(
+        spec,
+        output_dir,
+        diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+    )
 
 
 # ----------------------------------------------------------------------
@@ -151,6 +168,15 @@ def spinup(
             ),
         ),
     ] = False,
+    checkpoint_every_n_chunks: Annotated[
+        int,
+        Parameter(
+            help=(
+                "Crash-recovery cadence (#70). ``> 0`` writes rolling "
+                "<output_dir>/checkpoint.zarr during the spinup. 0 = off."
+            ),
+        ),
+    ] = 0,
 ) -> None:
     """Run a spinup integration. Saves only the endpoint state.
 
@@ -164,7 +190,12 @@ def spinup(
     """
     _configure_logging(verbose)
     spec = _load_and_prepare(config, debug=debug)
-    _run.spinup(spec, output_dir, diagnostics_per_save=diagnostics_per_save)
+    _run.spinup(
+        spec,
+        output_dir,
+        diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+    )
 
 
 # ----------------------------------------------------------------------
@@ -213,12 +244,29 @@ def restart(
             ),
         ),
     ] = False,
+    checkpoint_every_n_chunks: Annotated[
+        int,
+        Parameter(
+            help=(
+                "Crash-recovery cadence (#70) for the *resumed* run. When "
+                "> 0, writes the current state to "
+                "<output_dir>/checkpoint.zarr after every Nth "
+                "snapshot-aligned chunk. 0 = off."
+            ),
+        ),
+    ] = 0,
 ) -> None:
     """Resume a simulation from a previously saved state.
 
     The model is built from ``config`` (so you can change viscosity,
     forcing, etc. between runs); only the *state* is loaded from the
     ``--from`` zarr store.
+
+    If ``--from`` points at a crash-recovery checkpoint (a zarr store
+    with a ``somax_sim_t`` attr), the integration window is
+    automatically rebased so the run picks up where the checkpoint
+    left off. Legacy ``final_state.zarr`` stores (no attr) are
+    honoured as-is.
     """
     _configure_logging(verbose)
     spec = _load_and_prepare(config, debug=debug)
@@ -227,6 +275,7 @@ def restart(
         output_dir,
         restart_from=from_,
         diagnostics_per_save=diagnostics_per_save,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
     )
 
 

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -307,6 +307,174 @@ class TestSpinupRestartChain:
 
 
 # ----------------------------------------------------------------------
+# Crash-recovery checkpointing (#70)
+# ----------------------------------------------------------------------
+
+
+def _swm_jet_spec_with_saves(
+    *,
+    t1_seconds: float,
+    dt: float,
+    save_interval: float,
+    nx: int = 16,
+    ny: int = 16,
+) -> RunSpec:
+    """Variant of ``_swm_jet_spec`` with a controllable save_interval.
+
+    The default helper sets ``save_interval == t1`` (one saved interval →
+    one snapshot ordinal), which is enough for happy-path tests but too
+    coarse to exercise the crash-recovery cadence. The checkpoint is
+    written at snapshot-aligned chunk endpoints, so we need
+    ``save_interval < t1`` to see more than one ordinal tick.
+    """
+    spec = _swm_jet_spec(t1_seconds=t1_seconds, dt=dt, nx=nx, ny=ny)
+    spec.timestepping.save_interval = save_interval
+    spec.validate()
+    return spec
+
+
+class TestCrashRecoveryCheckpointing:
+    def test_checkpoint_zarr_not_written_when_disabled(self, tmp_path: Path) -> None:
+        """Default (checkpoint_every_n_chunks=0) must not create checkpoint.zarr."""
+        spec = _swm_jet_spec_with_saves(t1_seconds=600.0, dt=10.0, save_interval=200.0)
+        _run.simulate(spec, tmp_path)
+        assert not (tmp_path / "checkpoint.zarr").exists()
+
+    def test_checkpoint_zarr_written_when_enabled(self, tmp_path: Path) -> None:
+        """Opting in writes checkpoint.zarr with the sim_t attr."""
+        # Three saved intervals → snapshot ordinals 1, 2, 3.
+        spec = _swm_jet_spec_with_saves(t1_seconds=600.0, dt=10.0, save_interval=200.0)
+        _run.simulate(spec, tmp_path, checkpoint_every_n_chunks=1)
+
+        ckpt_path = tmp_path / "checkpoint.zarr"
+        assert ckpt_path.is_dir(), "checkpoint.zarr should have been written"
+
+        # The rolling checkpoint is overwritten each chunk; the final
+        # write corresponds to the last snapshot ordinal, i.e. sim_t=t1.
+        from somax import io as somax_io
+
+        ds = somax_io.load_dataset(ckpt_path)
+        assert "somax_sim_t" in ds.attrs, (
+            "checkpoint.zarr missing the somax_sim_t attribute"
+        )
+        assert float(ds.attrs["somax_sim_t"]) == pytest.approx(600.0)
+        assert "somax_snapshot_ordinal" in ds.attrs
+        assert "somax_checkpoint_of" in ds.attrs
+        assert ds.attrs["somax_checkpoint_of"] == "baroclinic_instability_swm"
+
+    def test_checkpoint_cadence_n_equals_2(self, tmp_path: Path) -> None:
+        """With every_n=2, only even-ordinal snapshots overwrite the file.
+
+        This is verifiable from the final checkpoint's sim_t: with four
+        snapshot ordinals (t=150, 300, 450, 600) and ``every_n=2``, only
+        ordinals 2 and 4 trigger a write, so the surviving file should
+        carry ``somax_sim_t=600`` (the last write) and ordinal ``4``.
+        """
+        spec = _swm_jet_spec_with_saves(t1_seconds=600.0, dt=10.0, save_interval=150.0)
+        _run.simulate(spec, tmp_path, checkpoint_every_n_chunks=2)
+
+        from somax import io as somax_io
+
+        ds = somax_io.load_dataset(tmp_path / "checkpoint.zarr")
+        assert int(ds.attrs["somax_snapshot_ordinal"]) == 4
+        assert float(ds.attrs["somax_sim_t"]) == pytest.approx(600.0)
+
+    def test_restart_rebases_t0_from_checkpoint(self, tmp_path: Path) -> None:
+        """``restart --from checkpoint.zarr`` resumes at the checkpoint's sim_t.
+
+        We pick an early snapshot (``every_n=1`` on a 2-interval run),
+        then feed the resulting ``checkpoint.zarr`` back into ``restart``
+        with a wider window. The rebased t0 should equal the checkpoint
+        sim_t — we observe this by asserting the effective integration
+        window in run.log.
+        """
+        # Stage 1: short run to emit a checkpoint at sim_t=200.
+        stage1_dir = tmp_path / "stage1"
+        stage1_spec = _swm_jet_spec_with_saves(
+            t1_seconds=200.0, dt=10.0, save_interval=200.0
+        )
+        _run.simulate(stage1_spec, stage1_dir, checkpoint_every_n_chunks=1)
+
+        stage1_ckpt = stage1_dir / "checkpoint.zarr"
+        assert stage1_ckpt.is_dir()
+
+        from somax import io as somax_io
+
+        ds = somax_io.load_dataset(stage1_ckpt)
+        assert float(ds.attrs["somax_sim_t"]) == pytest.approx(200.0)
+
+        # Stage 2: restart with a window that *starts* at 0 but whose t1
+        # is beyond the checkpoint's sim_t. The runner should rebase t0
+        # to 200 internally.
+        stage2_dir = tmp_path / "stage2"
+        stage2_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=200.0
+        )
+        result = _run.restart(stage2_spec, stage2_dir, restart_from=stage1_ckpt)
+
+        log_text = (stage2_dir / "run.log").read_text()
+        # The loguru line from _maybe_override_t0_from_checkpoint lands
+        # through the root logger (not run_log), but the run_log opener
+        # emits the rebased t0 in its own 'integration starting' line.
+        assert "t0=" in log_text
+        # Most robust: the integration wallclock window should equal
+        # t1 - sim_t = 400, not t1 - 0 = 600. That difference is hard
+        # to measure exactly; instead assert the artifacts exist and
+        # the run.log reports the post-rebase t0.
+        assert result.final_state_path.is_dir()
+        assert "200" in log_text  # rebased t0 appears somewhere in the log
+
+    def test_restart_from_legacy_final_state_is_unchanged(self, tmp_path: Path) -> None:
+        """A ``final_state.zarr`` with no ``somax_sim_t`` attr must behave
+        exactly like before: t0 comes from the spec, not the artifact.
+        """
+        # Stage 1: spinup writes final_state.zarr WITHOUT the sim_t attr
+        # (checkpointing disabled).
+        stage1_dir = tmp_path / "spinup"
+        stage1_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=600.0
+        )
+        _run.spinup(stage1_spec, stage1_dir)
+        final_state = stage1_dir / "final_state.zarr"
+        assert final_state.is_dir()
+        assert not (stage1_dir / "checkpoint.zarr").exists()
+
+        from somax import io as somax_io
+
+        ds = somax_io.load_dataset(final_state)
+        assert "somax_sim_t" not in ds.attrs
+
+        # Stage 2: restart from final_state.zarr — no rebase, integration
+        # runs the full spec window.
+        stage2_dir = tmp_path / "prod"
+        stage2_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=600.0
+        )
+        result = _run.restart(stage2_spec, stage2_dir, restart_from=final_state)
+        assert result.final_state_path.is_dir()
+
+    def test_restart_from_checkpoint_at_t1_raises(self, tmp_path: Path) -> None:
+        """A checkpoint whose sim_t >= spec.t1 leaves nothing to integrate."""
+        # Stage 1: checkpoint at t=600.
+        stage1_dir = tmp_path / "stage1"
+        stage1_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=600.0
+        )
+        _run.simulate(stage1_spec, stage1_dir, checkpoint_every_n_chunks=1)
+
+        # Stage 2: restart spec also has t1=600 → rebase would make
+        # the window empty. Must raise.
+        stage2_dir = tmp_path / "stage2"
+        stage2_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=600.0
+        )
+        with pytest.raises(ValueError, match="nothing left"):
+            _run.restart(
+                stage2_spec, stage2_dir, restart_from=stage1_dir / "checkpoint.zarr"
+            )
+
+
+# ----------------------------------------------------------------------
 # _build_save_times — Copilot review on PR #71 flagged that the previous
 # linspace path silently rescaled the snapshot spacing when save_interval
 # did not divide (t1 - t0) evenly. The function now uses arange semantics:

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -413,16 +413,26 @@ class TestCrashRecoveryCheckpointing:
         result = _run.restart(stage2_spec, stage2_dir, restart_from=stage1_ckpt)
 
         log_text = (stage2_dir / "run.log").read_text()
-        # The loguru line from _maybe_override_t0_from_checkpoint lands
-        # through the root logger (not run_log), but the run_log opener
-        # emits the rebased t0 in its own 'integration starting' line.
-        assert "t0=" in log_text
-        # Most robust: the integration wallclock window should equal
-        # t1 - sim_t = 400, not t1 - 0 = 600. That difference is hard
-        # to measure exactly; instead assert the artifacts exist and
-        # the run.log reports the post-rebase t0.
+        # The ``integration starting:`` line records the effective t0
+        # for this run; after rebase it must read ``t0=200 s (...)``.
+        # Using a regex anchored on that exact line avoids false
+        # positives from unrelated "200" occurrences (e.g.
+        # ``save_interval=200``).
+        import re
+
+        m = re.search(r"integration starting:[^\n]*\bt0=(\d+(?:\.\d+)?) s\b", log_text)
+        assert m is not None, (
+            f"'integration starting:' line with a t0=<seconds> field not "
+            f"found in run.log:\n{log_text}"
+        )
+        t0_logged = float(m.group(1))
+        assert t0_logged == pytest.approx(200.0), (
+            f"expected rebased t0=200 s in run.log, got t0={t0_logged}"
+        )
+        # Belt-and-braces: the original spec.t0 (0 s) should NOT appear
+        # as the starting t0 on that same line.
+        assert re.search(r"integration starting:[^\n]*\bt0=0 s\b", log_text) is None
         assert result.final_state_path.is_dir()
-        assert "200" in log_text  # rebased t0 appears somewhere in the log
 
     def test_restart_from_legacy_final_state_is_unchanged(self, tmp_path: Path) -> None:
         """A ``final_state.zarr`` with no ``somax_sim_t`` attr must behave
@@ -452,6 +462,70 @@ class TestCrashRecoveryCheckpointing:
         )
         result = _run.restart(stage2_spec, stage2_dir, restart_from=final_state)
         assert result.final_state_path.is_dir()
+
+    def test_rerun_removes_stale_checkpoint_from_prior_run(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-running into an output dir that holds an old checkpoint must
+        wipe that checkpoint (otherwise a later ``restart --from
+        <dir>/checkpoint.zarr`` would silently resume from the prior,
+        unrelated run — the Codex review concern on PR #98).
+        """
+        # Stage 1: emit a checkpoint at sim_t=200.
+        stage1_spec = _swm_jet_spec_with_saves(
+            t1_seconds=200.0, dt=10.0, save_interval=200.0
+        )
+        _run.simulate(stage1_spec, tmp_path, checkpoint_every_n_chunks=1)
+        assert (tmp_path / "checkpoint.zarr").is_dir()
+
+        # Stage 2: re-run into the SAME directory with checkpointing OFF.
+        # The stale checkpoint.zarr must be gone afterwards — otherwise a
+        # user resuming from <tmp_path>/checkpoint.zarr would pick up the
+        # prior run's state.
+        stage2_spec = _swm_jet_spec_with_saves(
+            t1_seconds=200.0, dt=10.0, save_interval=200.0
+        )
+        _run.simulate(stage2_spec, tmp_path)
+        assert not (tmp_path / "checkpoint.zarr").exists(), (
+            "stale checkpoint.zarr survived a subsequent checkpointing-off run"
+        )
+
+    def test_negative_checkpoint_cadence_raises(self, tmp_path: Path) -> None:
+        """Negative N must fail loudly up front (not silently disable)."""
+        spec = _swm_jet_spec_with_saves(t1_seconds=200.0, dt=10.0, save_interval=200.0)
+        with pytest.raises(ValueError, match=r">= 0"):
+            _run.simulate(spec, tmp_path, checkpoint_every_n_chunks=-1)
+
+    def test_restart_with_non_numeric_sim_t_attr_raises(self, tmp_path: Path) -> None:
+        """A hand-edited / corrupted ``somax_sim_t`` attr must raise a
+        clear ``ValueError`` rather than a cryptic ``TypeError``.
+        """
+        # Stage 1: produce a valid checkpoint, then corrupt its attr.
+        stage1_dir = tmp_path / "stage1"
+        stage1_spec = _swm_jet_spec_with_saves(
+            t1_seconds=200.0, dt=10.0, save_interval=200.0
+        )
+        _run.simulate(stage1_spec, stage1_dir, checkpoint_every_n_chunks=1)
+        ckpt = stage1_dir / "checkpoint.zarr"
+
+        # Overwrite somax_sim_t with a non-numeric value by rewriting the
+        # zarr store via xarray (the attr lives on the root group).
+        import xarray as xr
+
+        ds = xr.open_zarr(ckpt, consolidated=False).load()
+        ds.attrs["somax_sim_t"] = "not-a-number"
+        # Rewrite in-place.
+        import shutil
+
+        shutil.rmtree(ckpt)
+        ds.to_zarr(ckpt, mode="w", zarr_format=3, consolidated=False)
+
+        stage2_dir = tmp_path / "stage2"
+        stage2_spec = _swm_jet_spec_with_saves(
+            t1_seconds=600.0, dt=10.0, save_interval=200.0
+        )
+        with pytest.raises(ValueError, match=r"non-numeric somax_sim_t"):
+            _run.restart(stage2_spec, stage2_dir, restart_from=ckpt)
 
     def test_restart_from_checkpoint_at_t1_raises(self, tmp_path: Path) -> None:
         """A checkpoint whose sim_t >= spec.t1 leaves nothing to integrate."""


### PR DESCRIPTION
## Summary

Closes #70. Adds opt-in crash-recovery checkpointing to the chunked-integration path (PR #71 laid the groundwork). A 24-hour production run that dies at hour 23 is now recoverable: the ``restart`` command picks up the checkpoint's sim-time and only covers the remaining window.

## Writer side

- ``_chunked_integrate_with_diagnostics`` gains ``checkpoint_every_n_chunks``, ``checkpoint_dir``, and ``checkpoint_label`` kwargs.
- After each chunk's finiteness guard passes, if the chunk endpoint is a snapshot boundary **and** its snapshot-ordinal is a multiple of ``N``, the current state is written to ``<output_dir>/checkpoint.zarr`` via the existing ``io.state_to_dataset`` / ``io.save_dataset`` helpers.
- Only snapshot-aligned chunks qualify, so the on-disk checkpoint stays consistent with the saved snapshots up to that point.
- Attrs recorded on the zarr store:
  - ``somax_sim_t`` — the chunk endpoint's sim-time (consumed by ``restart``).
  - ``somax_snapshot_ordinal`` — which snapshot this corresponds to.
  - ``somax_checkpoint_of`` — the testcase name (for debugging).
- Rolling overwrite: ``save_dataset(..., mode=\"w\")``. No history, no ``keep_last`` (explicitly out of scope per the issue's recent update).

## Reader side

``restart()`` looks at the loaded dataset's attrs:

- If ``somax_sim_t`` is present and ``spec.t0 < sim_t < spec.t1``, the ``TimesteppingSpec`` is replaced with ``(sim_t, t1, dt, min(save_interval, t1 - sim_t))`` and re-validated.
- If ``sim_t >= spec.t1``, a ``ValueError`` is raised before any integration starts (clear user-facing error telling them to extend ``t1`` or pick an earlier checkpoint).
- If the attr is absent (legacy ``final_state.zarr`` from before this PR), behavior is unchanged — ``t0`` comes from the spec.

## CLI

``--checkpoint-every-n-chunks N`` added to ``somax-sim run`` / ``spinup`` / ``restart`` (default ``0`` = off).

```bash
# produce rolling checkpoints during a long run
somax-sim run --config prod.yaml --output-dir runs/prod --checkpoint-every-n-chunks 10

# resume from the last checkpoint after a crash
somax-sim restart --config prod.yaml --from runs/prod/checkpoint.zarr --output-dir runs/prod-resumed
```

## Tests (6 new)

| Test | Pins |
|---|---|
| ``test_checkpoint_zarr_not_written_when_disabled`` | Default (``n=0``) never writes ``checkpoint.zarr`` |
| ``test_checkpoint_zarr_written_when_enabled`` | Opt-in writes the file with expected attrs |
| ``test_checkpoint_cadence_n_equals_2`` | ``n=2`` only fires on even ordinals — last write is ordinal 4 |
| ``test_restart_rebases_t0_from_checkpoint`` | End-to-end resume: artifact's ``sim_t`` replaces ``spec.t0`` |
| ``test_restart_from_legacy_final_state_is_unchanged`` | Backwards-compat: no attr → integrate full spec window |
| ``test_restart_from_checkpoint_at_t1_raises`` | Safety: empty window → clear error |

## Test plan

- [x] ``uv run pytest`` — 503 passed (6 new + 497 regression)
- [x] ``uv run --group lint ruff check .`` — clean
- [x] ``uv run --group lint ruff format --check .`` — clean
- [x] ``uv run --group typecheck ty check somax`` — clean
- [x] ``somax-sim run --help`` shows the new flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)