### PR TITLE
docs(cli): basin data pipeline scaffold + decisions (#74, #75)

### DIFF
--- a/content/notes/basin_data_sources.md
+++ b/content/notes/basin_data_sources.md
@@ -1,0 +1,225 @@
+# Real-Basin Data Sources: Geometry + Forcing
+
+> **TL;DR.** Phase 4 / Phase 5 of the scenario x model refactor (epic [#72](https://github.com/jejjohnson/somax/issues/72)) needs land masks, bathymetry, and surface forcing for four basins (`north_atlantic`, `med_sea`, `gulf_stream`, `southern_ocean`). This note pins the decisions so [#78](https://github.com/jejjohnson/somax/issues/78) and [#79](https://github.com/jejjohnson/somax/issues/79) can proceed:
+>
+> 1. **Bathymetry:** GEBCO 2024 (15 arc-sec global grid).
+> 2. **Land mask:** derived from GEBCO (depth >= 0).
+> 3. **Forcing:** ERA5 monthly-mean surface stresses + net heat flux, averaged over **1993-2023** into an annual-mean climatology. Seasonal cycles are a follow-up.
+> 4. **Format:** one **Zarr v3** store per basin (`data/basin/<name>.zarr`) containing `mask`, `bathymetry`, `tau_x`, `tau_y`, `heat`, and lon/lat coordinate variables.
+> 5. **Pipeline:** a DVC stage per basin (`build-basin-<name>`) in `dvc.yaml`, invoking `scripts/data/build_basin.py`. `dvc repro` regenerates when source data or the script changes.
+> 6. **Storage:** **bring-your-own-remote**. somax ships the pipeline and CLI helpers; each user points DVC at their own remote (Google Drive, S3, Azure Blob, local disk, etc.). No canonical somax-hosted bundle.
+> 7. **Helpers:** `somax-sim data {init,fetch,build,status}` wraps the DVC flow so users never have to learn DVC's command surface just to get basin bundles.
+> 8. **Coordinates:** Cartesian beta-plane (Mercator-projected) for `north_atlantic`, `med_sea`, `gulf_stream`. Lat/lon native for `southern_ocean`.
+
+This note closes the "open questions" in [#74](https://github.com/jejjohnson/somax/issues/74) (geometry) and [#75](https://github.com/jejjohnson/somax/issues/75) (forcing). The loader and per-basin `_build()` fillers belong to Phase 4 ([#78](https://github.com/jejjohnson/somax/issues/78)) / Phase 5 ([#79](https://github.com/jejjohnson/somax/issues/79)); this PR scaffolds the pipeline + helpers and ships a synthetic-data placeholder build so the wiring is exercised end-to-end today.
+
+## Why both questions in one note
+
+[#74](https://github.com/jejjohnson/somax/issues/74) and [#75](https://github.com/jejjohnson/somax/issues/75) were filed separately because geometry and forcing are physically distinct. But the *engineering* questions they raise — distribution, format, resolution, versioning, licensing — are identical. Answering them separately risks diverging on arbitrary details. One decision, one bundle, one pipeline.
+
+## Per-basin canonical grids
+
+Each basin ships at **one** canonical grid chosen to keep smoke tests fast and production runs tractable on a single GPU:
+
+| Basin            | Shape   | Extent                                 | Reason                                 |
+| ---------------- | ------- | -------------------------------------- | -------------------------------------- |
+| `med_sea`        | 128x64  | ~3500 x 1500 km, ~25 km/cell           | Smallest basin — fast smoke target     |
+| `gulf_stream`    | 256x128 | ~4000 x 2000 km, ~15 km/cell           | Eddy-resolving WBC reference           |
+| `north_atlantic` | 256x256 | ~7000 x 7000 km, ~25-30 km/cell        | Full-basin QG reference                |
+| `southern_ocean` | 360x90  | 0-360E, 70S-30S (spherical cap)        | ACC-relevant; eddy-permitting on sphere |
+
+Users who want a different resolution invoke `somax-sim data build <name> --nx <N> --ny <M>`. The *committed* pipeline output is one canonical grid per basin.
+
+## Bathymetry: GEBCO 2024
+
+### Source
+
+[GEBCO 2024](https://www.gebco.net/data_and_products/gridded_bathymetry_data/) is a 15 arc-second (~450 m at the equator) global bathymetry grid. De facto community standard for ocean modeling, freely redistributable with attribution.
+
+### Rejected alternatives
+
+- **ETOPO 2022** (1 arc-min, NOAA) — coarser than GEBCO at no ergonomic gain.
+- **SRTM15+** (15 arc-sec, Scripps) — comparable to GEBCO but less widely cited in oceanography.
+- **Model-native bathymetries** (e.g., MITgcm's `bathymetry.bin`) — not a general source; tied to one model's historical grids.
+
+### Derived mask
+
+The wet/dry mask for each basin is **derived from GEBCO** at build time: `mask = (bathymetry < 0)`. Natural Earth 10m coastlines are used only as a QC overlay, not as the mask itself. Rationale: a single dataset eliminates mask/bathymetry inconsistency bugs — land cells with finite ocean depth, or vice versa — which are the most common kind of real-basin configuration error.
+
+### Minimum depth floor
+
+Shallow shelves (depth < 20 m) are raised to a configurable floor `min_depth` before regridding to avoid sub-grid-scale topography destabilizing the time step. Default floor is 20 m; `--min-depth 0` disables it. The floor is recorded in the Zarr store's `attrs["history"]`.
+
+## Surface forcing: ERA5
+
+### Source
+
+[ERA5](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-single-levels-monthly-means) (ECMWF Reanalysis v5) provides 0.25° x 0.25° global monthly-mean fields from 1940-present. Variables we consume:
+
+| ERA5 variable | Meaning                                   | Unit   |
+| ------------- | ----------------------------------------- | ------ |
+| `metss`       | Mean eastward turbulent surface stress    | N/m²   |
+| `mntss`       | Mean northward turbulent surface stress   | N/m²   |
+| `msnlwrf`     | Mean surface net longwave radiation flux  | W/m²   |
+| `msnswrf`     | Mean surface net shortwave radiation flux | W/m²   |
+| `mslhf`       | Mean surface latent heat flux             | W/m²   |
+| `msshf`       | Mean surface sensible heat flux           | W/m²   |
+
+Net heat flux stored in the bundle is `heat = msnlwrf + msnswrf + mslhf + msshf` (CF sign convention: positive downward into the ocean).
+
+### Temporal aggregation
+
+**Annual mean over 1993-2023** (31 years). Rationale:
+
+- 1993 onward is the altimetry era — forcing is observationally constrained.
+- 31 years averages out ENSO-decadal variability while staying inside the satellite era.
+- Annual-mean is sufficient for Phase 4 (stationary forcing). Monthly climatology and seasonal cycles are a follow-up.
+
+### Rejected alternatives
+
+- **CORE-II** (Large & Yeager, 1948-2009) — canonical for OMIP but older and no longer actively maintained.
+- **NCEP / NCEP2** (1948-present) — coarser (1.875°) and known to have persistent biases in tropical heat fluxes.
+- **JRA-55** (JMA) — comparable quality to ERA5 but with a less convenient open-data license for research redistribution.
+- **OAFlux** (heat fluxes only) — considered as a merge with ERA5 but adds complexity for modest gain.
+
+### Licensing
+
+ERA5 is distributed under the [Copernicus License](https://apps.ecmwf.int/datasets/licences/copernicus/), which permits redistribution of derived products with attribution. Each basin's Zarr store carries a `source` attr citing "Copernicus Climate Change Service (C3S) — ERA5 monthly-mean single levels" and a DOI pointer.
+
+## Spatial regridding
+
+Regridding happens **once, at build time** (inside the DVC stage). Runtime loads the pre-regridded Zarr directly — no regridding dependencies at runtime.
+
+- **Bathymetry:** conservative (area-weighted). Preserves ocean-basin volume — critical for QG inversion.
+- **Wind stress, heat flux:** bilinear. Conservative is scientifically preferred but introduces an `xesmf` runtime dep; at these grid sizes, bilinear differs by a fraction of a percent.
+- **Coast-adjacent cells:** fill-in via nearest-neighbor from the closest ocean cell before regridding, to avoid land-contaminated stresses at the coast.
+
+Regridding code lives in `scripts/data/build_basin.py` (build-time only, not imported at runtime). somax's *runtime* deps stay `xarray + numpy + jax` — no `xesmf`, no `pyproj`.
+
+## Coordinate handling
+
+### Cartesian basins (north_atlantic, med_sea, gulf_stream)
+
+Each basin is projected onto a local **Mercator-like Cartesian grid** at build time, using a basin-central reference latitude:
+
+- `med_sea`: 38°N
+- `gulf_stream`: 35°N
+- `north_atlantic`: 40°N
+
+The Zarr store records `(Lx, Ly)` in metres plus `lon`/`lat` coordinate variables for every T-cell (for plotting against a map). `Geometry.kind == "real_basin"` signals the Cartesian beta-plane regime to the compatibility checker.
+
+### Spherical basin (southern_ocean)
+
+`southern_ocean` stays in native lat/lon (spherical cap, 70°S-30°S). `Geometry.kind == "spherical_cap"`. Consumed by Phase 5 ([#79](https://github.com/jejjohnson/somax/issues/79)) + spherical models ([#73](https://github.com/jejjohnson/somax/issues/73)).
+
+## Distribution: DVC + bring-your-own-remote
+
+### Decision
+
+somax does **not** host a canonical basin bundle. The repo ships:
+
+1. **The pipeline.** `dvc.yaml` stages (`build-basin-med-sea`, ...) that regenerate each basin from source data.
+2. **The build script.** `scripts/data/build_basin.py` — reads GEBCO + ERA5, regrids, writes `data/basin/<name>.zarr`.
+3. **DVC tracking.** Each bundle is a DVC output; the `.dvc` pointer is committed to git; the Zarr store itself is cached by DVC (not in git).
+4. **CLI helpers.** `somax-sim data {init,fetch,build,status}` — see below.
+
+The user brings their own remote. First-time setup:
+
+```console
+$ somax-sim data init
+Pick a DVC remote backend:
+  [1] Google Drive  (free, personal projects)
+  [2] Amazon S3
+  [3] Azure Blob
+  [4] Local filesystem  (single machine / NFS)
+  [q] Quit
+> 1
+Folder ID (from your Google Drive URL): 1a2b3c...
+Installing dvc-gdrive ...
+Adding DVC remote 'somax-data' ...
+$ somax-sim data fetch med_sea
+Fetching data/basin/med_sea.zarr from remote 'somax-data' ...
+$ somax-sim data build gulf_stream --push
+Building data/basin/gulf_stream.zarr (takes ~5 min) ...
+Pushing to remote 'somax-data' ...
+```
+
+### Rejected alternatives
+
+- **Bundle in the repo** — rejected. Bundles are ~5-50 MB/basin; committing them bloats git and pushes the repo past comfortable clone sizes.
+- **Git LFS** — rejected. LFS bandwidth on public GitHub is metered; CI pulls hit the quota.
+- **pooch** — rejected. pooch exists to give you fetch-with-hash-cache semantics when you don't have a proper versioning system. somax *does* have DVC; pooch would be redundant.
+- **somax-hosted canonical bundle** (Zenodo, author's GDrive, GitHub Release) — rejected. Forces us to pick a platform, maintain credentials, and handle takedown / license complaints for upstream (Copernicus / GEBCO) attribution. BYO-remote sidesteps all of it.
+
+### Versioning
+
+No canonical bundle means no canonical versioning. Each user's remote is independently versioned via DVC's content-hash mechanism. The *build script* is versioned in git — reproducing a bundle from a given git commit is deterministic if the user's source GEBCO/ERA5 inputs are pinned.
+
+## File format: Zarr v3, one store per basin
+
+### Layout (one `.zarr` dir per basin under `data/basin/`)
+
+```
+data/basin/med_sea.zarr/
+  .zarray, .zgroup, .zattrs
+  lon/         (y, x) float32  degrees_east
+  lat/         (y, x) float32  degrees_north
+  bathymetry/  (y, x) float32  m, positive downward
+  mask/        (y, x) int8     1 = ocean, 0 = land
+  tau_x/       (y, x) float32  Pa, eastward
+  tau_y/       (y, x) float32  Pa, northward
+  heat/        (y, x) float32  W/m^2, positive into ocean
+
+root attrs:
+  title: "somax basin bundle: med_sea"
+  source: "GEBCO 2024 + ERA5 1993-2023 annual mean"
+  history: "built by scripts/data/build_basin.py <commit>"
+  conventions: "CF-1.10"
+  somax_basin_version: "<semver>"
+```
+
+### Rejected alternatives
+
+- **NetCDF4** — considered and rejected at reviewer's request. somax already uses Zarr v3 for *simulation outputs* ([`somax/_src/io/xarray.py`](../../somax/_src/io/xarray.py)); using the same format for inputs avoids a dual-format codebase.
+- **HDF5 direct** — no CF semantics; reinvents the wheel.
+- **Separate files per variable** (e.g., `med_sea_mask.npy`) — inflates the DVC pointer surface 5x and makes cross-variable coordinate consistency implicit rather than enforced at the store level.
+
+## Synthetic-data placeholder (this PR)
+
+[#78](https://github.com/jejjohnson/somax/issues/78) is where real GEBCO/ERA5 integration lands. Until then, `build_basin.py` runs in a **`--synthetic` mode** that constructs:
+
+- A rectangular-basin mask with a plausible coastline shape per basin (hand-drawn polygon).
+- A constant-depth bathymetry at 4000 m with shelf ramps near the coast.
+- Stommel-style sinusoidal `tau_x`, zero `tau_y`, zero `heat`.
+
+These are **placeholders** — the DVC pipeline is real, the Zarr schema is real, the CLI is real. Only the physical content is synthetic. Swapping in real data in [#78](https://github.com/jejjohnson/somax/issues/78) is a one-function change inside `build_basin.py`.
+
+## Out of scope (explicit non-goals)
+
+Deferred to future issues:
+
+- **Time-varying forcing** (monthly climatology / seasonal cycle). Phase 4 is stationary.
+- **Assimilation-ready data** (observational snapshots for DA experiments).
+- **Tracer forcing** (salinity, nutrients, DIC).
+- **Coupled / air-sea feedback** — somax ships prescribed forcing; bulk formulae are future work.
+- **Tidal forcing.**
+- **Sub-grid orography / mesoscale terrain beyond the canonical resolution.**
+- **A somax-hosted canonical bundle.** Explicitly rejected above; re-raise only if a specific publication needs a DOI-tracked artifact.
+
+## Summary — answers to the open questions
+
+Cross-referenced to [#74](https://github.com/jejjohnson/somax/issues/74) and [#75](https://github.com/jejjohnson/somax/issues/75):
+
+| Question                                             | Decision                                                  | Section |
+| ---------------------------------------------------- | --------------------------------------------------------- | ------- |
+| [#74](https://github.com/jejjohnson/somax/issues/74) Q1 — bathymetry source            | GEBCO 2024                                                | Bathymetry |
+| [#74](https://github.com/jejjohnson/somax/issues/74) Q2 / [#75](https://github.com/jejjohnson/somax/issues/75) Q4 — distribution         | DVC + BYO remote                                          | Distribution |
+| [#74](https://github.com/jejjohnson/somax/issues/74) Q3 / [#75](https://github.com/jejjohnson/somax/issues/75) Q2 — format               | Zarr v3, one store per basin                              | File format |
+| [#74](https://github.com/jejjohnson/somax/issues/74) Q4 — resolution policy            | one canonical grid per basin, rebuildable via CLI         | Per-basin grids |
+| [#74](https://github.com/jejjohnson/somax/issues/74) Q5 — coordinate handling          | Cartesian beta-plane per basin; spherical for southern_ocean | Coordinates |
+| [#75](https://github.com/jejjohnson/somax/issues/75) Q1 — forcing source               | ERA5 monthly-means, 1993-2023                             | Surface forcing |
+| [#75](https://github.com/jejjohnson/somax/issues/75) Q2 — time aggregation             | annual mean (Phase 4); seasonal deferred                  | Surface forcing |
+| [#75](https://github.com/jejjohnson/somax/issues/75) Q3 — spatial regridding           | bilinear for stress/heat, conservative for bathymetry, precomputed | Regridding |
+| [#75](https://github.com/jejjohnson/somax/issues/75) Q5 — stationary vs time-varying   | stationary only; time-varying is a follow-up              | Surface forcing |
+
+Real-data loader and per-basin `_build()` implementations belong to Phase 4 ([#78](https://github.com/jejjohnson/somax/issues/78)) and Phase 5 ([#79](https://github.com/jejjohnson/somax/issues/79)).

--- a/content/notes/basin_data_sources.md
+++ b/content/notes/basin_data_sources.md
@@ -28,7 +28,7 @@ Each basin ships at **one** canonical grid chosen to keep smoke tests fast and p
 | `north_atlantic` | 256x256 | ~7000 x 7000 km, ~25-30 km/cell        | Full-basin QG reference                |
 | `southern_ocean` | 360x90  | 0-360E, 70S-30S (spherical cap)        | ACC-relevant; eddy-permitting on sphere |
 
-Users who want a different resolution invoke `somax-sim data build <name> --nx <N> --ny <M>`. The *committed* pipeline output is one canonical grid per basin.
+Users who want the canonical bundle invoke `somax-sim data build <name>`. For a non-default resolution, invoke `python scripts/data/build_basin.py <name> --nx <N> --ny <M>` directly — the DVC stage and the CLI helper both bake in the canonical shape. The *committed* pipeline output is one canonical grid per basin.
 
 ## Bathymetry: GEBCO 2024
 
@@ -128,21 +128,19 @@ The user brings their own remote. First-time setup:
 ```console
 $ somax-sim data init
 Pick a DVC remote backend:
-  [1] Google Drive  (free, personal projects)
-  [2] Amazon S3
-  [3] Azure Blob
-  [4] Local filesystem  (single machine / NFS)
-  [q] Quit
+  [1] gdrive
+  [2] s3
+  [3] azure
+  [4] gcs
+  [5] local
 > 1
-Folder ID (from your Google Drive URL): 1a2b3c...
-Installing dvc-gdrive ...
-Adding DVC remote 'somax-data' ...
+Google Drive folder URL format: gdrive://<folder-id>
+remote URL: gdrive://1a2b3c...
 $ somax-sim data fetch med_sea
-Fetching data/basin/med_sea.zarr from remote 'somax-data' ...
 $ somax-sim data build gulf_stream --push
-Building data/basin/gulf_stream.zarr (takes ~5 min) ...
-Pushing to remote 'somax-data' ...
 ```
+
+Install the corresponding DVC extra manually (``pip install 'dvc[gdrive]'`` for gdrive, and similarly for ``s3`` / ``azure`` / ``gs``). ``data init`` prints an advisory hint but does not install anything on your behalf.
 
 ### Rejected alternatives
 

--- a/data/basin/.gitignore
+++ b/data/basin/.gitignore
@@ -1,0 +1,4 @@
+/southern_ocean.zarr
+/north_atlantic.zarr
+/gulf_stream.zarr
+/med_sea.zarr

--- a/dvc.lock
+++ b/dvc.lock
@@ -90,50 +90,50 @@ stages:
     deps:
     - path: scripts/data/build_basin.py
       hash: md5
-      md5: 23b374f49cb7d866c754a479d5d1df60
-      size: 14697
+      md5: 4432e1912a9b9f99e6f1bf5c3ff08c1f
+      size: 16889
     outs:
     - path: data/basin/southern_ocean.zarr
       hash: md5
-      md5: 1ed8a923d77b52ce7428f9858c9ca2d6.dir
-      size: 8597
+      md5: 0f0bb0c39e83ea86579c86d577bcae4d.dir
+      size: 8407
       nfiles: 15
   build-basin-north-atlantic:
     cmd: python scripts/data/build_basin.py north_atlantic --source synthetic
     deps:
     - path: scripts/data/build_basin.py
       hash: md5
-      md5: 23b374f49cb7d866c754a479d5d1df60
-      size: 14697
+      md5: 4432e1912a9b9f99e6f1bf5c3ff08c1f
+      size: 16889
     outs:
     - path: data/basin/north_atlantic.zarr
       hash: md5
-      md5: 3e07a3e2b984243c6d5469b39a3c57f6.dir
-      size: 12868
+      md5: 76c20d417b0fb36d677202af7dca67e5.dir
+      size: 12064
       nfiles: 21
   build-basin-gulf-stream:
     cmd: python scripts/data/build_basin.py gulf_stream --source synthetic
     deps:
     - path: scripts/data/build_basin.py
       hash: md5
-      md5: 23b374f49cb7d866c754a479d5d1df60
-      size: 14697
+      md5: 4432e1912a9b9f99e6f1bf5c3ff08c1f
+      size: 16889
     outs:
     - path: data/basin/gulf_stream.zarr
       hash: md5
-      md5: aaf1f76956b8b21e112e224bb8c720fe.dir
-      size: 9435
+      md5: 3c5c0eea00ab3523a916f8e3997128d2.dir
+      size: 9310
       nfiles: 15
   build-basin-med-sea:
     cmd: python scripts/data/build_basin.py med_sea --source synthetic
     deps:
     - path: scripts/data/build_basin.py
       hash: md5
-      md5: 23b374f49cb7d866c754a479d5d1df60
-      size: 14697
+      md5: 4432e1912a9b9f99e6f1bf5c3ff08c1f
+      size: 16889
     outs:
     - path: data/basin/med_sea.zarr
       hash: md5
-      md5: 1df4d580d61d69268a39b98268e3b507.dir
-      size: 8691
+      md5: 79cafa532edbfc7ece918726fc36874c.dir
+      size: 8472
       nfiles: 15

--- a/dvc.lock
+++ b/dvc.lock
@@ -85,3 +85,55 @@ stages:
       md5: 9d4daef19e2f471c32f505b818196977.dir
       size: 188406
       nfiles: 5
+  build-basin-southern-ocean:
+    cmd: python scripts/data/build_basin.py southern_ocean --source synthetic
+    deps:
+    - path: scripts/data/build_basin.py
+      hash: md5
+      md5: 23b374f49cb7d866c754a479d5d1df60
+      size: 14697
+    outs:
+    - path: data/basin/southern_ocean.zarr
+      hash: md5
+      md5: 1ed8a923d77b52ce7428f9858c9ca2d6.dir
+      size: 8597
+      nfiles: 15
+  build-basin-north-atlantic:
+    cmd: python scripts/data/build_basin.py north_atlantic --source synthetic
+    deps:
+    - path: scripts/data/build_basin.py
+      hash: md5
+      md5: 23b374f49cb7d866c754a479d5d1df60
+      size: 14697
+    outs:
+    - path: data/basin/north_atlantic.zarr
+      hash: md5
+      md5: 3e07a3e2b984243c6d5469b39a3c57f6.dir
+      size: 12868
+      nfiles: 21
+  build-basin-gulf-stream:
+    cmd: python scripts/data/build_basin.py gulf_stream --source synthetic
+    deps:
+    - path: scripts/data/build_basin.py
+      hash: md5
+      md5: 23b374f49cb7d866c754a479d5d1df60
+      size: 14697
+    outs:
+    - path: data/basin/gulf_stream.zarr
+      hash: md5
+      md5: aaf1f76956b8b21e112e224bb8c720fe.dir
+      size: 9435
+      nfiles: 15
+  build-basin-med-sea:
+    cmd: python scripts/data/build_basin.py med_sea --source synthetic
+    deps:
+    - path: scripts/data/build_basin.py
+      hash: md5
+      md5: 23b374f49cb7d866c754a479d5d1df60
+      size: 14697
+    outs:
+    - path: data/basin/med_sea.zarr
+      hash: md5
+      md5: 1df4d580d61d69268a39b98268e3b507.dir
+      size: 8691
+      nfiles: 15

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -94,3 +94,47 @@ stages:
     metrics:
       - data/simulations/doublegyre_bc_qg/metrics.json:
           cache: false
+
+  # --------------------------------------------------------------------
+  # Phase 4 / Phase 5 real-basin data bundles (#74 + #75)
+  #
+  # Each basin has its own stage so `dvc repro build-basin-<name>`
+  # rebuilds exactly one bundle. Outputs land at data/basin/<name>.zarr
+  # and are DVC-tracked (not committed to git). See
+  # content/notes/basin_data_sources.md for the design.
+  #
+  # `--source synthetic` is the Phase 3 placeholder; real GEBCO + ERA5
+  # integration comes in #78 and flips these to `--source real`.
+  # --------------------------------------------------------------------
+
+  build-basin-med-sea:
+    desc: Build the med_sea basin bundle (placeholder; #78 flips to real data).
+    cmd: python scripts/data/build_basin.py med_sea --source synthetic
+    deps:
+      - scripts/data/build_basin.py
+    outs:
+      - data/basin/med_sea.zarr
+
+  build-basin-gulf-stream:
+    desc: Build the gulf_stream basin bundle (placeholder).
+    cmd: python scripts/data/build_basin.py gulf_stream --source synthetic
+    deps:
+      - scripts/data/build_basin.py
+    outs:
+      - data/basin/gulf_stream.zarr
+
+  build-basin-north-atlantic:
+    desc: Build the north_atlantic basin bundle (placeholder).
+    cmd: python scripts/data/build_basin.py north_atlantic --source synthetic
+    deps:
+      - scripts/data/build_basin.py
+    outs:
+      - data/basin/north_atlantic.zarr
+
+  build-basin-southern-ocean:
+    desc: Build the southern_ocean basin bundle (placeholder).
+    cmd: python scripts/data/build_basin.py southern_ocean --source synthetic
+    deps:
+      - scripts/data/build_basin.py
+    outs:
+      - data/basin/southern_ocean.zarr

--- a/myst.yml
+++ b/myst.yml
@@ -15,6 +15,7 @@ project:
         - file: content/notes/shallow_water
         - file: content/notes/quasigeostrophic
         - file: content/notes/qg_spinup_durations
+        - file: content/notes/basin_data_sources
     - title: Tutorials
       children:
         - file: content/tutorials/getting_started

--- a/scripts/data/build_basin.py
+++ b/scripts/data/build_basin.py
@@ -1,0 +1,438 @@
+"""Build a real-basin Zarr bundle for Phase 4 / Phase 5 scenarios.
+
+Emits ``data/basin/<name>.zarr`` conforming to the schema documented in
+``content/notes/basin_data_sources.md``:
+
+  coords:   lon, lat
+  vars:     bathymetry, mask, tau_x, tau_y, heat
+  attrs:    title, source, history, conventions, somax_basin_version
+
+Two modes:
+
+  --source synthetic  (default; Phase 3 placeholder)
+      Constructs a deterministic toy bundle from analytical shapes.
+      The DVC pipeline, Zarr schema, and CLI helpers are exercised
+      end-to-end, but the physical content is placeholder — not real
+      bathymetry or wind stress.
+
+  --source real       (Phase 4 / #78)
+      Reads GEBCO 2024 + ERA5 1993-2023 monthly-mean climatologies,
+      regrids to the basin's canonical grid, writes the bundle.
+      Currently raises NotImplementedError — real-data integration
+      lands with the Phase 4 loader work.
+
+Run manually:
+
+    python scripts/data/build_basin.py med_sea
+    python scripts/data/build_basin.py gulf_stream --nx 128 --ny 64
+    python scripts/data/build_basin.py north_atlantic --out data/basin/na.zarr
+
+Or as a DVC stage:
+
+    dvc repro build-basin-med-sea
+
+The canonical per-basin shapes + reference latitudes are pinned in
+``BASIN_SPECS``. Users who want a different resolution pass
+``--nx / --ny`` (which invalidates the DVC cache, triggering a
+rebuild on the next ``dvc repro``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+import xarray as xr
+
+
+SOMAX_BASIN_VERSION = "0.1.0"
+
+BasinName = Literal["med_sea", "gulf_stream", "north_atlantic", "southern_ocean"]
+
+SourceKind = Literal["synthetic", "real"]
+
+
+@dataclass(frozen=True)
+class BasinSpec:
+    """Canonical geometry + forcing scale for a basin.
+
+    Args:
+        nx: Default zonal cells.
+        ny: Default meridional cells.
+        Lx: Zonal extent (m) — for Cartesian basins only.
+        Ly: Meridional extent (m) — for Cartesian basins only.
+        lon_bounds: ``(lon_min, lon_max)`` in degrees.
+        lat_bounds: ``(lat_min, lat_max)`` in degrees.
+        ref_lat: Reference latitude used for the local Mercator
+            projection (Cartesian basins only).
+        geometry_kind: ``"real_basin"`` for Cartesian masked basins
+            (``north_atlantic`` / ``med_sea`` / ``gulf_stream``);
+            ``"spherical_cap"`` for ``southern_ocean``.
+        tau0: Stommel-style wind-stress amplitude (Pa) used by the
+            synthetic mode; ignored in real mode.
+    """
+
+    nx: int
+    ny: int
+    Lx: float | None
+    Ly: float | None
+    lon_bounds: tuple[float, float]
+    lat_bounds: tuple[float, float]
+    ref_lat: float | None
+    geometry_kind: Literal["real_basin", "spherical_cap"]
+    tau0: float = 0.1
+
+
+BASIN_SPECS: dict[BasinName, BasinSpec] = {
+    "med_sea": BasinSpec(
+        nx=128,
+        ny=64,
+        Lx=3.5e6,
+        Ly=1.5e6,
+        lon_bounds=(-6.0, 36.5),
+        lat_bounds=(30.0, 46.0),
+        ref_lat=38.0,
+        geometry_kind="real_basin",
+        tau0=0.05,
+    ),
+    "gulf_stream": BasinSpec(
+        nx=256,
+        ny=128,
+        Lx=4.0e6,
+        Ly=2.0e6,
+        lon_bounds=(-82.0, -40.0),
+        lat_bounds=(25.0, 45.0),
+        ref_lat=35.0,
+        geometry_kind="real_basin",
+        tau0=0.1,
+    ),
+    "north_atlantic": BasinSpec(
+        nx=256,
+        ny=256,
+        Lx=7.0e6,
+        Ly=7.0e6,
+        lon_bounds=(-80.0, 0.0),
+        lat_bounds=(10.0, 70.0),
+        ref_lat=40.0,
+        geometry_kind="real_basin",
+        tau0=0.1,
+    ),
+    "southern_ocean": BasinSpec(
+        nx=360,
+        ny=90,
+        Lx=None,
+        Ly=None,
+        lon_bounds=(0.0, 360.0),
+        lat_bounds=(-70.0, -30.0),
+        ref_lat=None,
+        geometry_kind="spherical_cap",
+        tau0=0.15,
+    ),
+}
+
+
+# ----------------------------------------------------------------------
+# Build entry point
+# ----------------------------------------------------------------------
+
+
+def build_basin(
+    name: BasinName,
+    *,
+    source: SourceKind = "synthetic",
+    nx: int | None = None,
+    ny: int | None = None,
+    min_depth: float = 20.0,
+    out_path: Path | None = None,
+) -> Path:
+    """Build a single basin bundle and write it to disk.
+
+    Returns the absolute path of the resulting ``.zarr`` store.
+    """
+    if name not in BASIN_SPECS:
+        raise ValueError(
+            f"unknown basin {name!r}; known: {sorted(BASIN_SPECS)!r}"
+        )
+    spec = BASIN_SPECS[name]
+    nx_ = int(nx) if nx is not None else spec.nx
+    ny_ = int(ny) if ny is not None else spec.ny
+    if nx_ <= 0 or ny_ <= 0:
+        raise ValueError(f"nx, ny must be > 0 (got {nx_}, {ny_})")
+
+    out = Path(out_path) if out_path is not None else Path("data/basin") / f"{name}.zarr"
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if source == "synthetic":
+        ds = _build_synthetic(name, spec, nx=nx_, ny=ny_, min_depth=min_depth)
+    elif source == "real":
+        raise NotImplementedError(
+            "real-data build (GEBCO + ERA5 integration) is tracked in #78; "
+            "use --source synthetic for now."
+        )
+    else:
+        raise ValueError(f"unknown source kind {source!r}; use 'synthetic' or 'real'")
+
+    ds.attrs.update(
+        title=f"somax basin bundle: {name}",
+        source=_source_attr(source),
+        history=_history_attr(name, source, nx_, ny_, min_depth),
+        conventions="CF-1.10",
+        somax_basin_version=SOMAX_BASIN_VERSION,
+        basin_name=name,
+        geometry_kind=spec.geometry_kind,
+    )
+
+    # zarr_format=3 + consolidated=False matches somax/_src/io/xarray.py
+    # (consolidated metadata is not part of the v3 spec; xarray warns).
+    if out.exists():
+        import shutil
+        shutil.rmtree(out)
+    ds.to_zarr(out, mode="w", zarr_format=3, consolidated=False)
+    return out.resolve()
+
+
+# ----------------------------------------------------------------------
+# Synthetic mode
+# ----------------------------------------------------------------------
+
+
+def _build_synthetic(
+    name: BasinName,
+    spec: BasinSpec,
+    *,
+    nx: int,
+    ny: int,
+    min_depth: float,
+) -> xr.Dataset:
+    """Construct a placeholder basin with the right schema.
+
+    The mask + bathymetry are analytical proxies for the named basin —
+    enough to exercise mask-aware model code paths, but not physically
+    accurate. Swap for real GEBCO-derived data in #78.
+    """
+    lon_min, lon_max = spec.lon_bounds
+    lat_min, lat_max = spec.lat_bounds
+    # Cell-center longitudes/latitudes on a regular lon/lat grid.
+    lon_1d = np.linspace(lon_min, lon_max, nx, endpoint=False) + (
+        lon_max - lon_min
+    ) / nx / 2.0
+    lat_1d = np.linspace(lat_min, lat_max, ny, endpoint=False) + (
+        lat_max - lat_min
+    ) / ny / 2.0
+    lon, lat = np.meshgrid(lon_1d, lat_1d)  # (ny, nx)
+
+    mask = _synthetic_mask(name, lon, lat)
+    bathymetry = _synthetic_bathymetry(mask, depth_abyss=4000.0, min_depth=min_depth)
+    tau_x, tau_y = _synthetic_wind_stress(lat, lat_min, lat_max, tau0=spec.tau0)
+    heat = np.zeros_like(lon, dtype=np.float32)
+
+    # Apply mask: land cells get NaN forcing + 0 bathymetry + 0 stress.
+    tau_x = np.where(mask, tau_x, 0.0).astype(np.float32)
+    tau_y = np.where(mask, tau_y, 0.0).astype(np.float32)
+
+    ds = xr.Dataset(
+        data_vars={
+            "bathymetry": (("y", "x"), bathymetry.astype(np.float32)),
+            "mask": (("y", "x"), mask.astype(np.int8)),
+            "tau_x": (("y", "x"), tau_x),
+            "tau_y": (("y", "x"), tau_y),
+            "heat": (("y", "x"), heat),
+        },
+        coords={
+            "lon": (("y", "x"), lon.astype(np.float32)),
+            "lat": (("y", "x"), lat.astype(np.float32)),
+        },
+    )
+    # CF-style variable attrs.
+    ds["bathymetry"].attrs.update(
+        long_name="bathymetry", units="m", positive="down"
+    )
+    ds["mask"].attrs.update(long_name="wet/dry mask", flag_values=[0, 1], flag_meanings="land ocean")
+    ds["tau_x"].attrs.update(long_name="eastward surface wind stress", units="Pa")
+    ds["tau_y"].attrs.update(long_name="northward surface wind stress", units="Pa")
+    ds["heat"].attrs.update(long_name="net surface heat flux", units="W m-2", positive="down")
+    ds["lon"].attrs.update(long_name="longitude", units="degrees_east")
+    ds["lat"].attrs.update(long_name="latitude", units="degrees_north")
+
+    if spec.Lx is not None and spec.Ly is not None:
+        ds.attrs["Lx_m"] = float(spec.Lx)
+        ds.attrs["Ly_m"] = float(spec.Ly)
+    if spec.ref_lat is not None:
+        ds.attrs["ref_lat_deg"] = float(spec.ref_lat)
+    ds.attrs["lon_bounds"] = [float(lon_min), float(lon_max)]
+    ds.attrs["lat_bounds"] = [float(lat_min), float(lat_max)]
+    return ds
+
+
+def _synthetic_mask(name: BasinName, lon: np.ndarray, lat: np.ndarray) -> np.ndarray:
+    """Return a plausible-looking ocean mask (1 = ocean, 0 = land).
+
+    These are *not* real coastlines — they're analytical cutouts chosen
+    so each basin visually resembles its namesake. Swap for GEBCO in #78.
+    """
+    ones = np.ones_like(lon, dtype=bool)
+    if name == "med_sea":
+        # Narrow strip with cutouts for Iberia / Italy / Greece / Turkey.
+        mask = ones.copy()
+        # North African coast: lat < 31 is land.
+        mask &= lat >= 31.0
+        # European shore: lat > 45 is land.
+        mask &= lat <= 45.0
+        # Italy peninsula (rough lozenge).
+        italy = ((lon >= 7.0) & (lon <= 18.0)) & ((lat >= 36.0) & (lat <= 44.5))
+        italy_sea = ((lon - 13.0) ** 2 / 6.0 ** 2 + (lat - 40.0) ** 2 / 3.5 ** 2 < 1.0)
+        mask &= ~(italy & ~italy_sea)
+        return mask
+    if name == "gulf_stream":
+        # North-American coast sweeping NE; mask land west of a curved shore.
+        shore_lon = -82.0 + 0.8 * (lat - 25.0)  # linear NE-trending coast
+        mask = lon > shore_lon
+        # Northern limit of domain.
+        mask &= lat <= 45.0
+        return mask
+    if name == "north_atlantic":
+        # Americas to the west, Europe/Africa to the east.
+        west_shore = -80.0 + 0.6 * (lat - 10.0)
+        east_shore = -20.0 + 0.4 * (lat - 10.0)
+        mask = (lon > west_shore) & (lon < east_shore)
+        # Greenland block in the NW corner.
+        greenland = (lon > -55.0) & (lon < -20.0) & (lat > 60.0)
+        mask &= ~greenland
+        return mask
+    if name == "southern_ocean":
+        # Full zonal circumnavigation; block Antarctica below ~66°S.
+        mask = lat > -66.0
+        # Rough cut for the Antarctic Peninsula.
+        peninsula = (lon > 280.0) & (lon < 305.0) & (lat < -62.0)
+        mask &= ~peninsula
+        return mask
+    raise ValueError(f"no synthetic mask recipe for basin {name!r}")
+
+
+def _synthetic_bathymetry(
+    mask: np.ndarray,
+    *,
+    depth_abyss: float = 4000.0,
+    min_depth: float = 20.0,
+) -> np.ndarray:
+    """Flat-abyss bathymetry with a shelf ramp near the coast.
+
+    Returns positive-downward depth in metres. Land cells get 0.
+    """
+    # Distance (in cells) to the nearest land cell, approximated via a
+    # simple iterative dilation — cheap and good enough for a placeholder.
+    from scipy.ndimage import distance_transform_edt  # local import; SciPy is a soft dep
+
+    dist = distance_transform_edt(mask)
+    # Shelf ramps from min_depth at the coast to depth_abyss past ~8 cells in.
+    shelf_width_cells = 8.0
+    frac = np.clip(dist / shelf_width_cells, 0.0, 1.0)
+    depth = min_depth + (depth_abyss - min_depth) * frac
+    depth = np.where(mask, depth, 0.0)
+    return depth
+
+
+def _synthetic_wind_stress(
+    lat: np.ndarray,
+    lat_min: float,
+    lat_max: float,
+    *,
+    tau0: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Stommel-style zonal wind stress: ``tau_x = -tau0 cos(pi (lat-lat0)/L)``."""
+    L = lat_max - lat_min
+    tau_x = -tau0 * np.cos(np.pi * (lat - lat_min) / L)
+    tau_y = np.zeros_like(lat)
+    return tau_x, tau_y
+
+
+# ----------------------------------------------------------------------
+# Bundle metadata helpers
+# ----------------------------------------------------------------------
+
+
+def _source_attr(source: SourceKind) -> str:
+    if source == "synthetic":
+        return (
+            "synthetic placeholder (analytical mask + flat bathymetry + "
+            "Stommel wind stress); real GEBCO + ERA5 integration is tracked in #78"
+        )
+    return "GEBCO 2024 + ERA5 1993-2023 annual mean"
+
+
+def _history_attr(
+    name: BasinName, source: SourceKind, nx: int, ny: int, min_depth: float
+) -> str:
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=Path(__file__).resolve().parent,
+            stderr=subprocess.DEVNULL,
+        ).decode().strip()
+    except Exception:
+        commit = "unknown"
+    return (
+        f"built by scripts/data/build_basin.py (commit {commit}) — "
+        f"basin={name} source={source} nx={nx} ny={ny} min_depth={min_depth}"
+    )
+
+
+# ----------------------------------------------------------------------
+# CLI
+# ----------------------------------------------------------------------
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("basin", choices=sorted(BASIN_SPECS), help="Basin name.")
+    parser.add_argument(
+        "--source",
+        choices=["synthetic", "real"],
+        default="synthetic",
+        help="Source data kind (default: synthetic placeholder).",
+    )
+    parser.add_argument("--nx", type=int, default=None, help="Override zonal cells.")
+    parser.add_argument("--ny", type=int, default=None, help="Override meridional cells.")
+    parser.add_argument(
+        "--min-depth",
+        type=float,
+        default=20.0,
+        help="Shelf depth floor in metres (default 20).",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Output .zarr path (default: data/basin/<basin>.zarr).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        path = build_basin(
+            args.basin,
+            source=args.source,
+            nx=args.nx,
+            ny=args.ny,
+            min_depth=args.min_depth,
+            out_path=args.out,
+        )
+    except NotImplementedError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(f"wrote {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/data/build_basin.py
+++ b/scripts/data/build_basin.py
@@ -190,10 +190,39 @@ def build_basin(
     # zarr_format=3 + consolidated=False matches somax/_src/io/xarray.py
     # (consolidated metadata is not part of the v3 spec; xarray warns).
     if out.exists():
-        import shutil
-        shutil.rmtree(out)
+        _safe_rmtree_zarr(out)
     ds.to_zarr(out, mode="w", zarr_format=3, consolidated=False)
     return out.resolve()
+
+
+def _safe_rmtree_zarr(out: Path) -> None:
+    """Remove an existing Zarr store with guardrails.
+
+    A plain ``shutil.rmtree(out)`` would recursively delete *any* path
+    the caller passes — so a typo like ``--out data/basin`` would wipe
+    every materialized bundle. Guard against that:
+
+    - The path must have a ``.zarr`` suffix.
+    - If it's a directory, it must contain a Zarr root marker
+      (``zarr.json`` for v3, ``.zgroup`` / ``.zarray`` for v2).
+
+    Otherwise we refuse and ask the user for a clean output path.
+    """
+    import shutil
+
+    if out.suffix != ".zarr":
+        raise ValueError(
+            f"refusing to overwrite existing path {out!r}: output must have "
+            "'.zarr' suffix so build_basin doesn't wipe unrelated directories."
+        )
+    if out.is_dir():
+        markers = ("zarr.json", ".zgroup", ".zarray")
+        if not any((out / m).exists() for m in markers):
+            raise ValueError(
+                f"refusing to remove existing directory {out!r}: no Zarr root "
+                f"marker found ({markers!r}). Pass a fresh output path."
+            )
+    shutil.rmtree(out)
 
 
 # ----------------------------------------------------------------------
@@ -231,7 +260,8 @@ def _build_synthetic(
     tau_x, tau_y = _synthetic_wind_stress(lat, lat_min, lat_max, tau0=spec.tau0)
     heat = np.zeros_like(lon, dtype=np.float32)
 
-    # Apply mask: land cells get NaN forcing + 0 bathymetry + 0 stress.
+    # Apply mask: land cells get zero-valued forcing in this placeholder
+    # (real data may prefer NaN or a sentinel; Phase 4 / #78 will decide).
     tau_x = np.where(mask, tau_x, 0.0).astype(np.float32)
     tau_y = np.where(mask, tau_y, 0.0).astype(np.float32)
 
@@ -324,17 +354,43 @@ def _synthetic_bathymetry(
 
     Returns positive-downward depth in metres. Land cells get 0.
     """
-    # Distance (in cells) to the nearest land cell, approximated via a
-    # simple iterative dilation — cheap and good enough for a placeholder.
-    from scipy.ndimage import distance_transform_edt  # local import; SciPy is a soft dep
-
-    dist = distance_transform_edt(mask)
-    # Shelf ramps from min_depth at the coast to depth_abyss past ~8 cells in.
-    shelf_width_cells = 8.0
-    frac = np.clip(dist / shelf_width_cells, 0.0, 1.0)
+    shelf_width_cells = 8
+    dist = _bfs_distance_to_land(mask, max_dist=shelf_width_cells)
+    frac = np.clip(dist / float(shelf_width_cells), 0.0, 1.0)
     depth = min_depth + (depth_abyss - min_depth) * frac
     depth = np.where(mask, depth, 0.0)
     return depth
+
+
+def _bfs_distance_to_land(mask: np.ndarray, *, max_dist: int) -> np.ndarray:
+    """4-connected cell-distance from each ocean cell to the nearest land cell.
+
+    Clipped at ``max_dist`` — anything farther than that returns
+    ``max_dist``. Pure numpy (no SciPy), since we only need a few
+    iterations for the shelf-ramp application. Boundary handling uses
+    edge-replication, so we do not pull spurious "land" across the
+    domain edges (important for ``southern_ocean``, which is zonally
+    periodic but we treat as non-periodic for this placeholder).
+    """
+    is_ocean = mask.astype(bool)
+    # -1 marks "unset"; 0 is set immediately for land cells.
+    dist = np.where(is_ocean, -1, 0).astype(np.int32)
+    frontier = ~is_ocean  # current set of "just-reached" cells
+    for step in range(1, max_dist + 1):
+        padded = np.pad(frontier, 1, mode="edge")
+        neighbors = (
+            padded[:-2, 1:-1]
+            | padded[2:, 1:-1]
+            | padded[1:-1, :-2]
+            | padded[1:-1, 2:]
+        )
+        new_cells = neighbors & (dist == -1)
+        if not new_cells.any():
+            break
+        dist = np.where(new_cells, step, dist)
+        frontier = new_cells
+    dist = np.where(dist == -1, max_dist, dist)
+    return dist.astype(np.float64)
 
 
 def _synthetic_wind_stress(

--- a/somax/_src/cli/_data.py
+++ b/somax/_src/cli/_data.py
@@ -118,8 +118,10 @@ def init(
         somax-sim data init --backend local --url /data/somax
 
     The gdrive / s3 / azure / gcs backends need their DVC extra
-    installed (``pip install 'dvc[gdrive]'``). ``init`` detects missing
-    extras and prints a pip-install hint rather than silently failing.
+    installed (``pip install 'dvc[gdrive]'``). ``init`` prints an
+    advisory pip-install hint but cannot reliably preflight the extra;
+    the authoritative error — if the extra is missing — surfaces on
+    the first ``fetch`` / ``push`` that tries to touch the remote.
     """
     _require_dvc()
 
@@ -292,15 +294,30 @@ def _remote_configured() -> bool:
 
 
 def _remote_url() -> str | None:
-    """Return the URL of the 'somax-data' remote, or None if not configured."""
+    """Return the URL of the '<REMOTE_NAME>' remote, or ``None`` if absent.
+
+    ``None`` means the remote is not configured. It does **not** mean
+    "DVC itself failed" — those cases raise :class:`SystemExit` with an
+    actionable message so ``fetch`` / ``build --push`` / ``status`` do
+    not silently masquerade a broken DVC setup as "no remote configured".
+    """
+    # Guard 1: are we inside a DVC repo at all?
+    root = subprocess.run(["dvc", "root"], check=False, capture_output=True, text=True)
+    if root.returncode != 0:
+        raise SystemExit(
+            f"dvc reports this isn't a DVC repo (dvc root exited "
+            f"{root.returncode}). basin-data helpers assume you're inside "
+            "a somax checkout."
+        )
+    # Guard 2: listing remotes succeeded?
     result = subprocess.run(
-        ["dvc", "remote", "list"],
-        check=False,
-        capture_output=True,
-        text=True,
+        ["dvc", "remote", "list"], check=False, capture_output=True, text=True
     )
     if result.returncode != 0:
-        return None
+        raise SystemExit(
+            f"`dvc remote list` failed (exit {result.returncode}): "
+            f"{(result.stderr or '').strip() or '<no stderr>'}"
+        )
     for line in result.stdout.splitlines():
         # `dvc remote list` outputs one line per remote: "<name>\t<url>"
         parts = line.split(maxsplit=1)
@@ -310,21 +327,23 @@ def _remote_url() -> str | None:
 
 
 def _check_backend_installed(backend: RemoteBackend) -> None:
-    """Error out with a pip-install hint if the backend's DVC extra is missing."""
+    """Log installation guidance for backend-specific DVC extras.
+
+    somax does not reliably preflight whether a backend extra is
+    installed — a real check would require importing DVC internals or
+    probing a configured remote, both brittle across DVC versions. The
+    authoritative error comes from DVC itself on the next fetch/push.
+    This helper is advisory-only: print the pip hint up front so users
+    know what to install when a later DVC call complains.
+    """
     extra = _BACKEND_EXTRAS[backend]
     if extra is None:
         return  # 'local' needs no extra.
-    # Rather than doing a shallow import probe (fragile across DVC
-    # versions), rely on `dvc remote modify` — but that requires an
-    # existing remote. Simplest: rely on DVC's own error, but surface
-    # a clearer hint to the user up front.
     pip_hint = f"pip install 'dvc[{extra}]'"
-    # We cannot cheaply detect installation without importing DVC
-    # internals, so just mention the extra in the log and let DVC raise
-    # its own error on the subsequent fetch/push if it's missing.
     logger.info(
-        f"backend '{backend}' uses the '{extra}' DVC extra; "
-        f"if fetch/push fails with an import error, install it: {pip_hint}"
+        f"backend '{backend}' may require the '{extra}' DVC extra; "
+        f"if a later DVC fetch/push reports a missing dependency, "
+        f"install it with: {pip_hint}"
     )
 
 

--- a/somax/_src/cli/_data.py
+++ b/somax/_src/cli/_data.py
@@ -1,0 +1,392 @@
+"""CLI helpers for real-basin data bundles (#74 + #75).
+
+Thin wrappers around DVC so users never have to memorize DVC's command
+surface just to fetch / build / push basin bundles. Each helper
+delegates to ``dvc`` via :mod:`subprocess`; if ``dvc`` isn't on PATH,
+the user gets an actionable error.
+
+This module is imported by :mod:`somax._src.cli.app` and exposed under
+``somax-sim data {init,fetch,build,status}``.
+
+The design is documented in ``content/notes/basin_data_sources.md``
+(summarised here): somax ships the DVC pipeline + these helpers, but
+does **not** host a canonical bundle. Each user configures their own
+DVC remote (Google Drive / S3 / Azure / local); the helpers wrap that
+flow so the usual user-facing verbs (fetch, build, ...) do not require
+a DVC cheat-sheet.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Annotated, Literal
+
+from cyclopts import App, Parameter
+from loguru import logger
+
+
+# The four basin names the pipeline knows about. Kept in sync with
+# ``scripts/data/build_basin.py::BASIN_SPECS`` and the corresponding DVC
+# stages. Listed in the help of every ``data`` subcommand so users see
+# the valid options without reading the design doc.
+BASIN_NAMES = ("med_sea", "gulf_stream", "north_atlantic", "southern_ocean")
+
+BasinName = Literal["med_sea", "gulf_stream", "north_atlantic", "southern_ocean"]
+
+RemoteBackend = Literal["gdrive", "s3", "azure", "gcs", "local"]
+
+# Map each supported backend to the ``dvc[<extra>]`` pip extra that
+# provides its fsspec plugin. "local" needs nothing.
+_BACKEND_EXTRAS: dict[RemoteBackend, str | None] = {
+    "gdrive": "gdrive",
+    "s3": "s3",
+    "azure": "azure",
+    "gcs": "gs",
+    "local": None,
+}
+
+# Fixed remote name — keeping it consistent across users makes
+# troubleshooting easier ("run `dvc remote list`, you should see
+# `somax-data`").
+REMOTE_NAME = "somax-data"
+
+
+data_app = App(
+    name="data",
+    help=(
+        "Manage real-basin data bundles (#74 + #75). "
+        "Wraps DVC so you don't have to remember its CLI surface."
+    ),
+)
+
+
+# ----------------------------------------------------------------------
+# somax-sim data init
+# ----------------------------------------------------------------------
+
+
+@data_app.command
+def init(
+    *,
+    backend: Annotated[
+        RemoteBackend | None,
+        Parameter(
+            help=(
+                "DVC remote backend to configure. Omit for interactive "
+                "selection. 'local' points at a filesystem path; the "
+                "others (gdrive, s3, azure, gcs) are cloud-hosted."
+            ),
+        ),
+    ] = None,
+    url: Annotated[
+        str | None,
+        Parameter(
+            help=(
+                "Remote URL. For gdrive: 'gdrive://<folder-id>'. For s3: "
+                "'s3://<bucket>/<key>'. For azure: "
+                "'azure://<container>/<path>'. For gcs: 'gs://<bucket>/<key>'. "
+                "For local: an absolute filesystem path. Omit for "
+                "interactive entry."
+            ),
+        ),
+    ] = None,
+    force: Annotated[
+        bool,
+        Parameter(
+            help=(
+                "Overwrite an existing 'somax-data' remote. Without this "
+                "flag, 'dvc remote add' errors out if the remote already "
+                "exists — safer default."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Configure a DVC remote for your basin bundles.
+
+    somax does not host a canonical bundle — each user points DVC at
+    their own storage (Google Drive, S3, Azure Blob, GCS, or a local
+    disk path). This helper runs ``dvc remote add --default
+    somax-data <url>`` with the right backend-specific hints.
+
+    First-time setup:
+
+        somax-sim data init                             # interactive
+        somax-sim data init --backend gdrive --url gdrive://<id>
+        somax-sim data init --backend local --url /data/somax
+
+    The gdrive / s3 / azure / gcs backends need their DVC extra
+    installed (``pip install 'dvc[gdrive]'``). ``init`` detects missing
+    extras and prints a pip-install hint rather than silently failing.
+    """
+    _require_dvc()
+
+    if backend is None:
+        backend = _prompt_backend()
+    if url is None:
+        url = _prompt_url(backend)
+
+    _validate_url_for_backend(backend, url)
+    _check_backend_installed(backend)
+
+    args = ["dvc", "remote", "add", "--default"]
+    if force:
+        args.append("-f")
+    args.extend([REMOTE_NAME, url])
+    _run_dvc(args, "failed to add DVC remote")
+
+    logger.info(f"configured DVC remote '{REMOTE_NAME}' -> {url} (backend: {backend})")
+    logger.info(
+        "next: `somax-sim data fetch <basin>` (if your remote has bundles) "
+        "or `somax-sim data build <basin> --push` (to build and upload)"
+    )
+
+
+# ----------------------------------------------------------------------
+# somax-sim data fetch
+# ----------------------------------------------------------------------
+
+
+@data_app.command
+def fetch(
+    basin: Annotated[
+        BasinName,
+        Parameter(help=f"Basin to fetch. One of {BASIN_NAMES!r}."),
+    ],
+) -> None:
+    """Download a basin bundle from your configured DVC remote.
+
+    Equivalent to ``dvc pull data/basin/<basin>.zarr``. Fails with an
+    actionable message if no remote is configured (see ``data init``).
+    """
+    _require_dvc()
+    target = _basin_zarr_path(basin)
+    if not _remote_configured():
+        raise SystemExit(
+            f"no DVC remote named '{REMOTE_NAME}' is configured.\n"
+            f"run `somax-sim data init` first, or if you have a remote by a "
+            f"different name, run `dvc pull {target}` directly."
+        )
+    _run_dvc(
+        ["dvc", "pull", str(target)],
+        f"failed to pull {target} from remote '{REMOTE_NAME}'",
+    )
+    logger.info(f"pulled {target}")
+
+
+# ----------------------------------------------------------------------
+# somax-sim data build
+# ----------------------------------------------------------------------
+
+
+@data_app.command
+def build(
+    basin: Annotated[
+        BasinName,
+        Parameter(help=f"Basin to build. One of {BASIN_NAMES!r}."),
+    ],
+    *,
+    force: Annotated[
+        bool,
+        Parameter(
+            help=(
+                "Force rebuild even if DVC thinks outputs are up to date "
+                "(wraps `dvc repro --force`)."
+            ),
+        ),
+    ] = False,
+    push: Annotated[
+        bool,
+        Parameter(
+            help=(
+                "After a successful build, push the bundle to the "
+                "configured DVC remote."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Rebuild a basin bundle from source via the DVC pipeline.
+
+    Wraps ``dvc repro build-basin-<basin>``. The Phase 3 placeholder
+    build runs the synthetic generator in ``scripts/data/build_basin.py``;
+    Phase 4 (#78) swaps in GEBCO + ERA5 real-data integration.
+    """
+    _require_dvc()
+    stage = f"build-basin-{basin.replace('_', '-')}"
+    args = ["dvc", "repro"]
+    if force:
+        args.append("--force")
+    args.append(stage)
+    _run_dvc(args, f"failed to rebuild basin '{basin}'")
+    logger.info(f"built data/basin/{basin}.zarr via stage '{stage}'")
+
+    if push:
+        if not _remote_configured():
+            raise SystemExit(
+                f"--push specified but no DVC remote named '{REMOTE_NAME}' "
+                "is configured. run `somax-sim data init` first."
+            )
+        target = _basin_zarr_path(basin)
+        _run_dvc(
+            ["dvc", "push", str(target)],
+            f"built {basin} locally but failed to push to '{REMOTE_NAME}'",
+        )
+        logger.info(f"pushed {target} to remote '{REMOTE_NAME}'")
+
+
+# ----------------------------------------------------------------------
+# somax-sim data status
+# ----------------------------------------------------------------------
+
+
+@data_app.command
+def status() -> None:
+    """Show which basin bundles are materialized locally + the configured remote."""
+    _require_dvc()
+
+    remote_url = _remote_url()
+    if remote_url is None:
+        print("remote: (none configured) — run `somax-sim data init`")
+    else:
+        print(f"remote: {REMOTE_NAME} -> {remote_url}")
+
+    print("basin bundles:")
+    for name in BASIN_NAMES:
+        path = _basin_zarr_path(name)
+        if path.exists() and any(path.iterdir()):
+            print(f"  [x] {name:16s}  ({path})")
+        else:
+            print(f"  [ ] {name:16s}  (not materialized; fetch or build)")
+
+
+# ----------------------------------------------------------------------
+# Internal helpers
+# ----------------------------------------------------------------------
+
+
+def _basin_zarr_path(name: str) -> Path:
+    return Path("data") / "basin" / f"{name}.zarr"
+
+
+def _require_dvc() -> None:
+    """Abort with an actionable message if ``dvc`` is not on PATH."""
+    if shutil.which("dvc") is None:
+        raise SystemExit(
+            "dvc is not on PATH. install with `pip install dvc` (or "
+            "`pip install 'dvc[gdrive]'` etc. for cloud backends) and retry."
+        )
+
+
+def _run_dvc(args: list[str], failure_msg: str) -> None:
+    """Run a DVC command; abort the CLI on failure."""
+    logger.debug(f"$ {' '.join(args)}")
+    result = subprocess.run(args, check=False)
+    if result.returncode != 0:
+        raise SystemExit(f"{failure_msg} (dvc exited {result.returncode})")
+
+
+def _remote_configured() -> bool:
+    return _remote_url() is not None
+
+
+def _remote_url() -> str | None:
+    """Return the URL of the 'somax-data' remote, or None if not configured."""
+    result = subprocess.run(
+        ["dvc", "remote", "list"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return None
+    for line in result.stdout.splitlines():
+        # `dvc remote list` outputs one line per remote: "<name>\t<url>"
+        parts = line.split(maxsplit=1)
+        if len(parts) == 2 and parts[0] == REMOTE_NAME:
+            return parts[1].strip()
+    return None
+
+
+def _check_backend_installed(backend: RemoteBackend) -> None:
+    """Error out with a pip-install hint if the backend's DVC extra is missing."""
+    extra = _BACKEND_EXTRAS[backend]
+    if extra is None:
+        return  # 'local' needs no extra.
+    # Rather than doing a shallow import probe (fragile across DVC
+    # versions), rely on `dvc remote modify` — but that requires an
+    # existing remote. Simplest: rely on DVC's own error, but surface
+    # a clearer hint to the user up front.
+    pip_hint = f"pip install 'dvc[{extra}]'"
+    # We cannot cheaply detect installation without importing DVC
+    # internals, so just mention the extra in the log and let DVC raise
+    # its own error on the subsequent fetch/push if it's missing.
+    logger.info(
+        f"backend '{backend}' uses the '{extra}' DVC extra; "
+        f"if fetch/push fails with an import error, install it: {pip_hint}"
+    )
+
+
+def _prompt_backend() -> RemoteBackend:
+    print("Pick a DVC remote backend:")
+    options: list[RemoteBackend] = ["gdrive", "s3", "azure", "gcs", "local"]
+    for i, opt in enumerate(options, start=1):
+        print(f"  [{i}] {opt}")
+    while True:
+        raw = input("> ").strip()
+        try:
+            idx = int(raw)
+        except ValueError:
+            print(f"enter a number 1-{len(options)}")
+            continue
+        if 1 <= idx <= len(options):
+            return options[idx - 1]
+        print(f"enter a number 1-{len(options)}")
+
+
+def _prompt_url(backend: RemoteBackend) -> str:
+    hints = {
+        "gdrive": "Google Drive folder URL format: gdrive://<folder-id>",
+        "s3": "S3 URL format: s3://<bucket>/<key>",
+        "azure": "Azure Blob URL format: azure://<container>/<path>",
+        "gcs": "GCS URL format: gs://<bucket>/<key>",
+        "local": "Local path: any absolute filesystem path",
+    }
+    print(hints[backend])
+    url = input("remote URL: ").strip()
+    if not url:
+        raise SystemExit("no URL provided; aborting.")
+    return url
+
+
+def _validate_url_for_backend(backend: RemoteBackend, url: str) -> None:
+    """Lightweight URL-shape check so typos are caught before `dvc remote add`."""
+    schemes = {
+        "gdrive": "gdrive://",
+        "s3": "s3://",
+        "azure": "azure://",
+        "gcs": "gs://",
+    }
+    if backend == "local":
+        if not Path(url).is_absolute():
+            raise SystemExit(
+                f"local backend expects an absolute path; got {url!r}. "
+                "use e.g. /data/somax."
+            )
+        return
+    expected = schemes[backend]
+    if not url.startswith(expected):
+        raise SystemExit(
+            f"backend '{backend}' expects a URL starting with {expected!r}; "
+            f"got {url!r}."
+        )
+
+
+def main() -> int:
+    """Entry point — used only when running this module directly for debugging."""
+    return data_app() or 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/somax/_src/cli/app.py
+++ b/somax/_src/cli/app.py
@@ -22,6 +22,7 @@ from cyclopts import App, Parameter
 from loguru import logger
 
 from somax._src.cli import _run
+from somax._src.cli._data import data_app
 from somax._src.cli.spec import RunSpec, load_yaml
 
 
@@ -62,6 +63,12 @@ app = App(
     help="somax simulation runner — fresh runs, spinups, restarts.",
     version_flags=["--version", "-V"],
 )
+
+
+# Real-basin data-bundle helpers (#74 + #75). Mounted as
+# `somax-sim data {init,fetch,build,status}` — thin wrappers around
+# DVC so users don't need to memorize DVC's command surface.
+app.command(data_app)
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -137,6 +137,33 @@ class TestBuildBasinSynthetic:
         build_basin("med_sea", source="synthetic", nx=16, ny=8, out_path=out)
         assert out.exists()
 
+    def test_refuses_to_overwrite_non_zarr_path(self, tmp_path):
+        """Codex PR-#101 P1: a typo like --out data/basin would wipe the
+        whole bundle dir. Require a ``.zarr`` suffix so ``shutil.rmtree``
+        can't recursively nuke unrelated paths.
+        """
+        victim = tmp_path / "precious_data"
+        victim.mkdir()
+        (victim / "important.bin").write_text("do not delete")
+        with pytest.raises(ValueError, match=r"'\.zarr' suffix"):
+            build_basin("med_sea", source="synthetic", nx=8, ny=8, out_path=victim)
+        # The victim dir + file must still exist.
+        assert victim.exists()
+        assert (victim / "important.bin").read_text() == "do not delete"
+
+    def test_refuses_to_overwrite_zarr_named_non_zarr_dir(self, tmp_path):
+        """Even if the path has ``.zarr`` suffix, refuse if it's not an
+        actual Zarr store (no zarr.json / .zgroup / .zarray marker). This
+        catches the case where someone accidentally named an unrelated
+        directory ``foo.zarr`` and would otherwise lose its contents.
+        """
+        victim = tmp_path / "looks_like.zarr"
+        victim.mkdir()
+        (victim / "a_file.txt").write_text("not a zarr store")
+        with pytest.raises(ValueError, match="no Zarr root marker"):
+            build_basin("med_sea", source="synthetic", nx=8, ny=8, out_path=victim)
+        assert (victim / "a_file.txt").read_text() == "not a zarr store"
+
 
 # ----------------------------------------------------------------------
 # BASIN_SPECS integrity

--- a/tests/test_cli_data.py
+++ b/tests/test_cli_data.py
@@ -1,0 +1,222 @@
+"""Tests for the real-basin data CLI helpers (#74 + #75).
+
+Covers:
+  - ``scripts/data/build_basin.py`` synthetic mode: schema, mask
+    coverage, CF attrs, error paths.
+  - ``somax._src.cli._data`` URL validators + remote-name discovery.
+
+No tests actually shell out to ``dvc``. The heavyweight integration
+test is ``dvc repro`` itself, which runs in CI / by the developer on
+first push.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+import xarray as xr
+
+
+# Make the repo root importable so ``from scripts.data.build_basin
+# import ...`` works regardless of where pytest is invoked.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+
+from scripts.data.build_basin import (
+    BASIN_SPECS,
+    SOMAX_BASIN_VERSION,
+    build_basin,
+)
+from somax._src.cli._data import (
+    BASIN_NAMES,
+    REMOTE_NAME,
+    _basin_zarr_path,
+    _validate_url_for_backend,
+)
+
+
+# ----------------------------------------------------------------------
+# build_basin.py — synthetic mode
+# ----------------------------------------------------------------------
+
+
+class TestBuildBasinSynthetic:
+    @pytest.mark.parametrize("name", BASIN_NAMES)
+    def test_each_basin_writes_valid_zarr(self, name, tmp_path):
+        out = tmp_path / f"{name}.zarr"
+        result = build_basin(name, source="synthetic", nx=16, ny=8, out_path=out)
+        assert result == out.resolve()
+        ds = xr.open_zarr(out, consolidated=False)
+        # Schema: required variables.
+        for var in ("bathymetry", "mask", "tau_x", "tau_y", "heat"):
+            assert var in ds.data_vars, f"{name}: missing required variable {var!r}"
+        for coord in ("lon", "lat"):
+            assert coord in ds.coords, f"{name}: missing required coord {coord!r}"
+        # Shape: (y=ny, x=nx).
+        assert ds.mask.shape == (8, 16)
+        # Attrs the runtime will consume.
+        assert ds.attrs["basin_name"] == name
+        assert ds.attrs["somax_basin_version"] == SOMAX_BASIN_VERSION
+        assert ds.attrs["geometry_kind"] in ("real_basin", "spherical_cap")
+
+    @pytest.mark.parametrize("name", BASIN_NAMES)
+    def test_mask_has_both_ocean_and_land(self, name, tmp_path):
+        """A plausible placeholder basin should have *some* ocean and *some* land.
+
+        Otherwise the synthetic mask is either the whole domain (no mask
+        at all) or empty (no ocean to simulate) — either way useless for
+        mask-aware model paths.
+        """
+        out = tmp_path / f"{name}.zarr"
+        build_basin(name, source="synthetic", nx=32, ny=16, out_path=out)
+        ds = xr.open_zarr(out, consolidated=False)
+        mask = np.asarray(ds.mask)
+        ocean = int(mask.sum())
+        total = mask.size
+        assert 0 < ocean < total, (
+            f"{name}: mask must have both ocean and land; "
+            f"got {ocean}/{total} ocean cells"
+        )
+
+    def test_bathymetry_is_nonnegative_and_zero_on_land(self, tmp_path):
+        out = tmp_path / "med_sea.zarr"
+        build_basin("med_sea", source="synthetic", nx=32, ny=16, out_path=out)
+        ds = xr.open_zarr(out, consolidated=False)
+        bathy = np.asarray(ds.bathymetry)
+        mask = np.asarray(ds.mask).astype(bool)
+        assert (bathy >= 0).all(), (
+            "depth must be positive downward; saw negative values"
+        )
+        # Land cells carry zero depth so downstream code doesn't silently
+        # interpret land as ocean-with-finite-depth.
+        assert (bathy[~mask] == 0).all(), (
+            "land cells must have zero depth (else downstream will treat them as ocean)"
+        )
+
+    def test_min_depth_floor_is_respected_on_ocean_cells(self, tmp_path):
+        out = tmp_path / "med_sea.zarr"
+        build_basin(
+            "med_sea", source="synthetic", nx=32, ny=16, min_depth=50.0, out_path=out
+        )
+        ds = xr.open_zarr(out, consolidated=False)
+        bathy = np.asarray(ds.bathymetry)
+        mask = np.asarray(ds.mask).astype(bool)
+        # Ocean cells should all be at least min_depth.
+        assert bathy[mask].min() >= 50.0, (
+            f"min_depth=50 floor not respected on ocean cells; "
+            f"got min depth {bathy[mask].min()}"
+        )
+
+    def test_unknown_basin_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="unknown basin"):
+            build_basin("no_such_basin", out_path=tmp_path / "x.zarr")  # type: ignore[arg-type]
+
+    def test_bad_grid_shape_raises(self, tmp_path):
+        with pytest.raises(ValueError, match=r"nx, ny must be > 0"):
+            build_basin("med_sea", nx=0, ny=8, out_path=tmp_path / "x.zarr")
+
+    def test_real_source_raises_notimplemented(self, tmp_path):
+        """Real-data build (GEBCO + ERA5) is tracked in #78.
+
+        Guard against accidentally flipping it on before the loader
+        lands — the error message must point at the tracking issue.
+        """
+        with pytest.raises(NotImplementedError, match="#78"):
+            build_basin("med_sea", source="real", out_path=tmp_path / "x.zarr")
+
+    def test_overwrites_existing_zarr(self, tmp_path):
+        """Running the build twice must not trip on leftover zarr files."""
+        out = tmp_path / "med_sea.zarr"
+        build_basin("med_sea", source="synthetic", nx=16, ny=8, out_path=out)
+        # Second call should not raise.
+        build_basin("med_sea", source="synthetic", nx=16, ny=8, out_path=out)
+        assert out.exists()
+
+
+# ----------------------------------------------------------------------
+# BASIN_SPECS integrity
+# ----------------------------------------------------------------------
+
+
+class TestBasinSpecs:
+    def test_spec_names_match_cli_basin_names(self):
+        assert set(BASIN_SPECS) == set(BASIN_NAMES)
+
+    @pytest.mark.parametrize("name", BASIN_NAMES)
+    def test_cartesian_specs_have_Lx_Ly_and_ref_lat(self, name):
+        spec = BASIN_SPECS[name]
+        if spec.geometry_kind == "real_basin":
+            assert spec.Lx is not None, f"{name}: real_basin must have Lx"
+            assert spec.Ly is not None, f"{name}: real_basin must have Ly"
+            assert spec.ref_lat is not None, f"{name}: real_basin must have ref_lat"
+        else:  # spherical_cap
+            assert spec.Lx is None
+            assert spec.Ly is None
+            assert spec.ref_lat is None
+
+    @pytest.mark.parametrize("name", BASIN_NAMES)
+    def test_lon_lat_bounds_are_ordered(self, name):
+        spec = BASIN_SPECS[name]
+        lo, hi = spec.lon_bounds
+        assert lo < hi, f"{name}: lon_bounds must be (min, max); got {spec.lon_bounds}"
+        lo, hi = spec.lat_bounds
+        assert lo < hi, f"{name}: lat_bounds must be (min, max); got {spec.lat_bounds}"
+
+
+# ----------------------------------------------------------------------
+# _data.py — URL validators + path helpers
+# ----------------------------------------------------------------------
+
+
+class TestValidateUrlForBackend:
+    @pytest.mark.parametrize(
+        "backend,url",
+        [
+            ("gdrive", "gdrive://1a2b3c"),
+            ("s3", "s3://my-bucket/somax"),
+            ("azure", "azure://container/somax"),
+            ("gcs", "gs://my-bucket/somax"),
+            ("local", "/data/somax"),
+        ],
+    )
+    def test_well_formed_urls_pass(self, backend, url):
+        _validate_url_for_backend(backend, url)  # no exception
+
+    @pytest.mark.parametrize(
+        "backend,url,match",
+        [
+            ("gdrive", "https://drive.google.com/...", "gdrive://"),
+            ("s3", "my-bucket/somax", "s3://"),
+            ("azure", "https://example.com/", "azure://"),
+            ("gcs", "bucket/somax", "gs://"),
+            ("local", "relative/path", "absolute path"),
+        ],
+    )
+    def test_malformed_urls_raise(self, backend, url, match):
+        with pytest.raises(SystemExit, match=match):
+            _validate_url_for_backend(backend, url)
+
+
+class TestBasinZarrPath:
+    @pytest.mark.parametrize("name", BASIN_NAMES)
+    def test_path_matches_dvc_stage_output(self, name):
+        """The path the CLI computes must match the stage's ``outs:`` entry.
+
+        If the helpers look at ``data/basin/<name>.zarr`` but DVC writes
+        to ``data/basins/<name>.zarr`` (or similar), ``fetch`` and
+        ``build --push`` would silently reference different paths. Lock
+        it down here.
+        """
+        assert _basin_zarr_path(name) == Path("data") / "basin" / f"{name}.zarr"
+
+
+class TestRemoteNameIsStable:
+    def test_remote_name_constant(self):
+        """The remote name is baked into user-facing docs (the design
+        note + subcommand help). Don't rename it without updating both."""
+        assert REMOTE_NAME == "somax-data"


### PR DESCRIPTION
## Summary

Closes the "open questions" in #74 (real-basin geometry sourcing) and #75 (real-basin forcing climatologies) with a committed decision note and a runnable DVC pipeline scaffold. Answers every Q in both issues and lands the wiring Phase 4 (#78) needs.

## Decisions

See [content/notes/basin_data_sources.md](https://github.com/jejjohnson/somax/blob/feat/basin-data-sources-74-75/content/notes/basin_data_sources.md) for the full design. Headline calls:

| Question | Decision |
|---|---|
| Bathymetry | **GEBCO 2024** (15 arc-sec global) |
| Land mask | Derived from GEBCO (depth ≥ 0) — single source avoids mask/bathy inconsistency |
| Forcing | **ERA5** monthly-means, annual mean over **1993-2023** (seasonal cycle deferred) |
| Format | **Zarr v3** bundles, one store per basin, matching `somax/_src/io/xarray.py` |
| Distribution | **DVC pipeline + bring-your-own-remote** — somax ships the pipeline, users configure their own storage |
| Canonical grids | med_sea 128x64, gulf_stream 256x128, north_atlantic 256x256, southern_ocean 360x90 |
| Coordinates | Cartesian β-plane (Mercator) for Cartesian basins; lat/lon native for southern_ocean |

pooch is explicitly rejected — DVC already provides fetch-with-hash-versioning.

## Scaffold shipped

- `scripts/data/build_basin.py` — synthetic-placeholder mode so the pipeline runs end-to-end today. `--source real` (GEBCO + ERA5) is wired to raise `NotImplementedError` with a #78 pointer; a one-function swap when the loader lands.
- `dvc.yaml` — four new stages: `build-basin-{med-sea,gulf-stream,north-atlantic,southern-ocean}`. Outputs at `data/basin/<name>.zarr`, DVC-tracked (not git-tracked).
- `somax-sim data {init,fetch,build,status}` — thin DVC wrappers so users never need to memorize DVC's command surface. Supports gdrive / s3 / azure / gcs / local backends.
- Bundles materialized locally (`dvc repro`) — ready to push once a remote is configured.

## What's out of scope

- Real GEBCO + ERA5 data integration — Phase 4 (#78).
- Time-varying / seasonal forcing — future issue.
- A canonical somax-hosted bundle — explicitly rejected.

## Test plan

- [x] `uv run pytest --no-cov -n auto` — 565 passed (up from 527, +38 new)
- [x] `uv run --group lint ruff check .` — clean
- [x] `uv run --group lint ruff format --check .` — clean
- [x] `uv run --group typecheck ty check somax` — clean
- [x] `uv run dvc repro build-basin-med-sea` (and the other three) — materializes `data/basin/*.zarr` locally
- [x] `uv run somax-sim data status` — reports all four basins materialized, remote unconfigured

🤖 Generated with [Claude Code](https://claude.com/claude-code)