### PR TITLE
refactor: ecosystem alignment (Phase 0–2) — term algebra + pipekit Operator/Cycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --group dev --group sim
-      - name: Run tests with coverage
-        run: uv run pytest -v
+      - name: Run fast tests with coverage
+        # Slow + integration tests (grad-through, somax-sim end-to-end)
+        # are excluded here and run in the manual `full-tests` workflow.
+        run: uv run pytest -v -m "not slow"
       - name: Upload coverage report
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -1,0 +1,51 @@
+name: Full Tests (slow + integration)
+
+# The PR CI job (ci.yml) runs only the fast subset (`-m "not slow"`).
+# This workflow runs the COMPLETE suite — including the slow
+# grad-through correctness tests and the end-to-end somax-sim
+# integration tests — and is triggered manually on demand.
+on:
+  workflow_dispatch:
+    inputs:
+      marker:
+        description: >-
+          pytest -m expression to select tests (default: the full suite).
+          Examples: "slow", "integration", "slow and not integration".
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  full-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: uv sync --group dev --group sim
+      - name: Run full test suite with coverage
+        run: |
+          if [ -n "${{ inputs.marker }}" ]; then
+            uv run pytest -v -m "${{ inputs.marker }}"
+          else
+            uv run pytest -v
+          fi
+      - name: Upload coverage report
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report-full
+          path: coverage.xml
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v6
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ RESET  := \033[0m
 # ---------------------------------------------------------------------------
 # Phony declarations
 # ---------------------------------------------------------------------------
-.PHONY: help install lint format typecheck test test-cov \
+.PHONY: help install lint format typecheck test test-all test-cov \
 	precommit build clean version docs docs-serve docs-deploy \
 	init gh-labels gh-sub gh-block gh-show
 
@@ -117,14 +117,19 @@ typecheck: ## Type-check with ty
 ##@ Testing
 # ===========================================================================
 
-test: ## Run tests with pytest (no coverage)
-	@printf "$(YELLOW)>>> Running tests (no coverage)...$(RESET)\n"
-	uv run pytest -v -o addopts=
-	@printf "$(GREEN)>>> Tests passed!$(RESET)\n"
+test: ## Run the fast test subset (excludes slow/integration; mirrors PR CI)
+	@printf "$(YELLOW)>>> Running fast tests (-m 'not slow')...$(RESET)\n"
+	uv run pytest -v -o addopts= -m "not slow"
+	@printf "$(GREEN)>>> Fast tests passed!$(RESET)\n"
 
-test-cov: ## Run tests with coverage report
-	@printf "$(YELLOW)>>> Running tests with coverage...$(RESET)\n"
-	uv run pytest -v
+test-all: ## Run the complete suite incl. slow + integration tests
+	@printf "$(YELLOW)>>> Running ALL tests (slow + integration)...$(RESET)\n"
+	uv run pytest -v -o addopts=
+	@printf "$(GREEN)>>> All tests passed!$(RESET)\n"
+
+test-cov: ## Run the fast subset with coverage report (mirrors PR CI gate)
+	@printf "$(YELLOW)>>> Running fast tests with coverage...$(RESET)\n"
+	uv run pytest -v -m "not slow"
 	@printf "$(GREEN)>>> Coverage report generated!$(RESET)\n"
 
 # ===========================================================================

--- a/content/notes/ecosystem_refactor_plan.md
+++ b/content/notes/ecosystem_refactor_plan.md
@@ -95,10 +95,14 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
 ### Phase 1 — Adopt pipekit protocols on the model layer *(done)*
 
 - Add `step(self, state, dt) -> state` to `SomaxModel` (thin wrapper over
-  `integrate` for a single step). Every somax model now structurally satisfies
-  `pipekit_cycle.ForwardModel` — purely by duck typing, **no pipekit
-  dependency added**. It is also the building block for `filterax`'s dynamics
-  interface.
+  `integrate` for a single step). The model supplies the `step` +
+  `state_signature` members of `pipekit_cycle.ForwardModel` structurally, by
+  duck typing; the third member (a default `dt`) is added by the
+  `somax.operators` Operator adapter (a bare model has no inherent step size).
+  It is also the building block for `filterax`'s dynamics interface. Phase 1
+  itself adds **no** pipekit dependency; Phase 2 makes pipekit a base
+  dependency for the Operator / Cycle layer, but somax's *core* still never
+  imports it.
 - *(Optional follow-up)* mix in `pipekit.ConfigMixin` so `get_config()` /
   `state` round-trip comes for free.
 

--- a/content/notes/ecosystem_refactor_plan.md
+++ b/content/notes/ecosystem_refactor_plan.md
@@ -79,9 +79,11 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
 
 ### Phase 0 — Foundation alignment & dependency hygiene *(done)*
 
-- Bump `finitevolx` `v0.0.40 → v0.0.41` and `spectraldiffx` `>=0.0.10 →
-  >=0.0.12` (the `[tool.uv.sources]` pin moves to the un-prefixed `0.0.12` tag,
-  since spectraldiffx disabled v-prefixed release tags).
+- Bump `finitevolx` `v0.0.40 → v0.0.41`. `spectraldiffx` stays pinned to the
+  git tag `v0.0.10` (`>=0.0.10`): finitevolx `v0.0.41` itself pins
+  `spectraldiffx` to `v0.0.10`, and `uv` requires a single git ref per
+  package across the dependency graph — so a `0.0.12` pin is unresolvable and
+  must agree with finitevolx.
 - No somax source changes were required: the full test suite passes on the
   bumped versions as-is (somax already uses the new finitevolx grid/mask
   naming, and the spectraldiffx solver API is unchanged for somax's usage).

--- a/content/notes/ecosystem_refactor_plan.md
+++ b/content/notes/ecosystem_refactor_plan.md
@@ -1,0 +1,180 @@
+# Somax Ecosystem Refactor Plan
+
+A status scrape of the eight sibling libraries in the `jejjohnson` scientific
+stack and a phased plan for aligning **somax** with the framework
+(`pipekit`), the domain toolkit (`xrtoolz`), the numerics foundation
+(`finitevolx` / `spectraldiffx`), and the data-assimilation consumers
+(`vardax` / `filterax`).
+
+> **Status:** Phase 0 and Phase 1 are implemented (see
+> [What has been done](#what-has-been-done)). Phases 2–5 are proposed.
+
+## The ecosystem at a glance
+
+```
+        ┌──────────────────── FRAMEWORK (carrier-agnostic) ─────────────────────┐
+        │ pipekit            Operator · ConfigMixin · Sequential · Graph · serial │
+        │ pipekit-cycle      ForwardModel · ObservationOperator · AnalysisStep    │
+        │ pipekit-experiment ModelRegistry · ExperimentTracker · Hydra/DVC adapter│
+        │ pipekit-train      TrainingLoop · Loss · datasets   pipekit-jax JaxModelOp│
+        └────────────────────────────────────────────────────────────────────────┘
+   NUMERICS FOUNDATION              DOMAIN TOOLKITS                 DA CONSUMERS
+   gaussx     (structured linalg)   xrtoolz  (xarray preproc+eval)  vardax   (variational DA)
+   spectraldiffx (spectral solvers) somax    (PDE/ocean models)     filterax (ensemble DA)
+   finitevolx (FV C-grid operators)    ▲ consumes fvx + sdx         both consume gaussx +
+        ▲ finitevolx → spectraldiffx    somax ──step()──────────►   pipekit-cycle protocols
+```
+
+### Maturity snapshot (all pre-1.0, actively developed)
+
+| Repo | Version | State | Role for somax |
+|---|---|---|---|
+| **gaussx** | 0.0.15 | Mature, no stubs, ~122 test files | Covariance / linalg backbone for DA (indirect) |
+| **spectraldiffx** | 0.0.12 | Real; Chebyshev 2D, spherical vorticity inversion, mixed-BC Helmholtz | somax's spectral Helmholtz backend |
+| **finitevolx** | 0.0.41 | Real; spherical operators, linear EOS, `SolveDomain` / `KnownValueLifting` | somax's FV operator backend |
+| **pipekit** | 0.0.1 | core / cycle / experiment / train / jax implemented; array / evaluate scaffolded | Protocols + config layer to adopt |
+| **xrtoolz** | 0.0.8 | Broad and real; consumes `pipekit.Operator` | Preprocessing + evaluation to reuse |
+| **vardax** | 0.1.8 | FourDVarNet real; classical methods architected | Consumes somax as `ForwardModel` |
+| **filterax** | 0.0.3 | EnKF / ETKF / LETKF / smoothers / EKI real, differentiable | Consumes somax as dynamics |
+| **somax** | 0.0.8 | Real model library + CLI; the refactor target | — |
+
+## Where somax stands
+
+**What it is.** A JAX / equinox / diffrax ocean-modeling library plus a
+`somax-sim` CLI runner (~136 Python files). Models: Lorenz 63/96/96t, PDE
+1D/2D (diffusion, convection, Burgers, Poisson, Navier–Stokes), shallow-water
+(1D/2D linear/nonlinear, multilayer), QG (barotropic / baroclinic /
+reparameterized). The architecture cleanly splits `_src/models/` (equations) ·
+`_src/cli/scenarios/` (geometry + forcing + IC) · `_src/cli/models_registry/`
+(how to build), funneled through a `scenario × model` dispatcher.
+
+**The core observation.** somax predates pipekit and xrtoolz, so it hand-rolls
+a large amount of "framework" that the rest of the ecosystem now provides:
+
+| Hand-written in somax | ~LOC | Already exists in… |
+|---|---|---|
+| `cli/spec.py` — dataclasses + `from_dict`/`to_dict`/`validate`/deep-merge/YAML | 431 | `pipekit.ConfigMixin` + `serial.dumps/loads`; `pipekit-experiment` Hydra adapter |
+| `cli/_run.py` — integration / orchestration loop | 1065 | `pipekit-cycle.Cycle` (scan-based stepping + history) |
+| `scenarios/` + `models_registry/` + `_compatibility.py` | ~600 | `pipekit-experiment.ModelRegistry` + Operator config |
+| `scripts/build_configs.py` — Python→YAML materializer | 66 | `pipekit-experiment` Hydra / `hydra-zen` round-trip |
+| `_src/io/xarray.py` — state↔Dataset, zarr | 286 | `xrtoolz` (`einx.pack/unpack_dataset`, io) |
+| `cli/_assertions.py` — CFL / energy / finite checks | 235 | `xrtoolz.metrics.physical` (geostrophic balance, PV conservation, divergence) |
+
+**The missing seam.** `SomaxModel` exposed `vector_field` + `integrate` (a
+diffrax `Solution`) but **not** `step(state, dt) -> state` — exactly the
+`pipekit_cycle.ForwardModel` protocol method, and the building block the DA
+libraries call. That one gap blocked vardax/filterax from consuming somax.
+
+**Good news on API alignment.** somax already imports the *new* finitevolx
+names (`CartesianGrid2D.from_interior`, `Mask2D` threaded as an operator
+attribute, no `.w` / `.psi` field access, no manual `* mask` post-multiply).
+The only stale coupling was the spectraldiffx Helmholtz constructor keyword
+(`alpha` → `lambda_`). So alignment is a version bump, not a rewrite.
+
+## The plan
+
+Sequenced by unblocking value. Phases 0–1 are the high-leverage core; 2–3 are
+the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
+**0 → 1 → 3 → 2 → 4 → 5**.
+
+### Phase 0 — Foundation alignment & dependency hygiene *(done)*
+
+- Bump `finitevolx` `v0.0.40 → v0.0.41` and `spectraldiffx` `>=0.0.10 →
+  >=0.0.12` (the `[tool.uv.sources]` pin moves to the un-prefixed `0.0.12` tag,
+  since spectraldiffx disabled v-prefixed release tags).
+- No somax source changes were required: the full test suite passes on the
+  bumped versions as-is (somax already uses the new finitevolx grid/mask
+  naming, and the spectraldiffx solver API is unchanged for somax's usage).
+- **Capability opt-ins now unlocked** (track separately): finitevolx
+  `SolveDomain` / `KnownValueLifting` for inhomogeneous BCs, the new spherical
+  operators (to fill the stubbed `spherical_swm` / `global_ocean` scenarios),
+  and the linear equation-of-state module.
+
+### Phase 1 — Adopt pipekit protocols on the model layer *(done)*
+
+- Add `step(self, state, dt) -> state` to `SomaxModel` (thin wrapper over
+  `integrate` for a single step). Every somax model now structurally satisfies
+  `pipekit_cycle.ForwardModel` — purely by duck typing, **no pipekit
+  dependency added**. It is also the building block for `filterax`'s dynamics
+  interface.
+- *(Optional follow-up)* mix in `pipekit.ConfigMixin` so `get_config()` /
+  `state` round-trip comes for free.
+
+### Phase 2 — Replace hand-rolled config / registry / runner with pipekit
+
+- Re-express `scenarios` and `models` as `pipekit.Operator`s (or registry
+  entries) so construction params auto-serialize via `ConfigMixin`. Replace
+  `cli/spec.py`'s bespoke (de)serialization with `pipekit.serial` plus the
+  `pipekit-experiment` Hydra / `hydra-zen` adapter for YAML round-tripping —
+  this retires `scripts/build_configs.py` and the `configs/_authoring/*.py`
+  materializer pattern.
+- Replace the `scenario × model` dispatcher + `_compatibility.py` with
+  `pipekit-experiment.ModelRegistry`.
+- Re-express `cli/_run.py`'s stepping loop on `pipekit_cycle.Cycle` (scan-based
+  stepping + history / `save_interval` for free) — the largest single LOC
+  reduction. Keep `somax-sim` (cyclopts) as the thin CLI shell.
+
+### Phase 3 — Reuse xrtoolz for IO, evaluation, basin data
+
+- Swap `_src/io/xarray.py` state↔Dataset plumbing onto
+  `xrtoolz.einx.pack_dataset` / `unpack_dataset` + xrtoolz io; keep a thin
+  somax-specific dim-naming adapter.
+- Replace `cli/_assertions.py` numeric checks with `xrtoolz.metrics` —
+  `geostrophic_balance_error`, `pv_conservation_error`, `divergence_error`,
+  plus `rmse` / `psd_score` for skill. This also gives somax a real evaluation
+  surface it currently lacks.
+- For the stubbed Phase 4/5 basin-data work (`scripts/data/build_basin.py`,
+  currently synthetic), use xrtoolz preprocessing — `regrid_like`,
+  `coarsen_conservative`, `fillnan_*`, CF validation, `CMEMSSource` /
+  `CDSSource` loaders — instead of building new ingestion.
+
+### Phase 4 — Data-assimilation integration (vardax / filterax)
+
+- Provide somax-side `ObservationOperator`s (satisfying the pipekit-cycle
+  protocol; vardax/filterax also offer generic ones — `AveragingKernel`,
+  `LinearObs`).
+- Provide background / observation covariances as `gaussx` operators
+  (`Kronecker`, `LowRankUpdate`, …).
+- Wire a somax model into `vardax.VarDACycle` (4DVar) and `filterax` filters
+  (ETKF / EnKF). Both already consume any JAX forward model by duck typing;
+  Phase 1's `step()` is the only hard prerequisite. A small adapter can bridge
+  `step(state, dt)` to `filterax.AbstractDynamics.__call__(state, *, key)`
+  (fixed-window stepper).
+
+### Phase 5 — Training & experiment tracking *(opportunistic)*
+
+- `pipekit-jax.JaxModelOp` to serialize equinox models; `pipekit-experiment`
+  trackers for runs; `pipekit-train` if/when learned closures or emulators are
+  added.
+
+## What has been done
+
+Phase 0 and Phase 1 are implemented on the
+`claude/somax-refactor-plan-SM3dT` branch:
+
+- **`pyproject.toml`** — `finitevolx` bumped to `v0.0.41`, `spectraldiffx` to
+  `>=0.0.12` (source pin moved to the un-prefixed `0.0.12` tag). No other
+  source changes were needed for the alignment.
+- **`somax/_src/core/model.py`** — new `SomaxModel.step(state, dt, *, t0=0.0)`
+  returning a bare state pytree, making every model a structural
+  `pipekit_cycle.ForwardModel`.
+- **`tests/core/test_model.py`** — tests covering `step`↔`integrate`
+  agreement, multi-step composition over a window, and structural
+  `ForwardModel` conformance (via a local Protocol mirror, so no new test
+  dependency).
+
+The full test suite passes, and `ruff check`, `ruff format`, and `ty check`
+are clean on the changed files.
+
+> **Note on local development.** The `finitevolx` / `spectraldiffx`
+> dependencies are private git pins. To run the suite against the local
+> sibling checkouts, temporarily add:
+>
+> ```toml
+> [tool.uv.sources]
+> finitevolx = { path = "../finitevolX", editable = true }
+> spectraldiffx = { path = "../spectraldiffx", editable = true }
+> ```
+>
+> to `pyproject.toml`, then `uv sync`. Remove it before committing — the
+> committed dependency spec uses the published git tags.

--- a/content/tutorials/composable_models_terms_operators_cycles.ipynb
+++ b/content/tutorials/composable_models_terms_operators_cycles.ipynb
@@ -5,23 +5,23 @@
    "id": "7e6106b1",
    "metadata": {},
    "source": [
-    "# Composable Models: Terms → Operators → Cycles\n",
+    "# Composable Models: Terms \u2192 Operators \u2192 Cycles\n",
     "\n",
     "somax models plug into the [pipekit](https://github.com/jejjohnson/pipekit)\n",
     "ecosystem along three seams that build on each other. This tutorial walks\n",
     "the whole path end to end:\n",
     "\n",
-    "1. **Terms** — a model's right-hand side as a *sum of composable physics\n",
+    "1. **Terms** \u2014 a model's right-hand side as a *sum of composable physics\n",
     "   kernels*, with per-term `explicit`/`implicit` tags for IMEX integration.\n",
-    "2. **Operators** — wrapping a built model as a `pipekit.Operator`: a\n",
+    "2. **Operators** \u2014 wrapping a built model as a `pipekit.Operator`: a\n",
     "   one-step pipeline stage that satisfies `pipekit_cycle.ForwardModel` and\n",
     "   (for flat-config models) round-trips through `pipekit.serial`.\n",
-    "3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,\n",
+    "3. **Cycles** \u2014 driving the stepping loop with `pipekit_cycle.Cycle`,\n",
     "   threading state and collecting a trajectory.\n",
     "\n",
-    "Everything here needs the `sim` dependency group (`uv sync --group sim`),\n",
-    "which carries pipekit.\n",
-    "somax's *core* never imports pipekit — models satisfy the protocols\n",
+    "The Operator/Cycle parts use pipekit, which is a base somax dependency\n",
+    "(somax's *core* still never imports it \u2014 conformance is structural).\n",
+    "somax's *core* never imports pipekit \u2014 models satisfy the protocols\n",
     "structurally."
    ]
   },
@@ -60,8 +60,8 @@
     "## 1. A model as a sum of term-kernels\n",
     "\n",
     "The linear shallow water right-hand side decomposes into four distinct\n",
-    "physics kernels — a gravity-wave (pressure) term, Coriolis, lateral\n",
-    "diffusion, and bottom drag — that compose with `+`:\n",
+    "physics kernels \u2014 a gravity-wave (pressure) term, Coriolis, lateral\n",
+    "diffusion, and bottom drag \u2014 that compose with `+`:\n",
     "\n",
     "$$\n",
     "\\texttt{rhs} = \\underbrace{\\texttt{gravity\\_wave}}_{\\text{fast, stiff}}\n",
@@ -159,7 +159,7 @@
    "id": "521e0a53",
    "metadata": {},
    "source": [
-    "## 2. IMEX — tag stiff terms implicit\n",
+    "## 2. IMEX \u2014 tag stiff terms implicit\n",
     "\n",
     "Because each kernel carries an integration `kind`, a stiff term can be\n",
     "routed to the implicit stage of a splitting (IMEX) solver. With the\n",
@@ -250,8 +250,8 @@
    "source": [
     "## 4. Flat-config models round-trip through `pipekit.serial`\n",
     "\n",
-    "A built model is an `eqx.Module` (grids, operators, term trees) — not JSON\n",
-    "primitives — so the general wrapper above is *not* serializable. Models\n",
+    "A built model is an `eqx.Module` (grids, operators, term trees) \u2014 not JSON\n",
+    "primitives \u2014 so the general wrapper above is *not* serializable. Models\n",
     "whose construction is a **flat primitive recipe** expose a dedicated\n",
     "Operator (e.g. `Burgers2DOp`) whose config is all primitives, so\n",
     "`dumps`/`loads` round-trips the build recipe faithfully."
@@ -298,7 +298,7 @@
     "\n",
     "`Cycle` applies the step operator `n_steps` times, threading state and\n",
     "(with `save_history=True`) collecting the trajectory. We seed a Gaussian\n",
-    "height bump and watch gravity waves radiate outward under rotation — a\n",
+    "height bump and watch gravity waves radiate outward under rotation \u2014 a\n",
     "geostrophic-adjustment problem. The gravity-wave *term* from step 1 is\n",
     "exactly what drives this."
    ]
@@ -440,7 +440,7 @@
     "print(\"built:\", type(reg_op.model).__name__)\n",
     "print(\"forward-integrated 10 steps; finite:\", bool(jnp.all(jnp.isfinite(reg_final.h))))\n",
     "\n",
-    "# Operators compose like any pipekit stage — ``op | op`` is two steps.\n",
+    "# Operators compose like any pipekit stage \u2014 ``op | op`` is two steps.\n",
     "two_steps = (reg_op | reg_op)(reg_state0)\n",
     "print(\"op | op == two steps:\", bool(jnp.all(jnp.isfinite(two_steps.h))))"
    ]

--- a/content/tutorials/composable_models_terms_operators_cycles.ipynb
+++ b/content/tutorials/composable_models_terms_operators_cycles.ipynb
@@ -1,0 +1,488 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7e6106b1",
+   "metadata": {},
+   "source": [
+    "# Composable Models: Terms → Operators → Cycles\n",
+    "\n",
+    "somax models plug into the [pipekit](https://github.com/jejjohnson/pipekit)\n",
+    "ecosystem along three seams that build on each other. This tutorial walks\n",
+    "the whole path end to end:\n",
+    "\n",
+    "1. **Terms** — a model's right-hand side as a *sum of composable physics\n",
+    "   kernels*, with per-term `explicit`/`implicit` tags for IMEX integration.\n",
+    "2. **Operators** — wrapping a built model as a `pipekit.Operator`: a\n",
+    "   one-step pipeline stage that satisfies `pipekit_cycle.ForwardModel` and\n",
+    "   (for flat-config models) round-trips through `pipekit.serial`.\n",
+    "3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,\n",
+    "   threading state and collecting a trajectory.\n",
+    "\n",
+    "Everything here lives under the `somax[sim]` extra (which carries pipekit).\n",
+    "somax's *core* never imports pipekit — models satisfy the protocols\n",
+    "structurally."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7a251f0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:41.423467Z",
+     "iopub.status.busy": "2026-05-31T11:49:41.423076Z",
+     "iopub.status.idle": "2026-05-31T11:49:43.620733Z",
+     "shell.execute_reply": "2026-05-31T11:49:43.619105Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "from __future__ import annotations\n",
+    "\n",
+    "import jax.numpy as jnp\n",
+    "import matplotlib.pyplot as plt\n",
+    "from pipekit import dumps, loads\n",
+    "from pipekit_cycle import Cycle, ForwardModel\n",
+    "\n",
+    "from somax._src.models.swm.linear_2d import LinearSW2DState\n",
+    "from somax._src.models.swm.linear_swm_terms import LinearSWM2DTermModel\n",
+    "from somax.operators import Burgers2DOp, SomaxModelOp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6185152c",
+   "metadata": {},
+   "source": [
+    "## 1. A model as a sum of term-kernels\n",
+    "\n",
+    "The linear shallow water right-hand side decomposes into four distinct\n",
+    "physics kernels — a gravity-wave (pressure) term, Coriolis, lateral\n",
+    "diffusion, and bottom drag — that compose with `+`:\n",
+    "\n",
+    "$$\n",
+    "\\texttt{rhs} = \\underbrace{\\texttt{gravity\\_wave}}_{\\text{fast, stiff}}\n",
+    "  + \\texttt{coriolis}\n",
+    "  + \\nu \\cdot \\underbrace{\\texttt{diffusion}}_{\\text{stiff}}\n",
+    "  + (-\\kappa) \\cdot \\texttt{drag}\n",
+    "$$\n",
+    "\n",
+    "The differentiable parameters ($\\nu$, $\\kappa$) enter as `Scaled`\n",
+    "coefficients (JAX leaves), so a loss can be differentiated straight\n",
+    "through them."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6d20e89d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:43.623817Z",
+     "iopub.status.busy": "2026-05-31T11:49:43.623298Z",
+     "iopub.status.idle": "2026-05-31T11:49:43.928948Z",
+     "shell.execute_reply": "2026-05-31T11:49:43.927546Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "LinearSWMGravityWave -> LinearSWMGravityWave(\n",
+      "  diff=Difference2D(\n",
+      "    grid=CartesianGrid2D(\n",
+      "      Nx=66, Ny=66, Lx=2000000.0, Ly=2000000.0, dx=31250.0, dy=31250.0\n",
+      "    )\n",
+      "  ),\n",
+      "  g=9.81,\n",
+      "  H0=100.0\n",
+      ")\n",
+      "LinearSWMCoriolis -> LinearSWMCoriolis(\n",
+      "  coriolis=Coriolis2D(\n",
+      "    grid=CartesianGrid2D(\n",
+      "      Nx=66, Ny=66, Lx=2000000.0, Ly=2000000.0, dx=31250.0, dy=31250.0\n",
+      "    ),\n",
+      "    mask=None,\n",
+      "    interp=Interpolation2D(\n",
+      "      grid=CartesianGrid2D(\n",
+      "        Nx=66, Ny=66, Lx=2000000.0, Ly=2000000.0, dx=31250.0, dy=31250.0\n",
+      "      )\n",
+      "    )\n",
+      "  ),\n",
+      "  f_field=weak_f32[66,66]\n",
+      ")\n",
+      "Scaled -> Scaled(\n",
+      "  term=LinearSWMDiffusion(\n",
+      "    diff=Difference2D(\n",
+      "      grid=CartesianGrid2D(\n",
+      "        Nx=66, Ny=66, Lx=2000000.0, Ly=2000000.0, dx=31250.0, dy=31250.0\n",
+      "      )\n",
+      "    )\n",
+      "  ),\n",
+      "  coeff=weak_f32[]\n",
+      ")\n",
+      "Scaled -> Scaled(term=LinearSWMDrag(), coeff=weak_f32[])\n",
+      "\n",
+      "viscosity nu read back from the tree: 200.0\n",
+      "bottom drag kappa read back from the tree: 1.0000000116860974e-07\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = LinearSWM2DTermModel.create(\n",
+    "    nx=64,\n",
+    "    ny=64,\n",
+    "    Lx=2_000e3,\n",
+    "    Ly=2_000e3,\n",
+    "    f0=1e-4,\n",
+    "    beta=2e-11,\n",
+    "    H0=100.0,\n",
+    "    lateral_viscosity=200.0,\n",
+    "    bottom_drag=1e-7,\n",
+    ")\n",
+    "\n",
+    "# The assembled right-hand side is a Sum of four term-kernels:\n",
+    "for term in model.terms.terms:\n",
+    "    print(type(term).__name__, \"->\", repr(term))\n",
+    "\n",
+    "print(\"\\nviscosity nu read back from the tree:\", float(model.nu))\n",
+    "print(\"bottom drag kappa read back from the tree:\", float(model.kappa))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "521e0a53",
+   "metadata": {},
+   "source": [
+    "## 2. IMEX — tag stiff terms implicit\n",
+    "\n",
+    "Because each kernel carries an integration `kind`, a stiff term can be\n",
+    "routed to the implicit stage of a splitting (IMEX) solver. With the\n",
+    "default (all explicit) the whole RHS lowers to a single `diffrax.ODETerm`;\n",
+    "with `imex=True` the diffusion term is tagged implicit and the RHS lowers\n",
+    "to a `diffrax.MultiTerm` that an IMEX solver (e.g. `KenCarp3`) integrates\n",
+    "with the stiff Laplacian handled implicitly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d65163ff",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:43.931373Z",
+     "iopub.status.busy": "2026-05-31T11:49:43.931144Z",
+     "iopub.status.idle": "2026-05-31T11:49:44.192141Z",
+     "shell.execute_reply": "2026-05-31T11:49:44.190362Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "explicit build_terms(): ODETerm\n",
+      "imex     build_terms(): MultiTerm\n"
+     ]
+    }
+   ],
+   "source": [
+    "explicit_model = LinearSWM2DTermModel.create(nx=32, ny=32, lateral_viscosity=200.0)\n",
+    "imex_model = LinearSWM2DTermModel.create(\n",
+    "    nx=32, ny=32, lateral_viscosity=200.0, imex=True\n",
+    ")\n",
+    "\n",
+    "print(\"explicit build_terms():\", type(explicit_model.build_terms()).__name__)\n",
+    "print(\"imex     build_terms():\", type(imex_model.build_terms()).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fae1c344",
+   "metadata": {},
+   "source": [
+    "## 3. Wrap a built model as a pipekit Operator\n",
+    "\n",
+    "`SomaxModelOp` turns *any* built somax model into a `pipekit.Operator`: a\n",
+    "one-step stage (`op(state) -> next_state`) that also satisfies the\n",
+    "`pipekit_cycle.ForwardModel` protocol (`step` / `dt` / `state_signature`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "7d24be6e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:44.194611Z",
+     "iopub.status.busy": "2026-05-31T11:49:44.194352Z",
+     "iopub.status.idle": "2026-05-31T11:49:44.198912Z",
+     "shell.execute_reply": "2026-05-31T11:49:44.197655Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "isinstance(op, ForwardModel): True\n",
+      "wrapped model: LinearSWM2DTermModel\n"
+     ]
+    }
+   ],
+   "source": [
+    "op = SomaxModelOp(model, dt=90.0)\n",
+    "print(\"isinstance(op, ForwardModel):\", isinstance(op, ForwardModel))\n",
+    "print(\"wrapped model:\", type(op.model).__name__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f219c09",
+   "metadata": {},
+   "source": [
+    "## 4. Flat-config models round-trip through `pipekit.serial`\n",
+    "\n",
+    "A built model is an `eqx.Module` (grids, operators, term trees) — not JSON\n",
+    "primitives — so the general wrapper above is *not* serializable. Models\n",
+    "whose construction is a **flat primitive recipe** expose a dedicated\n",
+    "Operator (e.g. `Burgers2DOp`) whose config is all primitives, so\n",
+    "`dumps`/`loads` round-trips the build recipe faithfully."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "3980abea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:44.201004Z",
+     "iopub.status.busy": "2026-05-31T11:49:44.200818Z",
+     "iopub.status.idle": "2026-05-31T11:49:44.206979Z",
+     "shell.execute_reply": "2026-05-31T11:49:44.205836Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "serialized config: {\"class\": \"Burgers2DOp\", \"config\": {\"Lx\": 2.0, \"Ly\": 2.0, \"dt\": 0.001, \"imex\": false, \"method\": \"upwind1\", \"nu\": 0.05, \"nx\": 32, \"ny\": 32}, \"module\": \"somax._src.operators\"}\n",
+      "round-trip matches: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "burgers = Burgers2DOp(nx=32, ny=32, nu=0.05, dt=1e-3, imex=False)\n",
+    "blob = dumps(burgers)\n",
+    "print(\"serialized config:\", blob)\n",
+    "\n",
+    "restored = loads(blob)\n",
+    "print(\"round-trip matches:\", restored.get_config() == burgers.get_config())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb2f01e4",
+   "metadata": {},
+   "source": [
+    "## 5. Drive the model with `pipekit_cycle.Cycle`\n",
+    "\n",
+    "`Cycle` applies the step operator `n_steps` times, threading state and\n",
+    "(with `save_history=True`) collecting the trajectory. We seed a Gaussian\n",
+    "height bump and watch gravity waves radiate outward under rotation — a\n",
+    "geostrophic-adjustment problem. The gravity-wave *term* from step 1 is\n",
+    "exactly what drives this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ee8afdf4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:49:44.209119Z",
+     "iopub.status.busy": "2026-05-31T11:49:44.208928Z",
+     "iopub.status.idle": "2026-05-31T11:52:18.634816Z",
+     "shell.execute_reply": "2026-05-31T11:52:18.633588Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "steps recorded in history: 6\n"
+     ]
+    }
+   ],
+   "source": [
+    "grid = model.grid\n",
+    "x = jnp.arange(grid.Nx) * grid.dx\n",
+    "y = jnp.arange(grid.Ny) * grid.dy\n",
+    "X, Y = jnp.meshgrid(x, y)\n",
+    "cx, cy = grid.Nx * grid.dx / 2, grid.Ny * grid.dy / 2\n",
+    "sigma = grid.Nx * grid.dx / 12\n",
+    "h0 = jnp.exp(-0.5 * (((X - cx) / sigma) ** 2 + ((Y - cy) / sigma) ** 2))\n",
+    "state0 = LinearSW2DState(h=h0, u=jnp.zeros_like(h0), v=jnp.zeros_like(h0))\n",
+    "\n",
+    "cycle = Cycle(step_op=op, n_steps=120, save_history=True, history_stride=20)\n",
+    "final_state, _ = cycle(state0, None)\n",
+    "print(\"steps recorded in history:\", len(cycle.history))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "676a148b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:52:18.637344Z",
+     "iopub.status.busy": "2026-05-31T11:52:18.637084Z",
+     "iopub.status.idle": "2026-05-31T11:52:19.639909Z",
+     "shell.execute_reply": "2026-05-31T11:52:19.638747Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABLwAAAEtCAYAAAAC3Xl7AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAeoRJREFUeJzt3Xl4U2XePvD7JG3SltKWAt2k7MimgKBiFRwZKmXRkXEFEUERfiIdR3BFUVBfRVDBHUYRUQeUccMZUV6xbDogIosIIgIWQaUFgbaUpUvy/P7o2+Q5JznJSZo2J+n9ua5cpGc/oedO+uR8n0cRQggQERERERERERFFCUu4D4CIiIiIiIiIiCiU2OBFRERERERERERRhQ1eREREREREREQUVdjgRUREREREREREUYUNXkREREREREREFFXY4EVERERERERERFGFDV5ERERERERERBRV2OBFRERERERERERRhQ1eREREREREREQUVdjgRRHnm2++gc1mwy+//BLuQwm7GTNmQFEU/PHHHz6Xq6qqQnZ2Nl555ZUGOjKi8Lnjjjtw+eWXh/swTKFt27a44oor/C63YsUKJCYm4siRIw1wVET1b+jQoRg/fny4D8MUmAPUmDEL3JgF1BixwStKLVmyBM8991y4DwOvv/46unbtiri4OHTq1Akvvvhinbf50EMPYeTIkWjTpo1r2iuvvIJFixbVedvBWr9+Pfr164eEhARkZGTgzjvvRHl5ueH16+N1ksXGxmLKlCl44okncObMmZBum8wj3Nf9wYMH8eijj+LCCy9Es2bN0KJFC1x22WX44osvvC5fUlKCCRMmoGXLlmjSpAkGDBiALVu21OkYCgsLsWDBAjz44IOuab///jtmzJiBbdu21WnbwXI6nZg9ezbatWuHuLg49OjRA++8846hdRctWgRFUbw+ioqKQnaMgwcPRseOHTFz5syQbZPCI9w5oPXVV1+5fme9fTnz22+/4frrr0dKSgqSkpJw1VVX4eeff67TPv/73//i888/x/333++a9sMPP2DGjBnYv39/nbYdjPLyckyfPh2DBw9GamoqFEUJ+DNLfeSlFnMgupglC4qLi/H//t//w1lnnYW4uDi0bdsW48aN81iOWeAfPxMQBUFQVBo2bJho06ZNWI9h/vz5AoC45pprxKuvvipGjx4tAIinnnoq6G1u3bpVABDr169XTe/evbv405/+VMcjDv6Y4uLixHnnnSfmzZsnHnroIWG328XgwYMNrV+X12n69OkCgDhy5IjfZY8fPy5sNpt4/fXXDR0XRZ5wX/cvvviiiI+PFyNHjhQvvfSSeO6550Tv3r0FALFw4ULVsg6HQ1x88cWiSZMmYsaMGeKll14S3bp1E02bNhU//fRT0Mfw97//XZx99tmqaZs2bRIAxBtvvBH0duvigQceEADE+PHjxauvviqGDRsmAIh33nnH77pvvPGGACAee+wx8fbbb6sep0+f9rt+mzZtxLBhwwwd5yuvvCISEhJEWVmZoeXJnMKdAzKHwyF69eolmjRp4vW96sSJE6JTp04iLS1NzJo1S8yZM0dkZ2eLVq1aiT/++CPo/V511VVi0KBBqmnvvfeeACBWr14d9HaDVVhYKACI1q1bi8suuyzgPKprXjIHGiczZMGBAwdEdna2yM7OFo899ph4/fXXxeOPPy6uvPJK1XLMAmP4mYAocGzwilLhfpM7deqUaN68uUeojho1SjRp0kQcO3YsqO3eeeedonXr1sLpdKqmh7PBa8iQISIzM1OUlpa6pr322msCgPjf//1fn+vW9XUKpMFLCCGuuOIK0b9/f0PLUuQJ93W/Y8cOj9/FM2fOiC5duohWrVqppi9dulQAEO+9955r2uHDh0VKSooYOXJkUPuvrKwULVq0ENOmTVNND2eD16+//ipiY2PFpEmTXNOcTqfo37+/aNWqlaiurva5fu2H202bNgW1/0A+3BYXFwur1cpG8QgX7hyQzZs3TzRv3lz8/e9/9/peNWvWLAFAfPPNN65pu3btElarVUydOjWofRYXF4uYmBixYMEC1fRw/pF75swZcejQISFEcHlU17xkDjROZsiCIUOGiHbt2vlttGIWGMPPBESBY0ljBDpx4gTuuusutG3bFna7HWlpabj88stdt7ZfdtllWL58OX755RfXba5t27Z1rV9RUYHp06ejY8eOsNvtyM7Oxn333YeKigrVfhRFQX5+PhYvXozOnTsjLi4Offr0wbp16/we4+rVq3H06FHccccdqumTJk3CyZMnsXz58qDOfdmyZfjzn/8MRVFc09q2bYudO3di7dq1rvO97LLLgtp+oMrKyrBy5UrcdNNNSEpKck2/+eabkZiYiH/9618+1w/V61RSUoKxY8ciJSUFycnJuOWWW3Dq1CmP5S6//HJ89dVXOHbsmKHtknlEwnXfvXt3tGjRQjXNbrdj6NCh+PXXX3HixAnX9Pfffx/p6em4+uqrXdNatmyJ66+/Hh9//LHHcRnx1Vdf4Y8//kBubq5r2po1a3DBBRcAAG655RbXa9NQJdAff/wxqqqqVNe4oiiYOHEifv31V2zYsMHwtk6cOAGHwxHUcXz11Ve48MILERcXh/bt2+Ott97yWCYtLQ09evTAxx9/HNQ+qP5FQg7UOnbsGKZNm4bHHnsMKSkpXpd5//33ccEFF7iuUQDo0qULBg4c6Pf9U8/y5ctRXV2tyoFFixbhuuuuAwAMGDDA9dqsWbMmqH0Eym63IyMjI+j1Q5WXzIHoEQlZ8OOPP+Kzzz7Dvffei+bNm+PMmTOoqqryuiyzIHD8TEBkTEy4D4ACd/vtt+P9999Hfn4+unXrhqNHj+Krr77Crl270Lt3bzz00EMoLS3Fr7/+irlz5wIAEhMTAdT0JfOXv/wFX331FSZMmICuXbvi+++/x9y5c/HTTz9h2bJlqn2tXbsWS5cuxZ133gm73Y5XXnkFgwcPxjfffINzzjlH9xi3bt0KADj//PNV0/v06QOLxYKtW7fipptuCui8f/vtNxw4cAC9e/dWTX/uuefwt7/9DYmJiXjooYcAAOnp6T63dfz4cUNvEgkJCUhISNCd//3336O6utrjPG02G3r16uV6HfSE6nW6/vrr0a5dO8ycORNbtmzBggULkJaWhlmzZnlsVwiB9evXG+q0kswjEq57PUVFRR7X0tatW9G7d29YLOrvXS688EK8+uqr+Omnn3DuuecGtJ/169dDURScd955rmldu3bFY489hkceeQQTJkxA//79AQAXX3yx7naqqqpQWlpqaJ+pqake5yDbunUrmjRpgq5du6qmX3jhha75/fr187ufAQMGoLy8HDabDXl5eXj22WfRqVMnQ8e4d+9eXHvttRg3bhzGjBmDhQsXYuzYsejTpw+6d++uWrZPnz4evw9kHpGUAw8//DAyMjLw//7f/8Pjjz/uMd/pdGL79u249dZbPeZdeOGF+Pzzz3HixAk0bdo0oNdo/fr1aN68uaqfz0svvRR33nknXnjhBTz44IOu61F7XcoqKipUjfS+aBv6Qy0UeckciC6RkAW1/Xemp6dj4MCBWLVqFaxWKy6//HLMmzfP1QDHLAgcPxMQBSDct5hR4JKTk1XlMd7o3cb89ttvC4vFIr788kvV9Np+pP773/+6pgEQAMS3337rmvbLL7+IuLg48de//tXn/idNmiSsVqvXeS1bthQjRozwub43X3zxhQAg/vOf/3jMC7SksU2bNq7z8/WYPn26z+3U3ha9bt06j3nXXXedyMjI8Ll+XV+n2pLGW2+9VTX9r3/9q2jevLnH8r///rsAIGbNmuVzu2Q+kXDde7Nnzx4RFxcnRo8erZrepEkTj99bIYRYvny5ACBWrFgR8L5uuukmr7/3gZYNrF692lA+ABCFhYU+tzVs2DDRvn17j+knT54UAMQDDzzgc/2lS5eKsWPHijfffFN89NFHYtq0aSIhIUG0aNFCHDhwwO+51GadnFGHDx8Wdrtd3H333R7LP/nkkwKAKC4u9rttaniRkgPfffedsFqtrrJ+b+X3R44ccfVFo/Xyyy8LAOLHH3/0uy+tfv36iT59+nhMD7SMqbZ0yMgjEMGUMdU1L5kD0ScSsuDOO+8UAETz5s3F4MGDxdKlS8XTTz8tEhMTRYcOHcTJkyeFEMyCQMub+ZmAKDC8wysCpaSkYOPGjfj999+RlZUV0Lrvvfceunbtii5duqhGS/rzn/8MoKbETr7zIScnB3369HH93Lp1a1x11VX4z3/+A4fDAavV6nU/p0+fhs1m8zovLi4Op0+fDui4AeDo0aMAgGbNmgW8rtbixYsNHUP79u19zq/dht1u95hn5DxD9Trdfvvtqp/79++Pjz76CGVlZapSy9rXzttIWWRukXDda506dQrXXXcd4uPj8dRTT6nmnT59Wve6qZ0fqKNHj4YkH3r27ImVK1caWtZfaUJdz/P666/H9ddf7/p5+PDhyMvLw6WXXoonnngC8+fP93uM3bp1c93ZBtSUQnXu3Nnr6FdyRqSlpfndNjWsSMmBO++8E0OGDMGgQYN0l/H3/ikvE4ijR4/irLPOCng9rby8PMM5UN9CkZfMgegSCVlQO1p5RkYGli9f7rpDsVWrVhg5ciSWLFmC2267jVkQAH4mIAocG7wi0OzZszFmzBhkZ2ejT58+GDp0KG6++Wa/jTMAsGfPHuzatQstW7b0Ov/w4cOqn73dHnv22Wfj1KlTOHLkiO4fe/Hx8aisrPQ678yZM4iPj/d7rHqEEEGvW+uSSy6p8zYAuM7DW/8ZRs4zVK9T69atVT/XvkEdP35c1eBV+9rJfaBRZIiE617mcDgwYsQI/PDDD/jss888PpDHx8frXje184MRinxo1qyZqs+PuqiP8+zXrx/69u3rKhfxR5sPQM05Hj9+3GM6M8LcIiEHli5divXr12PHjh0+j8ff+6e8TKBCkQOZmZnIzMys83ZCIRQ5whyILpGQBbW/l9dff72qHPe6667D6NGjsX79etx2223MgjriZwIi39jgFYGuv/561x08n3/+OZ5++mnMmjULH374IYYMGeJzXafTiXPPPRdz5szxOj87Ozskx5iZmQmHw4HDhw+rvhGorKzE0aNHA/42CgCaN28OAF4DOVBHjhwx1IdXYmKiq88Db2rfAA8dOuQx79ChQ37PM1Svk963a9o3+trXrqH6GKDQiYTrXjZ+/Hh88sknWLx4setbY1lmZqbudQMg6IwIRT5UVlYaHtihZcuWPu90yczMxOrVqyGEUH1grMt5AjX/Z7t37za0rNF8AJgRZhcJOXDvvffiuuuug81mw/79+wHUDKwCAAcPHkRlZSWysrKQmpoKu91u2hw4ffq04b78QtUJtZ5Q5CVzILpEQhbU/l5q+9W1Wq2q65RZUHf8TECkjw1eESozMxN33HEH7rjjDhw+fBi9e/fGE0884XqT02uJ79ChA7777jsMHDjQUGv9nj17PKb99NNPSEhI0P1mCAB69eoFAPj2228xdOhQ1/Rvv/0WTqfTNT8QXbp0AQAUFhZ6zAv0m4cLLrgAv/zyi9/lpk+fjhkzZujOP+eccxATE4Nvv/1WdYtxZWUltm3bpprmTX28Tr7Uvna+Ouck8zL7dV/r3nvvxRtvvIHnnnsOI0eO9LpMr1698OWXX8LpdKq++d24cSMSEhJw9tln+92PVpcuXbB48WKUlpYiOTnZNT3QfFi/fj0GDBhgaNnCwkLVyFdavXr1woIFC7Br1y5069bNNX3jxo2u+cH4+eefDf1fBKqwsBAtWrSol21TaJg9Bw4ePIglS5ZgyZIlHvN69+6Nnj17Ytu2bbBYLDj33HPx7bffeiy3ceNGtG/fPuBOqoGaHPjggw88pgeaA0uXLsUtt9xiaNlQ3EXiS33kpS/Mgchg9iyoLYP87bffVNMrKyvxxx9/uNZlFtQdPxMQ6WODV4RxOBwoLy9X/TGXlpaGrKws1a3ATZo08fptxPXXX49PP/0Ur732GiZMmKCad/r0aTidTjRp0sQ1bcOGDdiyZYtrZMSDBw/i448/xuDBg33e1fDnP/8ZqampmDdvnqohZ968eUhISMCwYcMCPvezzjoL2dnZXt8QmzRp4voG2YhQ9eGVnJyM3Nxc/POf/8TDDz/sekN+++23UV5e7hr6GKjpz+jAgQNo0aKF65uS+nidfNm8eTMURUFOTk5It0v1K1KuewB4+umn8cwzz+DBBx/E3//+d93lrr32Wrz//vv48MMPce211wKo6SPivffew5VXXum1Lw9/cnJyIITA5s2bVXeV1Z6b0YwIZR9eV111FSZPnoxXXnkFL730EoCaD8Tz58/HWWedpeon5dChQygtLUWHDh0QGxsLoOZuVO0HzU8//RSbN2/GnXfeaegYA7F582bmg0lFSg589NFHHtPeffddLF26FG+99RZatWrlmn7ttdfigQcewLfffusarXj37t1YtWoV7rnnHn8viVc5OTlYsGABfv75Z9V7eKA5EK5+e7zlQH3kpS/MAXOLlCy47LLLkJaWhsWLF+PBBx909ce1aNEiOBwOXH755a5lmQWe+JmAKEQavJt8qpPjx4+LJk2aiDFjxog5c+aIV199VVx//fUCgHj22Wddy82ePVsAEJMnTxZLliwR//73v4UQQjgcDjF06FChKIoYMWKEePHFF8Vzzz0nbr/9dpGamio2bdrk2gYAcc4554gWLVqIxx57TMyaNUu0adNGxMXFie+++87vsdaOrHLttdeK1157Tdx8880CgHjiiSeCPv/8/Hxx1llnCafTqZp+xx13CEVRxOOPPy7eeecdUVBQEPQ+ArV582Zht9vFeeedJ+bNmyceeughERcXJwYNGqRarnbkN+3Ij3V5nbyNfCWEe0QZ7QhyV1xxhejXr19Q50nhEynX/YcffigAiE6dOom3337b41FUVORatrq6Wlx00UUiMTFRPProo+Lll18W3bt3F02bNg1qNCYhhKioqBDNmzcXU6dOVU2vrKwUKSkponPnzmLBggXinXfeET///HNQ+wjGvffeKwCICRMmiNdee00MGzZMABCLFy9WLTdmzBiP67Zjx47iuuuuE7NmzRLz588XEyZMEDExMSI7O1v1eupp06aNGDZsmMf0P/3pTx4j2xYXFwur1SoWLFgQ1HlS/YqUHPBG772qrKxMdOjQQaSlpYnZs2eLuXPniuzsbJGVlSUOHz4c1OtUVFQkYmJixD/+8Q/V9EOHDgmr1SouuugisWjRIvHOO+806MhjL774onj88cfFxIkTBQBx9dVXi8cff1w8/vjjoqSkxLWctxyoa14yB6JLJGXBm2++KQCICy64QLzwwgvinnvuEbGxsaJ///6iurratRyzwFgW8DMBUeDY4BVhKioqxL333it69uwpmjZtKpo0aSJ69uwpXnnlFdVy5eXl4sYbbxQpKSkCgGpY4srKSjFr1izRvXt3YbfbRbNmzUSfPn3Eo48+KkpLS13LARCTJk0S//znP0WnTp1cjTpGh/EVQohXX31VdO7cWdhsNtGhQwcxd+5cj8aqQGzZskUA8BhKuaioSAwbNkw0bdpUAPAI7fr25ZdfiosvvljExcWJli1bikmTJomysjLVMnoNXkIE/zoF0uBVUlIibDYb37giUKRc97W/j3oP7TaOHTsmxo0bJ5o3by4SEhLEn/70J9UH7WDceeedomPHjh7TP/74Y9GtWzcRExMT8DDgdeVwOMSTTz4p2rRpI2w2m+jevbv45z//6bGctw+3Dz30kOjVq5dITk4WsbGxonXr1mLixImGPtgKEdiH23nz5omEhASP7CJziJQc8EbvvUoIIQ4ePCiuvfZakZSUJBITE8UVV1wh9uzZE9R+av3lL38RAwcO9Jj+2muvifbt2wur1eo1k+pTmzZtdLNRvua95YAQdctL5kB0ibQseOedd0TPnj2F3W4X6enpIj8/3+vvF7PAfxbwMwFR4BQhwlRsTKanKAomTZrkKsMxi4EDByIrKwtvv/12uA8lojz33HOYPXs29u3bV6dRMim6mfW6N+rnn39Gly5d8Nlnn2HgwIHhPpyIct555+Gyyy7D3Llzw30oFGaRngNffvklLrvsMvz4449eR5gjfcwBkjELGi9mAUULi/9FiMzlySefxNKlSw11Ok81qqqqMGfOHEybNo2NXRTV2rdvj3HjxuGpp54K96FElBUrVmDPnj2YOnVquA+FqM769++PQYMGYfbs2eE+lIjCHKBowywIDrMgeq1btw5XXnklsrKyoCgKli1b5nedNWvWoHfv3rDb7ejYsSMWLVpU78cZSuy0niJO3759UVlZGe7DiCixsbE4cOBAuA+DqEHMmzcv3IcQcQYPHozy8vJwHwZRyHz22WfhPoSIwxygaMQsCByzIHqdPHkSPXv2xK233oqrr77a7/KFhYUYNmwYbr/9dixevBgFBQW47bbbkJmZiby8vAY44rpjgxcRERERERERURQbMmQIhgwZYnj5+fPno127dnj22WcBAF27dsVXX32FuXPnssGLIh+7dyNqfHjdExFzgIgAZgFROJw5c8ZwNZMQAoqiqKbZ7XbY7faQHMuGDRuQm5urmpaXl4e77rorJNtvCGzwIiIiIiIiIiIKozNnzqB5fCJOwWFo+cTERI/y0+nTp2PGjBkhOZ6ioiKkp6erpqWnp6OsrAynT5+OiL6h2eBFRERERERERBRGlZWVOAUHbsZZsPkZX7ASTrxV/hsOHjyIpKQk1/RQ3d0VLdjgZYDT6cTvv/+Opk2betwySER1I4TAiRMnkJWVBYvF3APHMguI6g+zgIgAZgERRVYO1Id4xQqb4vu8rUIBBJCUlKRq8AqljIwMFBcXq6YVFxcjKSkpIu7uAtjgZcjvv/+O7OzscB8GUVQ7ePAgWrVqFe7D8IlZQFT/mAVEBDALiCgycqA+xFoU2Pw0oguhwGDlY9BycnLw6aefqqatXLkSOTk59bvjEAprg9fMmTPx4Ycf4scff0R8fDwuvvhizJo1C507d3Ytc+bMGdx999149913UVFRgby8PLzyyiuqWtIDBw5g4sSJWL16NRITEzFmzBjMnDkTMTHu01uzZg2mTJmCnTt3Ijs7G9OmTcPYsWMNHWfTpk0BAHv37HE9J6LQmP3003j22WfRtWtXU+cAwCwgqk/MAiICmAVEBJw4cQIdO3VqtNeVVal5+FwmiO2Wl5dj7969rp8LCwuxbds2pKamonXr1pg6dSp+++03vPXWWwCA22+/HS+99BLuu+8+3HrrrVi1ahX+9a9/Yfny5UHsPTzC2uC1du1aTJo0CRdccAGqq6vx4IMPYtCgQfjhhx/QpEkTAMDkyZOxfPlyvPfee0hOTkZ+fj6uvvpq/Pe//wUAOBwODBs2DBkZGVi/fj0OHTqEm2++GbGxsXjyyScB1PxHDhs2DLfffjsWL16MgoIC3HbbbcjMzDQ0nGbtLcpNmzatt9sFiRqrLVu2AAC++OILxMXFmTYHAGYBUX1iFhARwCwgIrfGWipsVRRY/Zy7FYG/Nt9++y0GDBjg+nnKlCkAgDFjxmDRokU4dOgQDhw44Jrfrl07LF++HJMnT8bzzz+PVq1aYcGCBYYz0gwUYaLxZo8cOYK0tDSsXbsWl156KUpLS9GyZUssWbIE1157LQDgxx9/RNeuXbFhwwZcdNFF+Oyzz3DFFVfg999/d32rM3/+fNx///04cuQIbDYb7r//fixfvhw7duxw7WvEiBEoKSnBihUr/B5XWVkZkpOTUVxUxDczohArKytDekYGSktLkZSUZNocqD1WZgFR/WAWEBHALCAizxxoLGoz5V5bW9j99OFVIZx4unJ/o3uNAmWqHuBKS0sBAKmpqQCAzZs3o6qqCrm5ua5lunTpgtatW2PDhg0AgA0bNuDcc89V3cKcl5eHsrIy7Ny507WMvI3aZWq3oVVRUYGysjLVg4gahllyAGAWEIUTs4CIAGYBETU+tXd4+XuQf6Zp8HI6nbjrrrtwySWX4JxzzgEAFBUVwWazISUlRbVseno6ioqKXMvIb2a182vn+VqmrKwMp0+f9jiWmTNnIjk52fVgZ5REDcNMOQAwC4jChVlARACzgIgaJwU1DTW+HmzuMsY0DV6TJk3Cjh078O6774b7UDB16lSUlpa6HgcPHgz3IRE1CmbKAYBZQBQuzAIiApgFRNQ48Q6v0Alrp/W18vPz8cknn2DdunWqYUczMjJQWVmJkpIS1bc4xcXFyMjIcC3zzTffqLZXXFzsmlf7b+00eZmkpCTEx8d7HI/dbofdbg/JuRGRMffccw8+++wz0+QAwCwgCgdmAREBzAIiarxsFsDmp0HLaZqe2M0trHd4CSGQn5+Pjz76CKtWrUK7du1U8/v06YPY2FgUFBS4pu3evRsHDhxATk4OACAnJwfff/89Dh8+7Fpm5cqVSEpKQrdu3VzLyNuoXaZ2G0QUPrXjZnzyySfMAaJGjFlARACzgIjIqhh7kH9hvcNr0qRJWLJkCT7++GM0bdrUVVOfnJyM+Ph4JCcnY9y4cZgyZQpSU1ORlJSEv/3tb8jJycFFF10EABg0aBC6deuG0aNHY/bs2SgqKsK0adMwadIk1zcwt99+O1566SXcd999uPXWW7Fq1Sr861//wvLly8N27kRU44EHHgAALFiwgDlA1IgxC4gIYBYQERkpWbSyFy9DFFH7NUo4dq7zn/jGG29g7NixAIAzZ87g7rvvxjvvvIOKigrk5eXhlVdecd2ODAC//PILJk6ciDVr1qBJkyYYM2YMnnrqKcTEuNvz1qxZg8mTJ+OHH35Aq1at8PDDD7v24Q+HHCaqP/EJCV6nmy0HAGYBUX1iFhARwCwgopprKz0jA6WlpY3q2qrNlNlNOyBesfpc9rRw4L4T+xrdaxSosDZ4RQq+mRHVn0h6Q2MWENUfZgERAcwCIoqsHAil2kx5NqmjoQavu8v2NrrXKFCm6LSeiIiIiIiIiKixM9JHl+/mMKrFBi8iIiIiIiIiIhOwWRS/ozQ6BPvwMoINXkREREREREREJmCFgTu82DGVIWzwIiIiIiIiIiIyAYuBURotfuZTDTZ4ERERERERERGZgKE+vNjeZQgbvIiIiIiIiIiITMBq4A4vf/OpBhu8iIiIiIiIiIhMgHd4hQ4bvIiIiIiIiIiITIB3eIUOG7yIiIiIiIiIiEzAGmOB1WLxvYyTwzQawQYvIiIiIiIiIiITsFgVWCwcpTEU2OBFRERERERERGQGVgsUP3d4QeEdXkawwYuIiIiIiIiIyAQUiwLFT6/0CniHlxFs8CIiIiIiIiIiMgGLVYHFT4OXhQ1ehrDBi4iIiIiIiIjIBBSL/5JGRbCk0Qg2eBERERERERERmYDVZoHV6meURgcbvIxggxcRERERERERkQkoVgWKnwYvBc4GOprIxgYvIiIiIiIiIiITYB9eocMGLyIiIiIiIiIiE1AUBYrFzyiNTjZ4GcEGLyIiIiIiIiIiE7BYLbD4KWm0CN/zqQYbvIiIiIiIiIiITKCmDy8/d3gJ3uFlBBu8iIiIiIiIiIhMgA1eocMGLyIiIiIiIiIiE7DYrLDGWH0vYxENdDSRjQ1eREREREREREQmYFEUWPx0Wm9ReIeXEWzwIiIiIiIiIiIyAcVqgeKn03rFyU7rjWCDFxERERERERGRCVisCix++vCyOHmHlxFs8CIiIiIiIiIiMgFDndazwcsQNngREREREREREZkASxpDhw1eREREREREREQmYI1VYI313aBlBe/wMoINXkREREREREREJmCxWGDxc4eXxcE7vIxggxcRERERERERkQkY6sPLz3yqwQYvIiIiIiIiIiITMNSHl5/5VIMNXkRERERERBS5hLP+tq2wYYEalmKxQLH4afDyM59qsMGLiIiIiIiIiMgELFYDfXjxDi9D2OBFRERERERERGQGBkoawQYvQ9jgRUREREREROZQn+WJwQjmeFgGSXVgiYmBJdZ3U43FKRroaCIbG7yIiIiIiIiIiEygptN6q59lHA10NJGNTc9ERERERERERCZQO0qjv0cwXn75ZbRt2xZxcXHo27cvvvnmG91lFy1aBEVRVI+4uLhgTysseIcXRba63vLM242JIl8oSh+YBUTmZbbyJuYFUd0FcV0rwWSB0XWCuK6Fr3X09sv8IAMsFgssfkZh9Dffm6VLl2LKlCmYP38++vbti+eeew55eXnYvXs30tLSvK6TlJSE3bt3u35WFCXg/YYTrzgiIiIiIiIiIhOorzu85syZg/Hjx+OWW25Bt27dMH/+fCQkJGDhwoX6x6IoyMjIcD3S09PrcmoNjg1eREREREREREQmEEiDV1lZmepRUVHhdZuVlZXYvHkzcnNzXdMsFgtyc3OxYcMG3WMpLy9HmzZtkJ2djauuugo7d+4M7cnWM5Y0knmEo2SBo64QmUu4SpeYBUThZ/A6DKqsqY5UpUu+9s9cINKnc+0YvqZ9LSfqOGKd8NEBuE4Jl9HCLp/5wcwgLwyN0uio+V3Kzs5WTZ8+fTpmzJjhsfwff/wBh8PhcYdWeno6fvzxR6/76Ny5MxYuXIgePXqgtLQUzzzzDC6++GLs3LkTrVq1CuCMwiesV9i6detw5ZVXIisrC4qiYNmyZar5Y8eO9egkbfDgwapljh07hlGjRiEpKQkpKSkYN24cysvLVcts374d/fv3R1xcHLKzszF79uz6PjUiCtANN9zALCAiZgFRI1d7p0Hnzp2ZA0TUKAVyh9fBgwdRWlrqekydOjVkx5GTk4Obb74ZvXr1wp/+9Cd8+OGHaNmyJf7xj3+EbB/1LawNXidPnkTPnj3x8ssv6y4zePBgHDp0yPV45513VPNHjRqFnTt3YuXKlfjkk0+wbt06TJgwwTW/rKwMgwYNQps2bbB582Y8/fTTmDFjBl599dV6Oy8iCtw555zDLCAiZgFRI3fq1CkAwDPPPKO7DHOAiKKZxWox9ABqOpWXH3a73es2W7RoAavViuLiYtX04uJiZGRkGDqu2NhYnHfeedi7d2/dTrABhbWkcciQIRgyZIjPZex2u+5/wK5du7BixQps2rQJ559/PgDgxRdfxNChQ/HMM88gKysLixcvRmVlJRYuXAibzYbu3btj27ZtmDNnjuqNj4jC6+GHH0ZSUpLufGYBUePALCBq3AYOHAgAuPLKK3WXYQ4QUTRTLAoUP6MwKpbARku02Wzo06cPCgoKMHz4cACA0+lEQUEB8vPzDW3D4XDg+++/x9ChQwPadziZvmh4zZo1SEtLQ+fOnTFx4kQcPXrUNW/Dhg1ISUlxvZkBQG5uLiwWCzZu3Oha5tJLL4XNZnMtUzv05vHjx73us6KiwqPzNwoR4dR/SBThDPzhrDb2CGLbwZwDhRazIMoYvIYiMguoXjELIlwIPgf43Ib8cDr8Pwxui7lgLuHIAYBZYEgQ13idr2Onw/h7fxCPumaJbl74er2oUauvURqnTJmC1157DW+++SZ27dqFiRMn4uTJk7jlllsAADfffLOqJPKxxx7D559/jp9//hlbtmzBTTfdhF9++QW33XZbyM61vpm6wWvw4MF46623UFBQgFmzZmHt2rUYMmQIHI6aTgWLioqQlpamWicmJgapqakoKipyLeOtY7baed7MnDkTycnJroe2IzgialjMAiICmAVEFL4cAJgFRNQw6qvB64YbbsAzzzyDRx55BL169cK2bduwYsUKV/4dOHAAhw4dci1//PhxjB8/Hl27dsXQoUNRVlaG9evXo1u3biE71/pm6lEaR4wY4Xp+7rnnokePHujQoQPWrFnjut25PkydOhVTpkxx/VxWVsY3NKIwYhYQEcAsIKLw5QDALCCihqEoFv8ljUGO8Jmfn69bwrhmzRrVz3PnzsXcuXOD2o9ZmLrBS6t9+/Zo0aIF9u7di4EDByIjIwOHDx9WLVNdXY1jx4656vozMjK8dsxWO88bu92u29kbBUHntlyfQxDrzTM65LC8vjYM9IYd1hlyGNAfdlh4bNvHfilkmAURqrFkgfaYmQX1hllgYgZLclTXfzDXu4/9+MyW2tV9XZ+q61rKC01GKDo54zMX9PZDAWuoHACYBbqCuQ5V177QneczI4xsOxiaa1LRm6d3vXtsQzofH7vVzQxmRKNjscXCaov1vYyDpa9GRNTV8+uvv+Lo0aPIzMwEUDNMZklJCTZv3uxaZtWqVXA6nejbt69rmXXr1qGqqsq1zMqVK9G5c2c0a9asYU+AiEKCWUBEALOAiJgDRBR96quksTEK66tUXl6Obdu2Ydu2bQCAwsJCbNu2DQcOHEB5eTnuvfdefP3119i/fz8KCgpw1VVXoWPHjsjLywMAdO3aFYMHD8b48ePxzTff4L///S/y8/MxYsQIZGVlAQBuvPFG2Gw2jBs3Djt37sTSpUvx/PPPq25HJqLw2759O7OAiJgFRI3cyZMnAdRkAcAcIKLGR7FYDD3IP0UIo3UhobdmzRoMGDDAY/qYMWMwb948DB8+HFu3bkVJSQmysrIwaNAgPP7446pOJo8dO4b8/Hz85z//gcViwTXXXIMXXngBiYmJrmW2b9+OSZMmYdOmTWjRogX+9re/4f777zd8nGVlZUhOTkZxUZHPodIbtbreygyob2fWu5U5gP0a4uMWYaFzy7KqlMHo+gb32RiVlZUhXad8gFkQgRqqrMHgPg3TuS59ligwC0KKWRAF6lq2bPRzgJEySH/zXBs3WNJotHSJuVBnn332Ga6+5hqP6WbLAaCRZ4HR613vOnS6y4QNX+OOav19+fosESht1wZ61781xusyPtexWH3s10fO6CwXrWo/E5SWljaqa6s2U36d/wCS4n2XT5edrkCr259qdK9RoMLa4BUpGvWbmVFs8PK9vsF9NkaR9IbGLDCADV7+t2FgncaIWRAF2ODFXAgBZkGEYIMXG7zqUSTlQCjVZspvr05FUkKc72VPncFZE2Y2utcoUBHVaT0RERERERERUbQyUrLIkkZj2OBFwTN6J4eBb299ruOUvs1x+lgnCOpvXDQjsli8f2ujvvNL8w2S9I2Q/N0QR3CjqBbMt7zB3MmhkwV1zQFAPwtUOVAzwfs6chZoR3DT2w9HYKJIV9fPAZp5it71rt2PfP071Xd8qLdt4C4PH6OyCvn6l3NBe71Ky4U0FwBmA5mLkff7YCo4tNexdCeXejn16MqKXk4YvQtUtTGdyg7tz3IuSPsX2s8L0t1f8mcJj8MxMJojR4VvfJQYG5QYm59lOEqjEWzwIiIiIiIiIiIyA4vF42YMr8tEuLKysoDXCbR8kw1eREREREREREQmoFitUKw++nv7v2UiXUpKChQfd1prKYqCn376Ce3btze8Dhu8iIiIiIiIiIjMwGL1PcBB7TJR4P3330dqaqrf5YQQGDp0aMDbZ4MXBaaOffXo1toDqjp4RR6FRa7X1/b75Wt7evTq8D365JDq8nXq8LXrqOv3WYdPUayO/XjoXruafjyMZIFHHz6hzAKLettGssCjHw8jWcB+eyhShLr/TlXffAY+B2jX8ZUfBrLA4z1Zun4Vpcq9nKo/L/UfGcIqXeNyXz2qLNBe0/yMQJEtqH76jFzvgHoER511POY5dD4jGPxMoDs6OwDId9KoskB67uO89TIC8JUT3jPC41gpOlksBhq8Iv/3oE2bNrj00kvRvHlzQ8u3b98esbGxAe2DDV5ERERERERERCbQWEZpLCwsDGj5HTt2BLwPNngREREREREREZmBYqCkUYmOksb6xgYvClpQpUuqW4+1pUtV0vNKr+so1VVQ8VXWpEOoyhWkMqQYze2RqmGH3cPCyrcly0MOA5qyBAPljQBvS6bIZ7SswUgWyDlQ87OBLPBVIuWDoSzQlicayAKPazyYUmeiCGC0OwOf79XVlV7nqbJAzgGoy59Uy/k6HrksUvojQtFee3IWWKUskN/vrZqh4uXSJYt0rnK1k0epM0uXKAIY7SLAxzqGyhh9vPcr1fLnAIfuckL+XCAtJzTrCKn0UdXpt0XnOQBF/lwgX//ycjHqXBDScqr3e6jp/u1gtDGDZc9RSYmJVf/eeV3G2OfdSLJp0yasXr0ahw8fhtOpzpI5c+YEtU02eBERERERERERmUEj6rS+1pNPPolp06ahc+fOSE9PV43eGMhIjlps8CIiIiIiIiIiMoNG0mm97Pnnn8fChQsxduzYkG6XDV7km/a25DqWLqluS9bevlx9xv28qsL9XL5dufKMah1R4f7ZWa0uedCjSLccK/Y413OLLU61nHwrMmLlEaGk5TSvj5DvRJan65Q0eSynmhFdIUYRLogs8ChdMpAFcg4AxrJAzoGa3YQuC4S2dMlAFgjNO2tQpc6qDTALKMyMljUZKWOs1pYneu/OQKmSPhNUV6jWEVIuOCtOS9tWf64Q2m4QvPAoGZF+VuzxrueWWLt7u9oyklgpC6zu10C+jhVNLuiOzObrS2yWLlFDCGYkVnlURaOjsPt676/2ngui4pR609L7v6j2X97ok1zqrMkFvc8Lij3BvZCvURrlbWl2q5onl1TLL6O28lpeX2/EZ2ZERFOsVnXJrc4y0cRiseCSSy4J/XZDvkUiIiIiIiIiIgqcxWLsEUUmT56Ml19+OeTb5R1eRERERERERERm0Aj78LrnnnswbNgwdOjQAd26dUNsrPpOyw8//DCo7bLBizwFUbpgtHRJLkvwuH250l2WIE6fcD13nHQ/d54+qT4EucRRvpVZGtVB0bZ+y7clS6VLlvgmqsUsTZpK89zPhXyLslCXQaqOzVB5I/TLF7T/D7w1mRpaXbNAkwtGskDOAcBYFmhLnUOZBXIO1MyrpyxgGRNFCN8jNPsvY/QYiVWvO4NK9zWufe93nnJngfCVBaqR2nSyQDsam5QFipwFCfJnAvXnBVUpU6z33PQYmU1vBEehDgOO5krhZHQkVtVy2vd+A2WM8rVf87P7s4Cv93txxl3iKKTyZl8ljUaywKOkUSpvVqrdZYxKlTvbPHMhHt74HKVRusYVKReE0F77HPE52ilWA6M0Wn3PjzR33nknVq9ejQEDBqB58+Z16qhexgYvIiIiIiIiIiITUCxWKH7u4PI3P9K8+eab+OCDDzBs2LCQbpcNXkREREREREREZtAIR2lMTU1Fhw4dQr7d6HqViIiIiIiIiIgiVSPstH7GjBmYPn06Tp065X/hAPAOL/LJd+2+j348jNTrV2j65DhR4n5eLj0/cdzrMgBQfcpdr+84ox7qXI81zt1vT0yCu75eNE1RLSf3E2Cpcp+DRbOcah25dl7vucdr6q5PZh0+mVVQWeDQ9O1nIAu017iRLJBzAAhtFmj7CzGSBR7XrpEsYL89ZDZ6ffjp9OED6PfjI/fnpTjU16eq754zUj99J8tczx2aXBCnyqTlpH7+Tqs/JDur3PsVDqnPG6v7mrLEqj8KW+Pd/fPIffiJCrnPUE0/ZE2896ejvvbV17hwSn31SMv56qtHNz+YEVRXRvvs1FvH13u/1IeWfP0r0nUk99kFqPvt0uuzDwDEGe/9e8nXqzDYh5dcHqbY1f1yKpVyf2PSOWj77ZKorkq9zwHQvMfLr52vvx0UA6Vs7As4oilWKxSrn5JGP/MjzQsvvIB9+/YhPT0dbdu29ei0fsuWLUFtlw1eRERERERERERm0AhHaRw+fHi9bJcNXkREREREREREZtAIG7ymT59eL9tlgxfVMHors+EhiHVKlyqlYYY1JQqO0qPueSWHXc8rj7qnVxw/oVqnoqTc9bxaKmMSDun2ac3tnjFSGZM9JdH9vJn6NmmbfGu0Q307dC2L5vZgReeWZWHxXroAaMoXfI2+yvIFagghzAI5BwBjWSDnAGAsC+QcAEKbBTbtEOgGskB7jRvJAo8yJr0sYIkChYFHSXMt7XTV9e89C5Qq9TWlVEqlS3IZo/yZoEydC1XH3eXNlSfc61eWqUsaHaos8F7SKJc2A4AtyV3SaGvqzpbYZtJxa0qk5GSxWHTKGH3lgo9yJ7l0Sf5/YKkzhYXee7/0XJsXqpLmaqkcUCpvdGpKFVVljFIuyNMBdYmj3L2BXM7sqFR/FtFjtbnLpyyx6hJLudsDuRTTImWBr09PFqtUmqUpb4Ylxus8IdzTta+p4b8dKGIp1lgoMbF+lyH/+G5JRERERERERGQGilLzBYjPR+S3dqampuKPP/4wvHzr1q3xyy+/BLQPQ3d4lZWV+V9IIykpKeB1iIiIiIiIiIgardpGLX/LRLiSkhJ89tlnSE5ONrT80aNH4dCpttBjqMErJSUFSgAtiIqi4KeffkL79u0DOhgyB71blD1+lm9fdmhLGqVblqURmMRpaQQmafQ1QF26dOZQsev5qcPu0oXTR46r1jl91F1uUFnuvsVYr3QBAGyJ7ts/45u7y5jiT6rLLBIq3eckj9Uil0UpmtEjFPm2ZNVz9zrCornsdEZq015xLF+ghlbXLPA1GpteFsg5ABjLAjkHgNBmgZwDgLEsULTXuJEs4OitFG51LWfWbkMu+1ONzCaNygh1KZM8GqNcxiiXMwPqLDhz1P2lbGWZuizKccadBU4pCyyqkkb1+7gtyT3qWlxz95e3CdLIbuoiSKj7UZFKUOQyJmH1kQs+ysEMlS6x1JlCKJj3ftXogpqSX1W3J9I8UeEuQdaOiCx0RmmUy54BoOqEexvVZ9zZIpczOzTv47rlzTb3NakdvVUukYzVnl/tOpr+lISUBfK5QvsZQX595Hl6IzYChv524OeFyCYUi9//w2j5Px4zZky9bt9wH17vv/8+UlNT/S4nhMDQoUPrdFBERERERERERI1OI7nDy+k0+GVbHRhq8GrTpg0uvfRSNG/e3NBG27dvj9hYdqJGRERERERERGSYovjvoysK+vBqCIYavAoLCwPa6I4dO4I6GCIiIiIiIiKixkpYYzxL4b0sQ/7xVaKAqOr6dWrytfPkfnwcJ6U6/BPq/rjkPjrk/jlOHHT34VP+u3o44lNH3cMGV5RJtfuV7uO02tS3e9qT7O51St3rVJ9R9zcks0h1/XabuxcfxRanWs4a5+77Qzjd+1G9Pk5Nf2fy0ORQ1/8TmZWhLND+rhvIAl999ehlgZwDQPizQM4BwFgWKJrb0pkFFG4++/HRmy6VJiiqzwHu56JK04eX1D+POOXun6fquPval3MAAE4VuXPi9B/u9c8cV/cDVHlS7s9P6nvM6v5W3NZEXZEQ18x9fM6qKnijWDT9AUrXv9Mu5YI93v08xq5aB1bpNXFKx2DxUd4h9/UlT46CshaKQDp9zyna936dvwmcFe7rVZw5pVpHnHH34SX35yX32QWo++2T37tVfXhVGezDK1a/Dy95HZlN7pczRp0lItYmzXM/t2j+doB8/av685K2bbSPRYoejaSksSEE1eC1adMmrF69GocPH/aou5wzZ05IDoyIiIiIiIiIqFFhg1fIBNzg9eSTT2LatGno3Lkz0tPTVaM3BjKSIxERERERERERSdjgFTIBN3g9//zzWLhwIcaOHVsPh0OmIw0/7sGpX+6gVEtlBNJQw/Lw405p+HEAqDjuLks4fcRdviCXLpX8oh6O+MRR963NpVXuY6h0uo/bZlE3xCZLJQ+V5d7LFQAgJs59+3FsE/ftx7GJ7uNWEpLkVWCRzlWJca8jYuTyL81tyXLlkvx6s/2YzCSILJBzADCWBXIOAMayQM4BILRZIOcAYCwLLJrh1Q1lgbaCkVlAZuWj1FFVyiRngcN9fTkr1CXIcrmSUyp1rjzhnn7mqPq9Xy5jPHGo3L2cpqSxosxd1qRXxqQtaaw6oy5/qmWRBmOScwAAYhLdx6PIXRskuM/VYotXrSN0SsCE0Hw0l19jhaXOFCJGS+Q07/2KkfJm7TIOdym/kP8+qJauT20uSO+j1afc86rPqEui5TLGSqnc0SEtpy1H1MsCh1zeGKcpQZbI68ilj7F2dS7I5yTiEtzPNZ+NECN1dWA1UEoO9f+DEFKjh6/PC6osYUOJ2QlF8VuuLqLwZiOn04m9e/d6rSS89NJLg9pmwA1eFosFl1xySVA7IyIiIiIiIiIiHY3wDq+vv/4aN954I3755RcIbWO7osDhcOis6VvAr9LkyZPx8ssvB7UzIiIiIiIiIiLSoSjGHlHk9ttvx/nnn48dO3bg2LFjOH78uOtx7NixoLcb8B1e99xzD4YNG4YOHTqgW7duiI1V3wr+4YcfBn0w1MCCGfHD4Igs8nJCHoVF5xZlAKgocZclnD7qfi6PwKYtXfrttHu/chlTldQqHKsJg/JqdzvvWdL2bInq32V7svsY7Cnu53HNpRIFTemSfK5KvM7rIzSjuNTx/yHaWvepgQU78o+RLNBs20gWyDkAGMsCOQeA0GaBnAOAsSyQzxMwlgVBj8DELCCz0ssCH6XOjtPu67CyTH5+UrWOXLooPz9ZrP6McLLa/W2wXnlzk9PeSxgBIDZOKldq4j4G+dgAwJ7i/ln1uUA+V48RLeX96pdPEZmWqoxReJ+u/dmpV96oyQXpfdQpjbLo0IyirBqNUSpjrD4tlUs6jZU0akdflckjOMrHIz/XvveLOJ3z045sr1cO6us1pagnLDEQFt9NNf7mR5o9e/bg/fffR8eOHUO63YBfpTvvvBOrV6/GgAED0Lx5c3ZUT0REREREREQUCooF8NEI61omivTt2xd79+4Nf4PXm2++iQ8++ADDhg0L6YEQERERERERETVqjaQPr+3bt7ue/+1vf8Pdd9+NoqIinHvuuR6VhD169AhqHwE3eKWmpqJDhw5B7YwiRF1L7KAu23FKo7CgWr71WH1bsmqkFWnEtIoy9y3KcqmS9ufjVf5LF7QSpRHTEsvUI7/Ix1B9Rue4q9XnII84Y1GNulT31zQaQo0iTF3LnjWlzkayoFqTC0ayQJsLocwC7eiNRrJAaHIhpFnAHKBwkEprFL3yG81y6ulSNwfaEcqk8h690iXHGfU6lSflXHAvJ5cwAupscEiHZlX0R52NkbYt70c+Bu3nF/m49Uq2PD4nqUZZ0y9dCmo0NqK6qGv5nK/fYbmcT++5ZjlHpXTtVao/VzjkkkKHvB/3c2elettOaTmL1X3tWaRBmbUjO8r7kY9BPjahLVU0eK7qazyErz0/L0S2RtLg1atXLyiKonofvPXWW13Pa+fVpdP6gBu8ZsyYgenTp+ONN95AQkKC/xWIiIiIiIiIiMi/RtLgVVhYWO/7CLjB64UXXsC+ffuQnp6Otm3betxqtmXLlpAdHBERERERERFRYyEUBcJPg5aIgr7U27RpU+/7CLjBa/jw4fVwGEREREREREREjZzFWvPwt0wQXn75ZTz99NMoKipCz5498eKLL+LCCy/UXf69997Dww8/jP3796NTp06YNWsWhg4dGtS+wyHg++CmT5+u+3jkkUcC2ta6detw5ZVXIisrC4qiYNmyZar5Qgg88sgjyMzMRHx8PHJzc7Fnzx7VMseOHcOoUaOQlJSElJQUjBs3DuXl6mHkt2/fjv79+yMuLg7Z2dmYPXt2oKfdeAmn+lHnzTldD495Dof0cLoejkr3o9IpVI8q4X5o5+k99NaR9+OodKqOQT42vfPxdk5BvEAhe60jzQ033MAsMLMGygJ1DhjLAvmaDnUWqHPAWBaEBLOAWRDhFOF0PeB0uB8aqvdRj+ut5uHUPIRDSA/3ctpr3CHgehiZXukUmn2796Pev4+HXhbIr4GX14HcNmzYAADo3LkzcyDKGP08bfQ91ee1qJMfMsPXtc7D8DlID+3nHCKvaksa/T0CtHTpUkyZMgXTp0/Hli1b0LNnT+Tl5eHw4cNel1+/fj1GjhyJcePGYevWrRg+fDiGDx+OHTt21PUMG0zAr9LTTz/tdbrD4cCNN94Y0LZOnjyJnj174uWXX/Y6f/bs2XjhhRcwf/58bNy4EU2aNEFeXh7OnDnjWmbUqFHYuXMnVq5ciU8++QTr1q3DhAkTXPPLysowaNAgtGnTBps3b8bTTz+NGTNm4NVXXw3oWImofp1zzjnMAiJiFhA1cqdOnQIAPPPMM17nMweIKNoJxWLoEag5c+Zg/PjxuOWWW9CtWzfMnz8fCQkJWLhwodfln3/+eQwePBj33nsvunbtiscffxy9e/fGSy+9VNdTbDABlzQ+/fTTSE1Nxbhx41zTHA4HRowYEXBL35AhQzBkyBCv84QQeO655zBt2jRcddVVAIC33noL6enpWLZsGUaMGIFdu3ZhxYoV2LRpE84//3wAwIsvvoihQ4fimWeeQVZWFhYvXozKykosXLgQNpsN3bt3x7Zt2zBnzhzVGx8RhdfDDz+MpKQkj+nMAqLGhVlA1LgNHDgQAHDllVd6zGMOEFGjEECn9WVlZarJdrsddrvdY/HKykps3rwZU6dOdU2zWCzIzc113VmrtWHDBkyZMkU1LS8vz+POWzMLuFlw+fLluOeee/D+++8DAKqrq3Hddddh586dWL16dcgOrLCwEEVFRcjNzXVNS05ORt++fV3/IRs2bEBKSorrzQwAcnNzYbFYsHHjRtcyl156KWw291izeXl52L17N44fPx6y441adbxt0nNzFtfDY57VKj0srofV5n7YLIrqEau4H9p5eg+9deT9WG0W1THIx6Z3Pt7OKYgXKGSvdbRgFphEA2WBOgeMZYF8TYc6C9Q5YCwLQoJZ4IFZEFlU30DX9kXipb8R1fuox/VW87BoHopVkR7u5bTXuFWB62Fkus2iaPbt3o96/z4eelkgvwZB9rtCzIFIZ/TztNH3VJ/Xok5+yAxf1zoPw+cgPbSfc4i8qem03v8DALKzs5GcnOx6zJw50+s2//jjDzgcDqSnp6ump6eno6ioyOs6RUVFAS1fF+3bt8fRo0c9ppeUlKB9+/ZBbzfgO7wuuOACfPDBBxg+fDhsNhtef/117N27F6tXr/Z4Meqi9kX09QIXFRUhLS1NNT8mJgapqamqZdq1a+exjdp5zZo189h3RUUFKioqXD9rW02JqOEwC4gIYBYQUXhzAGAWEFHDEKLm4W8ZADh48KDqznhvd3dFgv3798PhpV+7iooK/Pbbb0FvN+AGLwD485//jLfeegvXXHMNunbtirVr16JFixZBH4TZzJw5E48++mi4D4OIwoxZQEQAs4CIajALiKghOISAw0+LV+38pKQkr11BaLVo0QJWqxXFxcWq6cXFxcjIyPC6TkZGRkDLB+Pf//636/n//u//Ijk52fWzw+FAQUEB2rZtG/T2DTV4XX311V6nt2zZEikpKapa9w8//DDog5HVvojFxcXIzMx0TS8uLkavXr1cy2hHFKiursaxY8dc6+v9J8n70Jo6daqqVrWsrAzZ2dl1O6FIIpfQCIOjh2jKboTF/aulxLhvF4f03Bpnk1dBjPSzLTHW9dye5G6lTj5+RrVOebX3W52rpICI/b/bPV3biLV4fS7vR3sM8rGpjjtGfQ7yucqvQVBlSSxlAsAsCKs6ZoHqGoCxLIjR5IKRLNDLAaDuWSDvX3t8elmgaHKBWRAazIIwkq4duZNcRfu7qbnG3NOldWLU15Rc3meJdV8rVtW1pl7H1kTOBfdyTU5Xe98/akZjdK1vcR9nkxh1SZG8bfm5fAzazy/yccvnozpX7eck+Wf5dTO6XCMVzhwAGkkWBPPer7c+NL/Dcjmv3nMAivSz1SZdezb15wqrdO05pedKpTsLLOrLFYrDfR3JZYly+aS2XFHej3wM8rEp2lJlg+eqvsbr+H7PzwtRwylqHv6WCYTNZkOfPn1QUFCA4cOH12zD6URBQQHy8/O9rpOTk4OCggLcddddrmkrV65ETk5OYDv3ofZYFEXBmDFjVPNiY2PRtm1bPPvss0Fv39BVIdeEyo+8vDx06NBBNS1U2rVrh4yMDBQUFLimlZWVYePGja4XOCcnByUlJdi8ebNrmVWrVsHpdKJv376uZdatW4eqqirXMitXrkTnzp11b1e22+2ullKjLaZEVD+YBUQEMAuIKLw5ADALiKhhCCEMPQI1ZcoUvPbaa3jzzTexa9cuTJw4ESdPnsQtt9wCALj55ptVndr//e9/x4oVK/Dss8/ixx9/xIwZM/Dtt9/qNpAFw+l0wul0onXr1jh8+LDrZ6fTiYqKCuzevRtXXHFF0Ns3dIfXG2+8EfQOfCkvL8fevXtdPxcWFmLbtm1ITU1F69atcdddd+F//ud/0KlTJ7Rr1w4PP/wwsrKyXK2AXbt2xeDBgzF+/HjMnz8fVVVVyM/Px4gRI5CVlQUAuPHGG/Hoo49i3LhxuP/++7Fjxw48//zzmDt3br2cExEFZ/v27UhMTATALCBqzJgFRI3byZMnAdRkAcAcIKLGpz7u8AKAG264AUeOHMEjjzyCoqIi9OrVCytWrHD1YXjgwAFYpLsdL774YixZsgTTpk3Dgw8+iE6dOmHZsmU455xzAt+5H4WFhSHfJhBkH16h8u2332LAgAGun2tvER4zZgwWLVqE++67DydPnsSECRNQUlKCfv36YcWKFYiLi3Ots3jxYuTn52PgwIGwWCy45ppr8MILL7jmJycn4/PPP8ekSZPQp08ftGjRAo888giHHAY0tyw7A15HfYuypnRJLl+wu/+/FJv7eUxCvGode0qi63l8c/fzilJ356CV5VWqdc46esr1PDHGfQ56pQuAunSpafME1/OE5urjkY9BPjb5uOXzAdTnqlfaJTxKQFjiBAD9+/d3PWcWNCDt71IIs0Bb7mQkC+RrDTCWBXIOAKHNAnn/2uPTywJVDgDGsiDYa5pZwCwwK71SXk1Jo3ztWOPd16EtSX7eRLVOXDN3FlSd0S9jjCmrdD0XDncuyOVKctkiAMS3cF/Xcc3cxyYfg3xs2uNWfS7wUdKo/dxEbtu2bQPgzgLmgEkZLMuFTkmjXPKrLXWW30ctsaddz7XlxFapdNFR5X4e43Rf7/K1r/1ZVdIoPbfGqbs5kcuW9Z5r3/t1z09b+qj3WcDXa0qNQhDtWYbk5+fr3qG1Zs0aj2nXXXcdrrvuuno6GrWCggIUFBS47vSSLVy4MKhtKsLAvXC9e/dGQUGBz1t8Zf369cPSpUtx1llnBXVQZlNWVobk5GQUFxVF763L0h+5ivwHr1Ndu684pQ+WVe4+dJTqCtVyljMn3D+cKnE9rT7sHmHBUXxAtU75QffwpmX7D7mel/zsHp605Bf1aDgnpD90S6vq9kduShv1/21K++au50lt3f1EJGa7+3awprdWrROTJv3OJ6S4njrjmrqeixjNyBmx7jdIVV8/9VnjbyJlZWVIz8hAaWmp6a8vZoGbkSxQ5QBgKAvkHACMZcEJTYNXKLNAzgHAWBaocgAwlgWx6g/KelkQkgZzk2IWhJmmsVt1/etkgeKohEwxkAXOE8dU6ziOFnl9fuqQu3+lEwfU/TGdPOTexolD5a7nZzT9fFbUscGraaa7gbtJZqp7emv1CIAJme4RA63NM7w+tzRNVa2jlwVCmwVW6Q98+XOB3pcOmnmRiFnQAHx8uWX4vV96rnftA4BS6W6wgioLjruflx6VV4GzvMT1vOq4e7nKEydVy1WWnZLmuZ87zriPIRQNXrEJcuO3+/OCPcV9Hcdq/k62JKa4nye7P0tYmmr+npazwObOH1+5IDeYG/68IIuAjIikHAil2kzZd/AQmvo57xNlZeiQnRk1r9Gjjz6Kxx57DOeffz4yMzOhaPqt/Oijj4LarqGvl7Zt24bvvvsOqamp/hf+v+XlIXuJiIiIiIiIiMg3I310BdOHl5nNnz8fixYtwujRo0O6XcP3Uw8cONDwi6ptjSMiIiIiIiIiIt8coubhb5loUllZiYsvvjjk2zXU4BVMB2KtWrUKeB0yIV+Nlxb9Ejsh1apbpP4sLPHuPjBE0xTVOvZm7tuU40+6b42uPqMumZDZEt37SSxz31XoqHTfrmy1qY/NnuS+RVjuqycxq6lqufiW7luO7c3c8yzSccvnA6j77nDq9d1h8XWLMRuLyaSCyAKh6ZPDSBbIOQAYywI5B4DQZoGcAzXH5z8LtH37MQsoqvgorxeqPvzc/ewJq9SXjV3dX6YiXTuWJu7ry9bUXaoY11xdquGsUvfnWSs2Tv2x1p4kHYP0l4FidV9f2pJGud+u+Bbu45GPwdZU/d4vH7d8PvK5yq9BzUzvffv57P+IKFSM9t+peS+Sy+RUc3x1u2HV67fLXa7rkQuV7vd+ub9MZ5W6zz5npfc+/BxS31oOzTp6JY1Wnb65ACC2SZz03H08vvv1lebJ56r5bCSs3kuVfV37Qq+vL1+YJRGlvjqtN7PbbrsNS5YswcMPPxzS7Rpq8GrTpk1Id0pERERERERERGqNpaSxdlASAHA6nXj11VfxxRdfoEePHoiNVTcOz5kzJ6h9cIgYIiIiIiIiIiITcP7fw98ykW7r1q2qn3v16gUA2LFjh2p6XbrMYoMXBUR1K7NqVBDNLcXy6CHSCEPybf+iUj2akk36OUHnFuUYzXDE9mR3yUNluVy64P12ZUBd/hTf3D0Ck7Z0KSHN/bOtuffRVeTzAbSjKemMuKgZitznKCpEJmUoC7S/6waywKbJBSNZIOcAENoskHMAMJYFqhwADGUBc4DMRrd0SUijtml/by06ZXpWuVRIPfqZJUG6dirc139sM+kzgVP/Y71F+gY4tom6JNpxxp0FTikLLKrR2NTfINuS3CWJchmjnAXa0diUBPdy8vko0rk6rZo8VOWCwVGYfY3MSNTQ9H4fNe/9qp+tchmjuwRQqU6Q14BSVSnNc1/HsZpRI1W7sUlljPJznc8RWlZpHavm740YadTG2KbuY1WVMMdpujmJk5aTzlX7GUHojLgYraOzkzECgL8buCL//i5g9erV9b4PNngREREREREREZmAUwg4/bR4+ZtPNdjgRURERERERERkAo1xlMa//vWvXksXFUVBXFwcOnbsiBtvvBGdO3cOaLsBN3iNGTMG48aNw6WXXhroqhQhdMsYAECRriz5VmbNrfpwSrfrxrpvJbbESyOcaUZZEg73bcryOCfyLcryKCkAYE9xlzLJI7jJ21Lk0U+gKYVKcZcxyaOvAZrSpZQ09/PEFPe249XrOKXyBfmWZdXr42sEJpYrkInUOQucmtI+A1kgX7uAsSyQcwAIbRbIOQAYywKnpmTLUBb4yAVmATWIIEZt0/5uKqqyJul6k6+BGHV5kWq0Y6l0CVLpkiZJoEglgHIWVJadUi3nUGWBzshsmtIlW5K7DEkejVEuY7QkqXPBqjNiq4iRssCj1Nn7yGwe17uRfkuYERRCwbz3y2XLHtmhU9av2KWSvyr1KMyq0Vt9lDHapO3JIys6pRJER6X3UV21rDZphHnNKI2q0RjlY0vwPkIroB61UT5XYVF/FlG9PvL1zr8dGjfhv6QxKmoaJcnJyVi2bBlSUlLQp08fAMCWLVtQUlKCQYMGYenSpZg1axYKCgpwySWXGN5uwFdFaWkpcnNz0alTJzz55JP47bffAt0EERERERERERFpOCEMPaJJRkYGbrzxRvz888/44IMP8MEHH2Dfvn246aab0KFDB+zatQtjxozB/fffH9B2A27wWrZsGX777TdMnDgRS5cuRdu2bTFkyBC8//77qKoy1oJORERERERERERqQhh7RJPXX38dd911FyzSXdwWiwV/+9vf8Oqrr0JRFOTn53uM4OhPUPc9tmzZElOmTMF3332HjRs3omPHjhg9ejSysrIwefJk7NmzJ5jNEhERERERERE1Wk5h7BFNqqur8eOPP3pM//HHH+H4vy5K4uLivPbz5UudOq0/dOgQVq5ciZUrV8JqtWLo0KH4/vvv0a1bN8yePRuTJ0+uy+apIck133r9dgC6fXcomiGIhVXahpCG4pW2bZH6vPDYjdTXjl2qgY9NLFEtF9f8tOu53FeHL3J/HXJNvvZ4LE2l/jqkvnrk5YQtHjIRIw87LA11rjfMMGCsfw6AfXRQwwhhFqhyAKi3LJBzAAhtFsg5ABjLAjkHAINZwBwgE1Nd43IuaH8f9a5/eZ1Y9fUhf0WtNHEvp+rlRtPnjU3KgpjEE67n9hR1H17OKnd/YXp9eGn76rHGu/vasTSR+udJSHIvo8kspYl7nrBJfXjF6nwmgKY/P4uPvnrkdXj9U7jpvff76kdK/v2Okfqyk659i6b/K5n8ScKiyQIR476uYu3S9VZxxv1c0weYcEpZYJE/v8j9i6lzStUfV5z7WPX68wI0/fmp+jFU9+cn5NzUyYKg/3agiGXkDq5ou8Nr9OjRGDduHB588EFccMEFAIBNmzbhySefxM033wwAWLt2Lbp37x7QdgNu8KqqqsK///1vvPHGG/j888/Ro0cP3HXXXbjxxhuRlFTzhv/RRx/h1ltvZYMXEREREREREZFBRvroirY+vObOnYv09HTMnj0bxcXFAID09HRMnjzZ1W/XoEGDMHjw4IC2G3CDV2ZmJpxOJ0aOHIlvvvkGvXr18lhmwIABSElJCXTTRERERERERESNlsMp4PBTs+hvfqSxWq146KGH8NBDD6GsrAwAXDdU1WrdunXA2w24wWvu3Lm47rrrEBcXp7tMSkoKCgsLAz4YMh+PIcdVP+gMTQzoDk8shP7vjUW+NTrWfYuy6jbiBPUvvaXSfcsyqqXhx3VuVwagup1a3rb2dmpVKUO8+7mv0iXIJQt6wwn7GFqY5QpkVkFlgVXzFmMgCyza/RjIAlUOACHNAjkHAINZoCldMpQFmvNmFlDY6ZU3q3431WXLuuXNFmk5q+YDeqx0jUqT5U5rEaO+ppx27+VFHlkglTLpZoGmREqVMzrlStrPC+oyRrv7uVzGpOn6wXB5s14WMCMolIx2Z6C3jtH3fqvN63QIdRcher/dQpMFIla6xirc3RuIOGkgNYMljXIWKJr9KHb38Slx7rJnX39HiFj5M4J7e6rXQLNfw387GMGMiGgOZ83D3zLRStvQVRcBN3iNHj06ZDsnIiIiIiIiIqIaTiHg9NNJl7/5kaB3794oKChAs2bNcN555/nskH7Lli1B7aNOndYTEREREREREVFoOIWAoxE0eF111VWw22vujB4+fHi97IMNXuQpmFHaNLfqy22zQue3zKNESqcUwuqjXEE1Cku1sZHZFLmMSS6LsGlHVnMv55RLFHyULqlGXtEddYWjsVGEqGMWaH/TjWSBos0FA1kg5wAQ2izQlh4YyQLtCEzMAoomqutVO1Mqb1ZlgdzLga+N65T2Waz65UUiQRqltbpKtZzQ/Ox1l5rSJbl8UlXGpLr27apV1KMxSiVW8nH7GJmN5c1kVj67M5BKmo2O3K76+8DXjqXtyde/qFCPxCq/3wqp1FB17WtKGnX5KmnU+7xgl/ap+bygKmP09beDzoitRkudmRHRySn8N2hFQxde06dP9/o8lHiFEBERERERERGZQG0fXv4e0aakpAQLFizA1KlTcezYMQA1pYy//fZb0NvkHV5ERERERERERCZQ5XSiyum7Rcvf/Eizfft25ObmIjk5Gfv378f48eORmpqKDz/8EAcOHMBbb70V1HbZ4EW+aW+tl2ep5mhGatIpa1KVNPkYrVB1S6/TXTqgaEZFVOLd+7U4q2GEXhmBU1vWIB+DXomCdiQaI6VLvsoVeFsymVUQWWC41NnXNWAgC+QcAEKcBR6lGQayQLuOgSzwKElgFpCZBFHeLBcR6JU3ApqyJr3rQ/Neq0glhRZptFSPY5N/lsua5FHRfI2cLF3jTvkYtKVLcsmVfL3H+Bil0Ve5kh7mAjUEH9e7bkmzj4hQjdgqT5e36+sY5OtDcx1Z5C4I9MoYtaM0Otw/K1YpCyw6z6EucVSPvupeTtudgarEUc4IX387qP4W0s8p3TJGZkTUcMJ/yWJ0NXcBU6ZMwdixYzF79mw0beoeGXno0KG48cYbg94uG7yIiIiIiIiIiEzA4RRw+Gnx8jc/0mzatAn/+Mc/PKafddZZKCoqCnq7bPAiIiIiIiIiIjIBIYTfTutFFIzSKLPb7SgrK/OY/tNPP6Fly5ZBb5f3PRIRERERERERmYBDGHtEk7/85S947LHHUFVVU56sKAoOHDiA+++/H9dcc03Q2+UdXhQ0n0OT6/Tjo1pOW49u0albl2rvRYy6WlmR+uoRvvoV0dmv7rDgmmPQGzLY8xyC6KuHKMLpZ4Gxvv3U16T+daiXBYqmz66QZoGmHw8jWeDZVw+zgKKT9ndY//rXvz7kPr2EU6c/P+01ZdV579dkgWIgCzyuQyPXtcFc8PkZg7lAkUD7+2jk/dXHZ2O9fru0f0cIvetf20enU+pLM0bqq0s6Tm0O6PWY56tPXSH19aXOAp3rHTD2d4R2vWCuf2ZGVHIauMPL3/xI8+yzz+Laa69FWloaTp8+jT/96U8oKipCTk4OnnjiiaC3ywYvIiIiIiIiIiITaIx9eCUnJ2PlypX46quvsH37dpSXl6N3797Izc2t03bZ4EVEREREREREZAJVToEqPw1a/uZHqn79+qFfv34h2x4bvCgwOkMVGy1rUN22q73FWK90QL592akdcjwWdaG+ZdpgWYOPW56DKlHgrcgUiQxkgdFSZ1Xpga8yYb0sqGMOAD6ywKM80UAWKJozN5IFzAGKFDrXPmC0vNlHuZPetaLdj1TGpC5ptquXM1Luob1edY5NlQs+yiBDmgve9kVkEka7M9Arada93gHAIV3X8rWjfU+Wr3+r/LlA+rwRRDcHnp/v9bpAULxPBwC9Umcf22apM9VqjCWNAFBQUICCggIcPnwYTs3f/QsXLgxqm2zwIiIiIiIiIiIyAadTwOnnDi5/8yPNo48+isceewznn38+MjMzofj4QioQbPAiIiIiIiIiIjIBp4FRGKOsvQvz58/HokWLMHr06JBulw1eFLxgyhpUw7OoW22F8L49VYmTemAk47cp6/Fxi7ChsgSj6xvcJ1FECqbUWScLVDmg2Z5eFtQ5BwDd6zKY0gO/2zCwDlFE8DGCm6HPATULup8K7++7HqMtWuRyJR8fZYMYUU53nq/yIuYCNRZ17M4AijRyoTzZV/cB8jXu0IzSKI+YKm+wrqVeRkuQrT5GWNRbRzPKq6F1fCxH0akxljRWVlbi4osvDvl2ebUQEREREREREZmAQwhDj2hy2223YcmSJSHfLu/wIiIiIiIiIiIygSqnQIyfmsZoGKVxypQprudOpxOvvvoqvvjiC/To0QOxsepBqebMmRPUPtjgRaHh67Z9vVV8TZBLHNS1S8aOR32ftLF1fHWMZ7TcycA6RFGtrlngq9yJWUBkbgbLm1WrqH7SKX3SljrLfJQtepRCels9mGvXYEYYHlmNGUGRKKiR2yXy6r66M/DxPq7bpUE9dnnCUmdqCI2lpHHr1q2qn3v16gUA2LFjh2p6XTqwZ4MXEREREREREZEJGClZjIaSxtWrV9f7PtjgRURERERERERkAk6ngMNPyaIzCkoaGwIbvIiIiIiIiIiITMBhoMHL33yqwQYvqn917tPDyAxo+uoxNuSvUeyHgygEGksWMAeI9K8DTd86Qqc/HHW/PT624eMa99n3l2t9g/2CBNPvjsH1iSKezvs7oH996PbfB+j34VfHPvuCZahvLfbtRyHEBq/QYYMXEREREREREZEJOJz+G7Qc9dfGG1XY4EVEREREREREZAKV1U5Yqn23aFX6mU812OBFDcvX7bkGS5yC2nYo8RZjoroLptyprtsONWYBUeBC8DnA8ODkwY9i7oFlSEQGBXGN+7xU5ZlCf0lDJczB0itXNHi9+8wPZgZ5wU7rQ8fUV9iMGTOgKIrq0aVLF9f8M2fOYNKkSWjevDkSExNxzTXXoLi4WLWNAwcOYNiwYUhISEBaWhruvfdeVFdXN/SpEFEdMAuICGAWEFENZgERRTOHEK5+vHQfgg1eRpi6wQsAunfvjkOHDrkeX331lWve5MmT8Z///Afvvfce1q5di99//x1XX321a77D4cCwYcNQWVmJ9evX480338SiRYvwyCOPhONUiKgOmAVEBDALiKgGs4CIopXfxi4Dd4DV1bFjxzBq1CgkJSUhJSUF48aNQ3l5uc91LrvsMo8vI26//fZ6PU5/TF/SGBMTg4yMDI/ppaWleP3117FkyRL8+c9/BgC88cYb6Nq1K77++mtcdNFF+Pzzz/HDDz/giy++QHp6Onr16oXHH38c999/P2bMmAGbzdbQp0O+BHNLb11HZOFtxBGDWdBIhCMHgt0vhQWzIIrVZ6lzKIV7/wSAWRCRghitWbV6MDONfkaoz1Hc67gfanzMMErjqFGjcOjQIaxcuRJVVVW45ZZbMGHCBCxZssTneuPHj8djjz3m+jkhIaFej9Mf019xe/bsQVZWFtq3b49Ro0bhwIEDAIDNmzejqqoKubm5rmW7dOmC1q1bY8OGDQCADRs24Nxzz0V6erprmby8PJSVlWHnzp26+6yoqEBZWZnqQUThxSwgIoBZQEQ1mAVEFK2qncLQo77s2rULK1aswIIFC9C3b1/069cPL774It599138/vvvPtdNSEhARkaG65GUlFRvx2mEqRu8+vbti0WLFmHFihWYN28eCgsL0b9/f5w4cQJFRUWw2WxISUlRrZOeno6ioiIAQFFRkeqNrHZ+7Tw9M2fORHJysuuRnZ0d2hMjooAwC4gIYBYQUQ1mARFFs6pqJyr9PKr+b5RGbSN8RUVFnfe/YcMGpKSk4Pzzz3dNy83NhcViwcaNG32uu3jxYrRo0QLnnHMOpk6dilOnTtX5eOrC1CWNQ4YMcT3v0aMH+vbtizZt2uBf//oX4uPj622/U6dOxZQpU1w/l5WV8Q3NrHhbcKPALCCfmAONBrOgkeI1ThrMgihgcDRH1eRIKiFkblEdOIT/Tulr52szaPr06ZgxY0ad9l9UVIS0tDTVtJiYGKSmpvr8UuDGG29EmzZtkJWVhe3bt+P+++/H7t278eGHH9bpeOrC1A1eWikpKTj77LOxd+9eXH755aisrERJSYnqG5zi4mJXPX9GRga++eYb1TZqR2jxVvNfy263w263h/4EiCgkmAVEBDALiKgGs4CIokkgfXgdPHhQVTboK6MeeOABzJo1y+d2d+3aFcCRqk2YMMH1/Nxzz0VmZiYGDhyIffv2oUOHDkFvty4iqum5vLwc+/btQ2ZmJvr06YPY2FgUFBS45u/evRsHDhxATk4OACAnJwfff/89Dh8+7Fpm5cqVSEpKQrdu3Rr8+IkoNJgFRAQwC4ioBrOAiKJJIKM0JiUlqR6+Grzuvvtu7Nq1y+ejffv2yMjIUOUjAFRXV+PYsWM+vxTQ6tu3LwBg7969QbwKoWHqO7zuueceXHnllWjTpg1+//13TJ8+HVarFSNHjkRycjLGjRuHKVOmIDU1FUlJSfjb3/6GnJwcXHTRRQCAQYMGoVu3bhg9ejRmz56NoqIiTJs2DZMmTeK3M0QRhFlARACzgIhqMAuIKJrV1yiNLVu2RMuWLf0ul5OTg5KSEmzevBl9+vQBAKxatQpOp9PViGXEtm3bAACZmZkBH2uomLrB69dff8XIkSNx9OhRtGzZEv369cPXX3/t+k+aO3cuLBYLrrnmGlRUVCAvLw+vvPKKa32r1YpPPvkEEydORE5ODpo0aYIxY8aohskkIvNjFhARwCwgohrMgigXTP9XOv1+hQT746IG5hBOOJy+f6cd9fg737VrVwwePBjjx4/H/PnzUVVVhfz8fIwYMQJZWVkAgN9++w0DBw7EW2+9hQsvvBD79u3DkiVLMHToUDRv3hzbt2/H5MmTcemll6JHjx71dqz+KEL46Q2NUFZWhuTkZBQXFYV9WE2iaFNWVob0jAyUlpaa/vpiFhDVH2YBEQHMAgoSG7yiSiTlQCjVZsq181chNj7R57JVp8vx/u1/rrfX6NixY8jPz8d//vMf1xcIL7zwAhITa45r//79aNeuHVavXo3LLrsMBw8exE033YQdO3bg5MmTyM7Oxl//+ldMmzYtrP+Hpr7Di4iIiIiIiIiosaioFnBW+27Eraqu3/uWUlNTsWTJEt35bdu2hXzvVHZ2NtauXVuvxxQMNngRERERERFR5OJdWBRFHE4BSz304dUYscGLiIiIiIiIiMgE2OAVOmzwIiIiIiIiIiIyATZ4hQ4bvIiIiIiIiIiITMDpFH4btJxs8DKEDV5ERERERERERCbgcAoovMMrJNjgRURERERERERkAg6HE4qfURodDt/zqQYbvIiIiIiIiIiITEAIASF838Hlbz7VYIMXEREREREREZEJCKeA8FOy6G8+1WCDFxERERERERGRCTidwm+n9Oy03hg2eBERERERERERmYBw1jz8LUP+scGLiIiIiIiIiMgE2IdX6LDBi4iIiIiIiIjIBFjSGDps8CIiIiIiIiIiMgFR7YSz2nfNovAzn2qwwYuIiIiIiIiIyAScQkDxU7LoZEmjIWzwIiIiIiIiIiIyASEEhJ+SRfbhZQwbvIiIiIiIiIiITEA4DTR4sQ8vQ9jgRURERERERERkAk4noPjttL6BDibCscGLiIiIiIiIiMgEhBB+SxZZ0mgMG7yIiIiIiIiIiEzAUS0Aq+8GLUc1G7yMYIMXEREREREREZEJsA+v0GGDFxERERERERGRCbDBK3TY4EVEREREREREZAJOIaD46aPLyT68DGGDFxERERERERGRCfAOr9BhgxcRERERERERkQkIYaDBi3d4GcIGLyIiIiIiIiIiExBOASfv8AoJNngREREREREREZmA0+EEHE7/y5BfbPAiIiIiIiIiIjIBp1MAfu7g8ncHGNVggxcRERERERERkQkIpwPC6fC7DPnHBi8iIiIiIiIiIhNgg1fosMGLiIiIiIiIiMgEhNNpoMGLfXgZwQYvIiIiIiIiIiITEA4HhMNPg5ef+VSDDV5ERERERERERCbgdFQC1Vb/y5BfbPAiIiIiIiIiIjIB9uEVOmzwIiIiIiIiIiIyATZ4hQ4bvIiIiIiIiIiITICd1ocOG7yIiIiIiIiIiEzA6XQAfhq8nLzDyxA2eBERERERERERmQBLGkOHDV5ERERERERERCbABq/QYYMXEREREREREZEJiOpKOGHxuwz5xwYvIiIiIiIiIiITEE6n3z682Gm9Mb6bDaPMyy+/jLZt2yIuLg59+/bFN998E+5DIqIwYBYQEXOAiABmARGZT21Jo78H+ddoGryWLl2KKVOmYPr06diyZQt69uyJvLw8HD58ONyHRkQNiFlARMwBIgKYBURkTsLpNPQg/xpNg9ecOXMwfvx43HLLLejWrRvmz5+PhIQELFy4MNyHRkQNiFlARMwBIgKYBURkTrzDK3QaRYNXZWUlNm/ejNzcXNc0i8WC3NxcbNiwwWP5iooKlJWVqR5EFPmYBUQUaA4AzAKiaMQsICKzYoNX6DSKBq8//vgDDocD6enpqunp6ekoKiryWH7mzJlITk52PbKzsxvqUImoHjELiCjQHACYBUTRiFlARGblqKqCo6rSz6Mq3IcZEThKoxdTp07FlClTXD+XlpaidevWOHHiRBiPiig61V5XQogwH4knZgFRw2EWEBHALCAic+dAQxDC4X+URlG/d3g98cQTWL58ObZt2wabzYaSkhK/6wghMH36dLz22msoKSnBJZdcgnnz5qFTp071eqy+NIoGrxYtWsBqtaK4uFg1vbi4GBkZGR7L2+122O1218+1tyt3DON/FFG0O3HiBJKTk+t1H8wCIvOr7ywINAcAZgFRODALiKgh/j4wI+F0AIqfBq96LmmsrKzEddddh5ycHLz++uuG1pk9ezZeeOEFvPnmm2jXrh0efvhh5OXl4YcffkBcXFy9Hq+eRtHgZbPZ0KdPHxQUFGD48OEAAKfTiYKCAuTn5/tdPysrCwcPHoQQAq1bt8bBgweRlJRUz0dd/8rKypCdnR015wNE3zk1hvMRQuDEiRPIysqq9/0zC7xrDL9nkS7azimcWVDXHACYBZGC52N+0ZAFP/zwA7p16xb1/y+RjOdjftpzasi/D8zIDA1ejz76KABg0aJFhpYXQuC5557DtGnTcNVVVwEA3nrrLaSnp2PZsmUYMWJEfR2qT42iwQsApkyZgjFjxuD888/HhRdeiOeeew4nT57ELbfc4nddi8WCVq1aub7FSUpKippwAaLvfIDoO6doP5+G/OaGWaCP52N+0XZO4cqCuuQAwCyINDwf84vkLDjrrLMANI7/l0jH8zE/+Zwa451dtUTVGf8NWo6aPry0g2do70RtKIWFhSgqKlINBJKcnIy+fftiw4YNbPCqbzfccAOOHDmCRx55BEVFRejVqxdWrFjh0VElEUU3ZgERMQeICGAWEJG52Gw2ZGRkoOiHfxlaPjEx0WPwjOnTp2PGjBn1cHS+1Q72EchAIA2h0TR4AUB+fr7hW5SJKHoxC4iIOUBEALOAiMwjLi4OhYWFqKysNLS8EAKKoqim+bq764EHHsCsWbN8bnPXrl3o0qWLof1HgkbV4FVXdrsd06dPD8stgvUh2s4HiL5z4vmYU7ScRy2ej/lF2zlFy/lEy3nU4vmYW7SdDxAd5xQN56AVbefE8zG/aDynYMXFxdVbB+933303xo4d63OZ9u3bB7Xt2sE+iouLkZmZ6ZpeXFyMXr16BbXNUFBEYx3rk4iIiIiIiIiIvFq0aBHuuusulJSU+FxOCIGsrCzcc889uPvuuwHU9C+WlpaGRYsWha0PL0tY9kpERERERERERKZz4MABbNu2DQcOHIDD4cC2bduwbds2lJeXu5bp0qULPvroIwCAoii466678D//8z/497//je+//x4333wzsrKyXCPhhgNLGomIiIiIiIiICADwyCOP4M0333T9fN555wEAVq9ejcsuuwwAsHv3bpSWlrqWue+++3Dy5ElMmDABJSUl6NevH1asWFFvJZpGsKSRiIiIiIiIiIiiCksaiYiIiIiIiIgoqrDBKwAvv/wy2rZti7i4OPTt2xfffPNNuA/Jw4wZM6AoiuohDyt65swZTJo0Cc2bN0diYiKuueYaFBcXq7Zx4MABDBs2DAkJCUhLS8O9996L6urqBjuHdevW4corr0RWVhYURcGyZctU84UQeOSRR5CZmYn4+Hjk5uZiz549qmWOHTuGUaNGISkpCSkpKRg3bpyq3hgAtm/fjv79+yMuLg7Z2dmYPXt2WM5n7NixHv9ngwcPNu35zJw5ExdccAGaNm2KtLQ0DB8+HLt371YtE6rfszVr1qB3796w2+3o2LEjFi1aVC/nFIhIyAEg8rMg2nLAyDlFUhY09hwAmAXMgvo5n0jKAYBZADALmAX1cz7MgsjLAjIpQYa8++67wmaziYULF4qdO3eK8ePHi5SUFFFcXBzuQ1OZPn266N69uzh06JDrceTIEdf822+/XWRnZ4uCggLx7bffiosuukhcfPHFrvnV1dXinHPOEbm5uWLr1q3i008/FS1atBBTp05tsHP49NNPxUMPPSQ+/PBDAUB89NFHqvlPPfWUSE5OFsuWLRPfffed+Mtf/iLatWsnTp8+7Vpm8ODBomfPnuLrr78WX375pejYsaMYOXKka35paalIT08Xo0aNEjt27BDvvPOOiI+PF//4xz8a/HzGjBkjBg8erPo/O3bsmGoZM51PXl6eeOONN8SOHTvEtm3bxNChQ0Xr1q1FeXm5a5lQ/J79/PPPIiEhQUyZMkX88MMP4sUXXxRWq1WsWLEi5OdkVKTkgBCRnwXRlgNGzimSsqAx54AQzAJmQf2dTyTlgBDMAmYBs6C+zodZEFlZQObFBi+DLrzwQjFp0iTXzw6HQ2RlZYmZM2eG8ag8TZ8+XfTs2dPrvJKSEhEbGyvee+8917Rdu3YJAGLDhg1CiJrwtVgsoqioyLXMvHnzRFJSkqioqKjXY/dG+wbgdDpFRkaGePrpp13TSkpKhN1uF++8844QQogffvhBABCbNm1yLfPZZ58JRVHEb7/9JoQQ4pVXXhHNmjVTndP9998vOnfu3KDnI0TNG9pVV12lu46Zz0cIIQ4fPiwAiLVr1wohQvd7dt9994nu3bur9nXDDTeIvLy8+j4lXZGSA0JEVxZEWw4IEX1Z0JhyQAhmAbOgfs5HiMjOASGYBcyChsEsMPf5CNH4soDMiyWNBlRWVmLz5s3Izc11TbNYLMjNzcWGDRvCeGTe7dmzB1lZWWjfvj1GjRqFAwcOAAA2b96Mqqoq1Xl06dIFrVu3dp3Hhg0bcO655yI9Pd21TF5eHsrKyrBz586GPREvCgsLUVRUpDqH5ORk9O3bV3UOKSkpOP/8813L5ObmwmKxYOPGja5lLr30UthsNtcyeXl52L17N44fP95AZ+O2Zs0apKWloXPnzpg4cSKOHj3qmmf286kdmSM1NRVA6H7PNmzYoNpG7TLhuuYiLQeA6M2CaM0BIHKzoLHkAMAsAJgF9S1ScwBgFjALwoNZUMNM59OYsoDMjQ1eBvzxxx9wOByqiw8A0tPTUVRUFKaj8q5v375YtGgRVqxYgXnz5qGwsBD9+/fHiRMnUFRUBJvNhpSUFNU68nkUFRV5Pc/aeeFWewy+/i+KioqQlpammh8TE4PU1FRTnufgwYPx1ltvoaCgALNmzcLatWsxZMgQOBwO1/GY9XycTifuuusuXHLJJTjnnHNc+wvF75neMmVlZTh9+nR9nI5PkZQDQHRnQTTmABC5WdCYcgBgFtTOr50XTtGYBZGaAwCzQD6ucF8b3jALzHvteMMs8H68ZswCMreYcB8AhdaQIUNcz3v06IG+ffuiTZs2+Ne//oX4+PgwHhnpGTFihOv5ueeeix49eqBDhw5Ys2YNBg4cGMYj82/SpEnYsWMHvvrqq3AfCmkwCyJPpGYBc8DcmAWRJVJzAGAWmB2zILIwC4hCg3d4GdCiRQtYrVaPUSSKi4uRkZERpqMyJiUlBWeffTb27t2LjIwMVFZWoqSkRLWMfB4ZGRlez7N2XrjVHoOv/4uMjAwcPnxYNb+6uhrHjh2LiPNs3749WrRogb1797qOx4znk5+fj08++QSrV69Gq1atXNND9Xumt0xSUlJYPphFcg4A0ZUFjSEHgMjIgsaWAwCzoHZ+7bxwagxZEAk5ADALtMcV7t8bI5gF5rh2jGIWmDcLyNzY4GWAzWZDnz59UFBQ4JrmdDpRUFCAnJycMB6Zf+Xl5di3bx8yMzPRp08fxMbGqs5j9+7dOHDggOs8cnJy8P3336sCdOXKlUhKSkK3bt0a/Pi12rVrh4yMDNU5lJWVYePGjapzKCkpwebNm13LrFq1Ck6nE3379nUts27dOlRVVbmWWblyJTp37oxmzZo10Nl49+uvv+Lo0aPIzMwEYL7zEUIgPz8fH330EVatWoV27dqp5ofq9ywnJ0e1jdplwnXNRXIOANGVBY0hBwBzZ0FjzQGAWQAwCxqSmXMAYBYwC5gFDYVZYN4sIJMLb5/5kePdd98VdrtdLFq0SPzwww9iwoQJIiUlRTWKhBncfffdYs2aNaKwsFD897//Fbm5uaJFixbi8OHDQoia4WBbt24tVq1aJb799luRk5MjcnJyXOvXDgc7aNAgsW3bNrFixQrRsmXLBhtyWAghTpw4IbZu3Sq2bt0qAIg5c+aIrVu3il9++UUIUTPscEpKivj444/F9u3bxVVXXeV12OHzzjtPbNy4UXz11VeiU6dOqmF6S0pKRHp6uhg9erTYsWOHePfdd0VCQkK9DNPr63xOnDgh7rnnHrFhwwZRWFgovvjiC9G7d2/RqVMncebMGVOez8SJE0VycrJYs2aNaqjkU6dOuZYJxe9Z7bDD9957r9i1a5d4+eWXwz7scKTkgBCRnwXRlgP+zinSsqAx54AQzAJmQf2cT6TlgBDMAmYBs6A+zodZEHlZQObFBq8AvPjii6J169bCZrOJCy+8UHz99dfhPiQPN9xwg8jMzBQ2m02cddZZ4oYbbhB79+51zT99+rS44447RLNmzURCQoL461//Kg4dOqTaxv79+8WQIUNEfHy8aNGihbj77rtFVVVVg53D6tWrBQCPx5gxY4QQNUMPP/zwwyI9PV3Y7XYxcOBAsXv3btU2jh49KkaOHCkSExNFUlKSuOWWW8SJEydUy3z33XeiX79+wm63i7POOks89dRTDX4+p06dEoMGDRItW7YUsbGxok2bNmL8+PEeH5TMdD7ezgWAeOONN1zLhOr3bPXq1aJXr17CZrOJ9u3bq/YRLpGQA0JEfhZEWw74O6dIy4LGngNCMAuYBaE/n0jLASGYBUIwC5gFoT8fZkFkZgGZkyKEEMHfH0ZERERERERERGQu7MOLiIiIiIiIiIiiChu8iIiIiIiIiIgoqrDBi4iIiIiIiIiIogobvIiIiIiIiIiIKKqwwYuIiIiIiIiIiKIKG7yIiIiIiIiIiCiqsMGLiIiIiIiIiIiiChu8KOLs378fiqJAURT06tXLNX3s2LEYPnx4yPfXtm1b1/5KSkpCvn0iChxzgIgAZgER1WAWEJE3bPCiiPXFF1+goKCg3vezadMmfPDBB/W+HyIKHHOAiABmARHVYBYQkYwNXhSxmjdvjubNm9f7flq2bInU1NR63w8RBY45QEQAs4CIajALiEjGBi8KqyNHjiAjIwNPPvmka9r69eths9nq/O3Mpk2b0LJlS8yaNQsAMGPGDPTq1QsLFy5E69atkZiYiDvuuAMOhwOzZ89GRkYG0tLS8MQTT9Rpv0QUGOYAEQHMAiKqwSwgolCJCfcBUOPWsmVLLFy4EMOHD8egQYPQuXNnjB49Gvn5+Rg4cGDQ2121ahWuvvpqzJ49GxMmTHBN37dvHz777DOsWLEC+/btw7XXXouff/4ZZ599NtauXYv169fj1ltvRW5uLvr27RuKUyQiP5gDRAQwC4ioBrOAiEKFDV4UdkOHDsX48eMxatQonH/++WjSpAlmzpwZ9PY++ugj3HzzzViwYAFuuOEG1Tyn04mFCxeiadOm6NatGwYMGIDdu3fj008/hcViQefOnTFr1iysXr2ab2hEDYg5QEQAs4CIajALiCgU2OBFpvDMM8/gnHPOwXvvvYfNmzfDbrcHtZ2NGzfik08+wfvvv+91RJa2bduiadOmrp/T09NhtVphsVhU0w4fPhzU/okoeMwBIgKYBURUg1lARHXFPrzIFPbt24fff/8dTqcT+/fvD3o7HTp0QJcuXbBw4UJUVVV5zI+NjVX9rCiK12lOpzPoYyCi4DAHiAhgFhBRDWYBEdUVG7wo7CorK3HTTTfhhhtuwOOPP47bbrst6G9QWrRogVWrVmHv3r24/vrrvb6pEZH5MAeICGAWEFENZgERhQIbvCjsHnroIZSWluKFF17A/fffj7PPPhu33npr0NtLS0vDqlWr8OOPP2LkyJGorq4O4dESUX1gDhARwCwgohrMAiIKBTZ4UVitWbMGzz33HN5++20kJSXBYrHg7bffxpdffol58+YFvd2MjAysWrUK33//PUaNGgWHwxHCoyaiUGIOEBHALCCiGswCIgoVRQghwn0QRIHYv38/2rVrh61bt6JXr14Nss81a9ZgwIABOH78OFJSUhpkn0SkjzlARACzgIhqMAuIyBve4UUR6+KLL8bFF19c7/vp3r07hgwZUu/7IaLAMQeICGAWEFENZgERyXiHF0Wc6upq10gtdrsd2dnZ9bq/X375xdW5Zfv27VVDFBNReDAHiAhgFhBRDWYBEXnDBi8iIiIiIiIiIooqbIomIiIiIiIiIqKowgYvIiIiIiIiIiKKKmzwIiIiIiIiIiKiqMIGLyIiIiIiIiIiiips8CIiIiIiIiIioqjCBi8iIiIiIiIiIooqbPAiIiIiIiIiIqKowgYvIiIiIiIiIiKKKmzwIiIiIiIiIiKiqPL/AVR/MrSWYBPZAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1600x360 with 5 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plot the initial bump and a few snapshots from the cycle history.\n",
+    "snapshots = [(0, state0)] + [\n",
+    "    (((i + 1) * cycle.history_stride), carrier)\n",
+    "    for i, (carrier, _state) in enumerate(cycle.history[:3])\n",
+    "]\n",
+    "fig, axes = plt.subplots(1, len(snapshots), figsize=(4 * len(snapshots), 3.6))\n",
+    "vmax = float(jnp.max(jnp.abs(h0)))\n",
+    "for ax, (step, st) in zip(axes, snapshots, strict=True):\n",
+    "    im = ax.pcolormesh(\n",
+    "        X / 1e3, Y / 1e3, st.h, cmap=\"RdBu_r\", vmin=-vmax, vmax=vmax, shading=\"auto\"\n",
+    "    )\n",
+    "    ax.set_title(f\"step {step}  (t = {step * op.dt / 3600:.1f} h)\")\n",
+    "    ax.set_xlabel(\"x [km]\")\n",
+    "    ax.set_aspect(\"equal\")\n",
+    "axes[0].set_ylabel(\"y [km]\")\n",
+    "fig.colorbar(im, ax=axes, shrink=0.8, label=\"height h [m]\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc74a530",
+   "metadata": {},
+   "source": [
+    "## 6. The `scenario x model` registry, end to end\n",
+    "\n",
+    "`SomaxModelOp.from_registry` builds *any* compatible scenario x model pair\n",
+    "through the dispatcher and hands back `(op, state0)` ready for `Cycle`.\n",
+    "This is the full \"what we simulate (scenario) x how we simulate it\n",
+    "(model)\" composition, wrapped as a pipekit Operator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "8fa3200b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-31T11:52:19.642362Z",
+     "iopub.status.busy": "2026-05-31T11:52:19.642115Z",
+     "iopub.status.idle": "2026-05-31T11:52:34.199632Z",
+     "shell.execute_reply": "2026-05-31T11:52:34.198509Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "built: LinearShallowWater2D\n",
+      "forward-integrated 10 steps; finite: True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "op | op == two steps: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "reg_op, reg_state0 = SomaxModelOp.from_registry(\n",
+    "    \"double_gyre\",\n",
+    "    \"linear_swm\",\n",
+    "    dt=60.0,\n",
+    "    scenario_params={\"grid\": {\"nx\": 16, \"ny\": 16}},\n",
+    "    model_params={\"params\": {\"lateral_viscosity\": 100.0, \"bottom_drag\": 1e-6}},\n",
+    ")\n",
+    "reg_final, _ = Cycle(step_op=reg_op, n_steps=10)(reg_state0, None)\n",
+    "print(\"built:\", type(reg_op.model).__name__)\n",
+    "print(\"forward-integrated 10 steps; finite:\", bool(jnp.all(jnp.isfinite(reg_final.h))))\n",
+    "\n",
+    "# Operators compose like any pipekit stage — ``op | op`` is two steps.\n",
+    "two_steps = (reg_op | reg_op)(reg_state0)\n",
+    "print(\"op | op == two steps:\", bool(jnp.all(jnp.isfinite(two_steps.h))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dcdc67cc",
+   "metadata": {},
+   "source": [
+    "## Recap\n",
+    "\n",
+    "- **Terms** make a model's RHS a transparent sum of physics kernels, with\n",
+    "  IMEX tags (`gravity_wave + coriolis + nu*diffusion - kappa*drag`).\n",
+    "- **Operators** (`SomaxModelOp` / `Burgers2DOp`) expose a model as a\n",
+    "  pipekit stage + `ForwardModel`; flat-recipe models also `serial`\n",
+    "  round-trip.\n",
+    "- **Cycles** drive the stepping loop and collect trajectories.\n",
+    "\n",
+    "The same three seams power the somax-sim runner (which drives its chunked\n",
+    "integration with `Cycle`) and let somax models plug into data-assimilation\n",
+    "libraries (vardax, filterax) by satisfying `ForwardModel` structurally."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/tutorials/composable_models_terms_operators_cycles.ipynb
+++ b/content/tutorials/composable_models_terms_operators_cycles.ipynb
@@ -19,7 +19,8 @@
     "3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,\n",
     "   threading state and collecting a trajectory.\n",
     "\n",
-    "Everything here lives under the `somax[sim]` extra (which carries pipekit).\n",
+    "Everything here needs the `sim` dependency group (`uv sync --group sim`),\n",
+    "which carries pipekit.\n",
     "somax's *core* never imports pipekit — models satisfy the protocols\n",
     "structurally."
    ]

--- a/content/tutorials/composable_models_terms_operators_cycles.py
+++ b/content/tutorials/composable_models_terms_operators_cycles.py
@@ -27,7 +27,8 @@
 # 3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,
 #    threading state and collecting a trajectory.
 #
-# Everything here lives under the `somax[sim]` extra (which carries pipekit).
+# Everything here needs the `sim` dependency group (`uv sync --group sim`),
+# which carries pipekit.
 # somax's *core* never imports pipekit — models satisfy the protocols
 # structurally.
 

--- a/content/tutorials/composable_models_terms_operators_cycles.py
+++ b/content/tutorials/composable_models_terms_operators_cycles.py
@@ -1,0 +1,218 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Composable Models: Terms → Operators → Cycles
+#
+# somax models plug into the [pipekit](https://github.com/jejjohnson/pipekit)
+# ecosystem along three seams that build on each other. This tutorial walks
+# the whole path end to end:
+#
+# 1. **Terms** — a model's right-hand side as a *sum of composable physics
+#    kernels*, with per-term `explicit`/`implicit` tags for IMEX integration.
+# 2. **Operators** — wrapping a built model as a `pipekit.Operator`: a
+#    one-step pipeline stage that satisfies `pipekit_cycle.ForwardModel` and
+#    (for flat-config models) round-trips through `pipekit.serial`.
+# 3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,
+#    threading state and collecting a trajectory.
+#
+# Everything here lives under the `somax[sim]` extra (which carries pipekit).
+# somax's *core* never imports pipekit — models satisfy the protocols
+# structurally.
+
+# %%
+from __future__ import annotations
+
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from pipekit import dumps, loads
+from pipekit_cycle import Cycle, ForwardModel
+
+from somax._src.models.swm.linear_2d import LinearSW2DState
+from somax._src.models.swm.linear_swm_terms import LinearSWM2DTermModel
+from somax.operators import Burgers2DOp, SomaxModelOp
+
+
+# %% [markdown]
+# ## 1. A model as a sum of term-kernels
+#
+# The linear shallow water right-hand side decomposes into four distinct
+# physics kernels — a gravity-wave (pressure) term, Coriolis, lateral
+# diffusion, and bottom drag — that compose with `+`:
+#
+# $$
+# \texttt{rhs} = \underbrace{\texttt{gravity\_wave}}_{\text{fast, stiff}}
+#   + \texttt{coriolis}
+#   + \nu \cdot \underbrace{\texttt{diffusion}}_{\text{stiff}}
+#   + (-\kappa) \cdot \texttt{drag}
+# $$
+#
+# The differentiable parameters ($\nu$, $\kappa$) enter as `Scaled`
+# coefficients (JAX leaves), so a loss can be differentiated straight
+# through them.
+
+# %%
+model = LinearSWM2DTermModel.create(
+    nx=64,
+    ny=64,
+    Lx=2_000e3,
+    Ly=2_000e3,
+    f0=1e-4,
+    beta=2e-11,
+    H0=100.0,
+    lateral_viscosity=200.0,
+    bottom_drag=1e-7,
+)
+
+# The assembled right-hand side is a Sum of four term-kernels:
+for term in model.terms.terms:
+    print(type(term).__name__, "->", repr(term))
+
+print("\nviscosity nu read back from the tree:", float(model.nu))
+print("bottom drag kappa read back from the tree:", float(model.kappa))
+
+
+# %% [markdown]
+# ## 2. IMEX — tag stiff terms implicit
+#
+# Because each kernel carries an integration `kind`, a stiff term can be
+# routed to the implicit stage of a splitting (IMEX) solver. With the
+# default (all explicit) the whole RHS lowers to a single `diffrax.ODETerm`;
+# with `imex=True` the diffusion term is tagged implicit and the RHS lowers
+# to a `diffrax.MultiTerm` that an IMEX solver (e.g. `KenCarp3`) integrates
+# with the stiff Laplacian handled implicitly.
+
+# %%
+explicit_model = LinearSWM2DTermModel.create(nx=32, ny=32, lateral_viscosity=200.0)
+imex_model = LinearSWM2DTermModel.create(
+    nx=32, ny=32, lateral_viscosity=200.0, imex=True
+)
+
+print("explicit build_terms():", type(explicit_model.build_terms()).__name__)
+print("imex     build_terms():", type(imex_model.build_terms()).__name__)
+
+
+# %% [markdown]
+# ## 3. Wrap a built model as a pipekit Operator
+#
+# `SomaxModelOp` turns *any* built somax model into a `pipekit.Operator`: a
+# one-step stage (`op(state) -> next_state`) that also satisfies the
+# `pipekit_cycle.ForwardModel` protocol (`step` / `dt` / `state_signature`).
+
+# %%
+op = SomaxModelOp(model, dt=90.0)
+print("isinstance(op, ForwardModel):", isinstance(op, ForwardModel))
+print("wrapped model:", type(op.model).__name__)
+
+
+# %% [markdown]
+# ## 4. Flat-config models round-trip through `pipekit.serial`
+#
+# A built model is an `eqx.Module` (grids, operators, term trees) — not JSON
+# primitives — so the general wrapper above is *not* serializable. Models
+# whose construction is a **flat primitive recipe** expose a dedicated
+# Operator (e.g. `Burgers2DOp`) whose config is all primitives, so
+# `dumps`/`loads` round-trips the build recipe faithfully.
+
+# %%
+burgers = Burgers2DOp(nx=32, ny=32, nu=0.05, dt=1e-3, imex=False)
+blob = dumps(burgers)
+print("serialized config:", blob)
+
+restored = loads(blob)
+print("round-trip matches:", restored.get_config() == burgers.get_config())
+
+
+# %% [markdown]
+# ## 5. Drive the model with `pipekit_cycle.Cycle`
+#
+# `Cycle` applies the step operator `n_steps` times, threading state and
+# (with `save_history=True`) collecting the trajectory. We seed a Gaussian
+# height bump and watch gravity waves radiate outward under rotation — a
+# geostrophic-adjustment problem. The gravity-wave *term* from step 1 is
+# exactly what drives this.
+
+# %%
+grid = model.grid
+x = jnp.arange(grid.Nx) * grid.dx
+y = jnp.arange(grid.Ny) * grid.dy
+X, Y = jnp.meshgrid(x, y)
+cx, cy = grid.Nx * grid.dx / 2, grid.Ny * grid.dy / 2
+sigma = grid.Nx * grid.dx / 12
+h0 = jnp.exp(-0.5 * (((X - cx) / sigma) ** 2 + ((Y - cy) / sigma) ** 2))
+state0 = LinearSW2DState(h=h0, u=jnp.zeros_like(h0), v=jnp.zeros_like(h0))
+
+cycle = Cycle(step_op=op, n_steps=120, save_history=True, history_stride=20)
+final_state, _ = cycle(state0, None)
+print("steps recorded in history:", len(cycle.history))
+
+
+# %%
+# Plot the initial bump and a few snapshots from the cycle history.
+snapshots = [(0, state0)] + [
+    (((i + 1) * cycle.history_stride), carrier)
+    for i, (carrier, _state) in enumerate(cycle.history[:3])
+]
+fig, axes = plt.subplots(1, len(snapshots), figsize=(4 * len(snapshots), 3.6))
+vmax = float(jnp.max(jnp.abs(h0)))
+for ax, (step, st) in zip(axes, snapshots, strict=True):
+    im = ax.pcolormesh(
+        X / 1e3, Y / 1e3, st.h, cmap="RdBu_r", vmin=-vmax, vmax=vmax, shading="auto"
+    )
+    ax.set_title(f"step {step}  (t = {step * op.dt / 3600:.1f} h)")
+    ax.set_xlabel("x [km]")
+    ax.set_aspect("equal")
+axes[0].set_ylabel("y [km]")
+fig.colorbar(im, ax=axes, shrink=0.8, label="height h [m]")
+plt.show()
+
+
+# %% [markdown]
+# ## 6. The `scenario x model` registry, end to end
+#
+# `SomaxModelOp.from_registry` builds *any* compatible scenario x model pair
+# through the dispatcher and hands back `(op, state0)` ready for `Cycle`.
+# This is the full "what we simulate (scenario) x how we simulate it
+# (model)" composition, wrapped as a pipekit Operator.
+
+# %%
+reg_op, reg_state0 = SomaxModelOp.from_registry(
+    "double_gyre",
+    "linear_swm",
+    dt=60.0,
+    scenario_params={"grid": {"nx": 16, "ny": 16}},
+    model_params={"params": {"lateral_viscosity": 100.0, "bottom_drag": 1e-6}},
+)
+reg_final, _ = Cycle(step_op=reg_op, n_steps=10)(reg_state0, None)
+print("built:", type(reg_op.model).__name__)
+print("forward-integrated 10 steps; finite:", bool(jnp.all(jnp.isfinite(reg_final.h))))
+
+# Operators compose like any pipekit stage — ``op | op`` is two steps.
+two_steps = (reg_op | reg_op)(reg_state0)
+print("op | op == two steps:", bool(jnp.all(jnp.isfinite(two_steps.h))))
+
+
+# %% [markdown]
+# ## Recap
+#
+# - **Terms** make a model's RHS a transparent sum of physics kernels, with
+#   IMEX tags (`gravity_wave + coriolis + nu*diffusion - kappa*drag`).
+# - **Operators** (`SomaxModelOp` / `Burgers2DOp`) expose a model as a
+#   pipekit stage + `ForwardModel`; flat-recipe models also `serial`
+#   round-trip.
+# - **Cycles** drive the stepping loop and collect trajectories.
+#
+# The same three seams power the somax-sim runner (which drives its chunked
+# integration with `Cycle`) and let somax models plug into data-assimilation
+# libraries (vardax, filterax) by satisfying `ForwardModel` structurally.

--- a/content/tutorials/composable_models_terms_operators_cycles.py
+++ b/content/tutorials/composable_models_terms_operators_cycles.py
@@ -27,8 +27,8 @@
 # 3. **Cycles** — driving the stepping loop with `pipekit_cycle.Cycle`,
 #    threading state and collecting a trajectory.
 #
-# Everything here needs the `sim` dependency group (`uv sync --group sim`),
-# which carries pipekit.
+# The Operator/Cycle parts use pipekit, which is a base somax dependency
+# (somax's *core* still never imports it — conformance is structural).
 # somax's *core* never imports pipekit — models satisfy the protocols
 # structurally.
 

--- a/myst.yml
+++ b/myst.yml
@@ -16,6 +16,7 @@ project:
         - file: content/notes/quasigeostrophic
         - file: content/notes/qg_spinup_durations
         - file: content/notes/basin_data_sources
+        - file: content/notes/ecosystem_refactor_plan
     - title: Tutorials
       children:
         - file: content/tutorials/getting_started

--- a/myst.yml
+++ b/myst.yml
@@ -25,6 +25,7 @@ project:
         - file: content/tutorials/lorenz96t_simulation
         - file: content/tutorials/swm_simulation
         - file: content/tutorials/qg_simulation
+        - file: content/tutorials/composable_models_terms_operators_cycles
     - title: "13 Steps to Navier-Stokes"
       children:
         - file: content/tutorials/step01_linear_convection_1d

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "einops>=0.8.2",
     "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.41",
     "spectraldiffx>=0.0.10",
+    "pipekit",
+    "pipekit-cycle",
 ]
 
 [project.urls]
@@ -63,8 +65,6 @@ sim = [
     "pyyaml>=6.0.3",
     "dvc>=3.67.1",
     "loguru>=0.7.3",
-    "pipekit",
-    "pipekit-cycle",
 ]
 docs = [
     "mkdocs>=1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "lineax>=0.1.0",
     "einops>=0.8.2",
     "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.41",
-    "spectraldiffx>=0.0.12",
+    "spectraldiffx>=0.0.10",
 ]
 
 [project.urls]
@@ -85,7 +85,11 @@ allow-direct-references = true
 packages = ["somax"]
 
 [tool.uv.sources]
-spectraldiffx = { git = "https://github.com/jejjohnson/spectraldiffx.git", tag = "0.0.12" }
+# Pinned to v0.0.10 to match finitevolx v0.0.41's own spectraldiffx pin —
+# uv requires a single git ref per package across the dependency graph,
+# so this must agree with finitevolx (a 0.0.12 pin conflicts and fails to
+# resolve).
+spectraldiffx = { git = "https://github.com/jejjohnson/spectraldiffx.git", tag = "v0.0.10" }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
     "diffrax>=0.7.2",
     "lineax>=0.1.0",
     "einops>=0.8.2",
-    "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.40",
-    "spectraldiffx>=0.0.10",
+    "finitevolx @ git+https://github.com/jejjohnson/finitevolX.git@v0.0.41",
+    "spectraldiffx>=0.0.12",
 ]
 
 [project.urls]
@@ -85,7 +85,7 @@ allow-direct-references = true
 packages = ["somax"]
 
 [tool.uv.sources]
-spectraldiffx = { git = "https://github.com/jejjohnson/spectraldiffx.git", tag = "v0.0.10" }
+spectraldiffx = { git = "https://github.com/jejjohnson/spectraldiffx.git", tag = "0.0.12" }
 
 [tool.ruff]
 target-version = "py312"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,18 @@ testpaths = ["tests"]
 addopts = "--cov=somax --cov-report=term-missing --cov-report=xml:coverage.xml"
 filterwarnings = ["error", "ignore::DeprecationWarning"]
 xfail_strict = true
+markers = [
+    # Full-pipeline tests that exercise the somax-sim runner end to end
+    # (CLI orchestration, crash-recovery checkpointing, spinup/restart
+    # chains). Auto-applied to tests/test_cli_*.py by tests/conftest.py.
+    "integration: end-to-end pipeline tests (slower, not pure unit tests)",
+    # Heavy tests dominated by JIT-compiled differentiation or long
+    # integrations (e.g. ``test_grad_through_*``). Excluded from the PR
+    # CI job via ``-m 'not slow'``; run in the manual full-suite
+    # workflow. Auto-applied by tests/conftest.py; all ``integration``
+    # tests are also marked ``slow``.
+    "slow: heavy correctness/integration tests excluded from PR CI",
+]
 
 [tool.coverage.run]
 source = ["somax"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ sim = [
     "pyyaml>=6.0.3",
     "dvc>=3.67.1",
     "loguru>=0.7.3",
+    "pipekit",
+    "pipekit-cycle",
 ]
 docs = [
     "mkdocs>=1.6",
@@ -90,6 +92,10 @@ packages = ["somax"]
 # so this must agree with finitevolx (a 0.0.12 pin conflicts and fails to
 # resolve).
 spectraldiffx = { git = "https://github.com/jejjohnson/spectraldiffx.git", tag = "v0.0.10" }
+# pipekit is a uv workspace; consume its subpackages from git subdirectories.
+# Both come from the same repo, so a single ref keeps them in lockstep.
+pipekit = { git = "https://github.com/jejjohnson/pipekit.git", subdirectory = "packages/pipekit" }
+pipekit-cycle = { git = "https://github.com/jejjohnson/pipekit.git", subdirectory = "packages/pipekit-cycle" }
 
 [tool.ruff]
 target-version = "py312"

--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -22,6 +22,8 @@ import diffrax as dfx
 import jax.numpy as jnp
 import numpy as np
 from loguru import logger
+from pipekit import StatefulOperator
+from pipekit_cycle import Cycle
 
 from somax import io
 from somax._src.cli import _assertions
@@ -599,6 +601,200 @@ def _build_diagnostic_grid(
     return diag_ts, save_indices
 
 
+@dataclasses.dataclass(frozen=True)
+class _ChunkCarry:
+    """Carry-state threaded through the chunked integration `Cycle`.
+
+    Args:
+        index: Next diagnostic-chunk index to integrate (0-based).
+        prev_energy: Total-energy-like scalar from the previous chunk,
+            used to flag >10x growth before a NaN appears. ``None`` until
+            the first chunk produces one.
+        snapshot_ordinal: Count of snapshots retained so far, excluding
+            the initial state (matches ``len(save_states) - 1`` in the
+            original loop — the cadence key for crash-recovery
+            checkpoints).
+        save_states: Snapshot states retained so far, starting with the
+            initial state. Stacked into the returned trajectory.
+    """
+
+    index: int
+    prev_energy: float | None
+    snapshot_ordinal: int
+    save_states: tuple[Any, ...]
+
+
+class _ChunkStep(StatefulOperator):
+    """One diagnostic chunk of the integration as a ``StatefulOperator``.
+
+    ``_apply(state, carry)`` integrates ``model`` from one diagnostic time
+    to the next, logs physical + state diagnostics, aborts on a non-finite
+    state, retains the state when the chunk endpoint is a snapshot
+    boundary, and writes a crash-recovery checkpoint when due — i.e. the
+    body of the original chunked loop, with the per-iteration accumulators
+    moved into :class:`_ChunkCarry`. Holds runtime-only references
+    (model, run log), so it is excluded from config serialization.
+    """
+
+    __config_mixin_auto__ = False
+    forbid_in_yaml = True
+
+    def __init__(
+        self,
+        *,
+        model: Any,
+        state_class: type,
+        dt: float,
+        diag_ts: np.ndarray,
+        save_indices: set[int],
+        n_diag_intervals: int,
+        max_steps_per_chunk: int,
+        run_log: RunLogContext,
+        mode: str,
+        checkpoint_every_n_chunks: int,
+        checkpoint_dir: Path | None,
+        checkpoint_label: str | None,
+    ) -> None:
+        self.model = model
+        self.state_class = state_class
+        self.dt = dt
+        self.diag_ts = diag_ts
+        self.save_indices = save_indices
+        self.n_diag_intervals = n_diag_intervals
+        self.max_steps_per_chunk = max_steps_per_chunk
+        self.run_log = run_log
+        self.mode = mode
+        self.checkpoint_every_n_chunks = checkpoint_every_n_chunks
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_label = checkpoint_label
+
+    def _apply(self, state: Any, carry: _ChunkCarry) -> tuple[Any, _ChunkCarry]:
+        log = self.run_log.log
+        i = carry.index
+        chunk_t0 = float(self.diag_ts[i])
+        chunk_t1 = float(self.diag_ts[i + 1])
+
+        t_chunk_start = time.perf_counter()
+        sol = self.model.integrate(
+            state,
+            chunk_t0,
+            chunk_t1,
+            self.dt,
+            saveat=dfx.SaveAt(t1=True),
+            max_steps=self.max_steps_per_chunk,
+        )
+        chunk_wall = time.perf_counter() - t_chunk_start
+
+        new_state = _extract_final_state(sol.ys, self.state_class)
+        state_diag = _state_diagnostics(new_state)
+        phys_line, phys_flat = _format_physical_scalars(self.model, new_state)
+
+        # Detect large energy jumps (10x growth between chunks is suspicious)
+        # to give the user an early warning before NaN appears.
+        energy_value: float | None = None
+        for k in (
+            "total_energy",
+            "energy",
+            "total_kinetic_energy",
+            "kinetic_energy",
+        ):
+            if k in phys_flat:
+                energy_value = float(phys_flat[k])
+                break
+        warning = ""
+        prev_energy = carry.prev_energy
+        if (
+            prev_energy is not None
+            and energy_value is not None
+            and abs(prev_energy) > 0
+            and not np.isnan(energy_value)
+            and abs(energy_value) > 10 * abs(prev_energy)
+        ):
+            # Both branches inside this block know prev_energy and
+            # energy_value are non-None floats; help ty narrow the types.
+            prev_e: float = prev_energy
+            cur_e: float = energy_value
+            growth = cur_e / prev_e if prev_e != 0 else float("inf")
+            warning = f" !! energy grew {growth:.1f}x from previous chunk"
+        new_prev_energy = prev_energy
+        if energy_value is not None and not np.isnan(energy_value):
+            new_prev_energy = energy_value
+
+        log.debug(
+            f"chunk {i + 1}/{self.n_diag_intervals} "
+            f"sim_t={format_time_seconds(chunk_t1)} | "
+            f"{_format_state_stats(state_diag)}"
+            + (f" | physics: {phys_line}" if phys_line else "")
+            + f" | wall={format_wallclock(chunk_wall)}"
+            + warning
+        )
+
+        if _has_non_finite(state_diag):
+            log.debug(
+                f"ABORT at chunk {i + 1}/{self.n_diag_intervals}: non-finite state"
+            )
+            raise IntegrationDivergedError(
+                f"somax-sim {self.mode} integration produced non-finite values "
+                f"during chunk {i + 1}/{self.n_diag_intervals} "
+                f"(sim_t={format_time_seconds(chunk_t1)}).\n"
+                f"  {_format_state_stats(state_diag)}\n"
+                f"  Refusing to write artifacts. The non-finite values "
+                f"appeared between sim_t={format_time_seconds(chunk_t0)} and "
+                f"sim_t={format_time_seconds(chunk_t1)} — earlier chunks were "
+                f"finite. This is consistent with a slow numerical instability, "
+                f"not an immediate CFL violation."
+            )
+
+        # Only retain states at snapshot boundaries.
+        is_snapshot_boundary = (i + 1) in self.save_indices
+        new_save_states = carry.save_states + (
+            (new_state,) if is_snapshot_boundary else ()
+        )
+        new_ordinal = carry.snapshot_ordinal + (1 if is_snapshot_boundary else 0)
+
+        # Crash-recovery checkpoint (#70): write the current state to a
+        # rolling ``checkpoint.zarr`` every N snapshot-aligned chunk
+        # endpoints. Aligning to snapshot boundaries keeps the on-disk
+        # checkpoint consistent with the saved snapshots up to that
+        # point. We write AFTER the non-finite guard so a bad state
+        # never lands on disk.
+        if (
+            self.checkpoint_every_n_chunks > 0
+            and self.checkpoint_dir is not None
+            and is_snapshot_boundary
+        ):
+            # ``new_ordinal`` == len(save_states) - 1 after the append.
+            snapshot_ordinal = new_ordinal
+            due = (
+                snapshot_ordinal > 0
+                and snapshot_ordinal % self.checkpoint_every_n_chunks == 0
+            )
+            if due:
+                ckpt_path = Path(self.checkpoint_dir) / "checkpoint.zarr"
+                ckpt_attrs: dict[str, Any] = {
+                    "somax_sim_t": float(chunk_t1),
+                    "somax_snapshot_ordinal": int(snapshot_ordinal),
+                }
+                if self.checkpoint_label:
+                    ckpt_attrs["somax_checkpoint_of"] = str(self.checkpoint_label)
+                ckpt_ds = io.state_to_dataset(
+                    new_state, time=float(chunk_t1), attrs=ckpt_attrs
+                )
+                io.save_dataset(ckpt_ds, ckpt_path, mode="w")
+                log.debug(
+                    f"checkpoint written at snapshot {snapshot_ordinal} "
+                    f"(sim_t={format_time_seconds(chunk_t1)}) → {ckpt_path.name}"
+                )
+
+        new_carry = _ChunkCarry(
+            index=i + 1,
+            prev_energy=new_prev_energy,
+            snapshot_ordinal=new_ordinal,
+            save_states=new_save_states,
+        )
+        return new_state, new_carry
+
+
 def _chunked_integrate_with_diagnostics(
     model: Any,
     state0: Any,
@@ -658,6 +854,14 @@ def _chunked_integrate_with_diagnostics(
 
     Raises:
         IntegrationDivergedError: If any chunk produces non-finite state.
+
+    The chunk-by-chunk loop is driven by :class:`pipekit_cycle.Cycle`: the
+    body lives in :class:`_ChunkStep` (a ``StatefulOperator``) and the
+    snapshot list / energy tracker / checkpoint bookkeeping are threaded
+    through an immutable :class:`_ChunkCarry`. Observability (diagnostic
+    logging, the non-finite abort, crash-recovery checkpoints) runs inside
+    the step operator — pipekit's per-step hook dispatch is a reserved
+    no-op today, so the step is the place those side effects live.
     """
     from types import SimpleNamespace
 
@@ -678,125 +882,30 @@ def _chunked_integrate_with_diagnostics(
         + " | initial state"
     )
 
-    state = state0
-    save_states: list[Any] = [state0]
+    step = _ChunkStep(
+        model=model,
+        state_class=type(state0),
+        dt=dt,
+        diag_ts=diag_ts,
+        save_indices=save_indices,
+        n_diag_intervals=n_diag_intervals,
+        max_steps_per_chunk=max_steps_per_chunk,
+        run_log=run_log,
+        mode=mode,
+        checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+        checkpoint_dir=checkpoint_dir,
+        checkpoint_label=checkpoint_label,
+    )
+    carry0 = _ChunkCarry(
+        index=0,
+        prev_energy=None,
+        snapshot_ordinal=0,
+        save_states=(state0,),
+    )
+    cycle = Cycle(step_op=step, n_steps=n_diag_intervals)
+
     t_chunks_start = time.perf_counter()
-
-    # Track previous total-energy-like scalar across chunks so we can
-    # surface large jumps as a "growth" warning even before NaN appears.
-    prev_energy: float | None = None
-
-    for i in range(n_diag_intervals):
-        chunk_t0 = float(diag_ts[i])
-        chunk_t1 = float(diag_ts[i + 1])
-
-        t_chunk_start = time.perf_counter()
-        sol = model.integrate(
-            state,
-            chunk_t0,
-            chunk_t1,
-            dt,
-            saveat=dfx.SaveAt(t1=True),
-            max_steps=max_steps_per_chunk,
-        )
-        chunk_wall = time.perf_counter() - t_chunk_start
-
-        new_state = _extract_final_state(sol.ys, type(state0))
-        state_diag = _state_diagnostics(new_state)
-        phys_line, phys_flat = _format_physical_scalars(model, new_state)
-
-        # Detect large energy jumps (10x growth between chunks is suspicious)
-        # to give the user an early warning before NaN appears.
-        energy_value: float | None = None
-        for k in (
-            "total_energy",
-            "energy",
-            "total_kinetic_energy",
-            "kinetic_energy",
-        ):
-            if k in phys_flat:
-                energy_value = float(phys_flat[k])
-                break
-        warning = ""
-        if (
-            prev_energy is not None
-            and energy_value is not None
-            and abs(prev_energy) > 0
-            and not np.isnan(energy_value)
-            and abs(energy_value) > 10 * abs(prev_energy)
-        ):
-            # Both branches inside this block know prev_energy and
-            # energy_value are non-None floats; help ty narrow the types.
-            prev_e: float = prev_energy
-            cur_e: float = energy_value
-            growth = cur_e / prev_e if prev_e != 0 else float("inf")
-            warning = f" !! energy grew {growth:.1f}x from previous chunk"
-        if energy_value is not None and not np.isnan(energy_value):
-            prev_energy = energy_value
-
-        log.debug(
-            f"chunk {i + 1}/{n_diag_intervals} "
-            f"sim_t={format_time_seconds(chunk_t1)} | "
-            f"{_format_state_stats(state_diag)}"
-            + (f" | physics: {phys_line}" if phys_line else "")
-            + f" | wall={format_wallclock(chunk_wall)}"
-            + warning
-        )
-
-        if _has_non_finite(state_diag):
-            log.debug(f"ABORT at chunk {i + 1}/{n_diag_intervals}: non-finite state")
-            raise IntegrationDivergedError(
-                f"somax-sim {mode} integration produced non-finite values "
-                f"during chunk {i + 1}/{n_diag_intervals} "
-                f"(sim_t={format_time_seconds(chunk_t1)}).\n"
-                f"  {_format_state_stats(state_diag)}\n"
-                f"  Refusing to write artifacts. The non-finite values "
-                f"appeared between sim_t={format_time_seconds(chunk_t0)} and "
-                f"sim_t={format_time_seconds(chunk_t1)} — earlier chunks were "
-                f"finite. This is consistent with a slow numerical instability, "
-                f"not an immediate CFL violation."
-            )
-
-        # Only retain states at snapshot boundaries.
-        is_snapshot_boundary = (i + 1) in save_indices
-        if is_snapshot_boundary:
-            save_states.append(new_state)
-
-        # Crash-recovery checkpoint (#70): write the current state to a
-        # rolling ``checkpoint.zarr`` every N snapshot-aligned chunk
-        # endpoints. Aligning to snapshot boundaries keeps the on-disk
-        # checkpoint consistent with the saved snapshots up to that
-        # point. We write AFTER the non-finite guard so a bad state
-        # never lands on disk.
-        if (
-            checkpoint_every_n_chunks > 0
-            and checkpoint_dir is not None
-            and is_snapshot_boundary
-        ):
-            snapshot_ordinal = len(save_states) - 1  # 1-based: first == index 1
-            due = (
-                snapshot_ordinal > 0
-                and snapshot_ordinal % checkpoint_every_n_chunks == 0
-            )
-            if due:
-                ckpt_path = Path(checkpoint_dir) / "checkpoint.zarr"
-                ckpt_attrs: dict[str, Any] = {
-                    "somax_sim_t": float(chunk_t1),
-                    "somax_snapshot_ordinal": int(snapshot_ordinal),
-                }
-                if checkpoint_label:
-                    ckpt_attrs["somax_checkpoint_of"] = str(checkpoint_label)
-                ckpt_ds = io.state_to_dataset(
-                    new_state, time=float(chunk_t1), attrs=ckpt_attrs
-                )
-                io.save_dataset(ckpt_ds, ckpt_path, mode="w")
-                log.debug(
-                    f"checkpoint written at snapshot {snapshot_ordinal} "
-                    f"(sim_t={format_time_seconds(chunk_t1)}) → {ckpt_path.name}"
-                )
-
-        state = new_state
-
+    _final_state, final_carry = cycle(state0, carry0)
     total_chunks_wall = time.perf_counter() - t_chunks_start
     log.debug(
         f"all {n_diag_intervals} chunks completed in "
@@ -806,7 +915,9 @@ def _chunked_integrate_with_diagnostics(
     # Concatenate snapshot states into a single time-stacked pytree
     # matching the shape diffrax would have returned with
     # ``SaveAt(ts=save_ts)``.
-    stacked = jax.tree_util.tree_map(lambda *xs: jnp.stack(xs, axis=0), *save_states)
+    stacked = jax.tree_util.tree_map(
+        lambda *xs: jnp.stack(xs, axis=0), *final_carry.save_states
+    )
     return SimpleNamespace(ys=stacked, stats={})
 
 

--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -615,13 +615,17 @@ class _ChunkCarry:
             original loop — the cadence key for crash-recovery
             checkpoints).
         save_states: Snapshot states retained so far, starting with the
-            initial state. Stacked into the returned trajectory.
+            initial state. Stacked into the returned trajectory. A
+            ``list`` appended **in place** at snapshot boundaries — the
+            frozen dataclass only forbids rebinding the field, not
+            mutating the list it points to, so accumulation stays
+            amortized O(1) per snapshot (a tuple would be O(N²)).
     """
 
     index: int
     prev_energy: float | None
     snapshot_ordinal: int
-    save_states: tuple[Any, ...]
+    save_states: list[Any]
 
 
 class _ChunkStep(StatefulOperator):
@@ -745,11 +749,13 @@ class _ChunkStep(StatefulOperator):
                 f"not an immediate CFL violation."
             )
 
-        # Only retain states at snapshot boundaries.
+        # Only retain states at snapshot boundaries. Append in place to the
+        # threaded list (amortized O(1)); the same list object flows through
+        # every carry, so the final carry holds the full trajectory.
         is_snapshot_boundary = (i + 1) in self.save_indices
-        new_save_states = carry.save_states + (
-            (new_state,) if is_snapshot_boundary else ()
-        )
+        new_save_states = carry.save_states
+        if is_snapshot_boundary:
+            new_save_states.append(new_state)
         new_ordinal = carry.snapshot_ordinal + (1 if is_snapshot_boundary else 0)
 
         # Crash-recovery checkpoint (#70): write the current state to a
@@ -900,7 +906,7 @@ def _chunked_integrate_with_diagnostics(
         index=0,
         prev_energy=None,
         snapshot_ordinal=0,
-        save_states=(state0,),
+        save_states=[state0],
     )
     cycle = Cycle(step_op=step, n_steps=n_diag_intervals)
 

--- a/somax/_src/core/model.py
+++ b/somax/_src/core/model.py
@@ -6,6 +6,7 @@ import abc
 
 import diffrax as dfx
 import equinox as eqx
+import jax.tree_util as jtu
 from jaxtyping import PyTree
 
 
@@ -86,6 +87,53 @@ class SomaxModel(eqx.Module):
             stepsize_controller=stepsize_controller,
             **kw,
         )
+
+    def step(
+        self,
+        state: PyTree,
+        dt: float,
+        *,
+        t0: float = 0.0,
+        **kw,
+    ) -> PyTree:
+        """Advance ``state`` by one increment ``dt`` and return the new state.
+
+        This single-step interface is what makes every somax model
+        structurally satisfy the :class:`pipekit_cycle.ForwardModel`
+        protocol (``step(state, dt) -> state``). Satisfaction is purely
+        structural — somax does not import pipekit — so a model can be
+        driven by the ``pipekit_cycle.Cycle`` runner and supplied as the
+        forward model to data-assimilation libraries (vardax, filterax)
+        without any subclassing.
+
+        Unlike :meth:`integrate`, which returns a diffrax ``Solution``
+        carrying a leading time axis, ``step`` returns a bare state
+        pytree with the same structure as ``state``.
+
+        Args:
+            state: Current state pytree.
+            dt: Increment to advance by. Used as both the integration
+                window (``t0 -> t0 + dt``) and the initial solver step.
+            t0: Absolute start time of the step. Autonomous models can
+                ignore it; models with time-dependent forcing should
+                thread it through. Defaults to ``0.0``.
+            **kw: Forwarded to :meth:`integrate` (e.g. ``solver``,
+                ``stepsize_controller``).
+
+        Returns:
+            The state advanced to ``t0 + dt``.
+        """
+        sol = self.integrate(
+            state,
+            t0=t0,
+            t1=t0 + dt,
+            dt=dt,
+            saveat=dfx.SaveAt(t1=True),
+            **kw,
+        )
+        # ``SaveAt(t1=True)`` stacks a length-1 leading time axis onto
+        # every leaf; drop it to recover a bare state pytree.
+        return jtu.tree_map(lambda leaf: leaf[-1], sol.ys)
 
     def diagnose(self, state: PyTree) -> PyTree:
         """Compute on-demand diagnostics from state.

--- a/somax/_src/core/model.py
+++ b/somax/_src/core/model.py
@@ -103,13 +103,16 @@ class SomaxModel(eqx.Module):
     ) -> PyTree:
         """Advance ``state`` by one increment ``dt`` and return the new state.
 
-        This single-step interface is what makes every somax model
-        structurally satisfy the :class:`pipekit_cycle.ForwardModel`
-        protocol (``step(state, dt) -> state``). Satisfaction is purely
-        structural — somax does not import pipekit — so a model can be
-        driven by the ``pipekit_cycle.Cycle`` runner and supplied as the
-        forward model to data-assimilation libraries (vardax, filterax)
-        without any subclassing.
+        This is the stepping primitive of the
+        :class:`pipekit_cycle.ForwardModel` contract. A model supplies
+        ``step`` and :attr:`state_signature` directly; the third protocol
+        member — a default ``dt`` — is an adapter concern (a bare model
+        has no inherent step size), so full ``ForwardModel`` conformance
+        is provided by the :mod:`somax.operators` Operator wrapper, which
+        carries ``dt`` alongside the model. None of this imports pipekit:
+        the model is usable by ``pipekit_cycle.Cycle`` and by
+        data-assimilation libraries (vardax, filterax) purely
+        structurally.
 
         Unlike :meth:`integrate`, which returns a diffrax ``Solution``
         carrying a leading time axis, ``step`` returns a bare state
@@ -146,6 +149,18 @@ class SomaxModel(eqx.Module):
         Override to return a ``Diagnostics`` instance.
         """
         return {}
+
+    @property
+    def state_signature(self) -> None:
+        """No named-dimension signature — somax states are bare pytrees.
+
+        Part of the :class:`pipekit_cycle.ForwardModel` contract (``step``,
+        ``dt``, ``state_signature``). ``None`` means the model does not
+        advertise a shape/dtype signature; structural, no pipekit import.
+        Override to return a ``pipekit.Signature`` if a model tracks named
+        dimensions.
+        """
+        return None
 
 
 class TermModel(SomaxModel):

--- a/somax/_src/core/model.py
+++ b/somax/_src/core/model.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import abc
+from typing import TYPE_CHECKING
 
 import diffrax as dfx
 import equinox as eqx
 import jax.tree_util as jtu
 from jaxtyping import PyTree
+
+
+if TYPE_CHECKING:
+    from somax._src.core.terms import Term
 
 
 class SomaxModel(eqx.Module):
@@ -141,3 +146,52 @@ class SomaxModel(eqx.Module):
         Override to return a ``Diagnostics`` instance.
         """
         return {}
+
+
+class TermModel(SomaxModel):
+    """A :class:`SomaxModel` whose RHS is an assembled :class:`Term` tree.
+
+    Instead of hand-writing ``vector_field``, a ``TermModel`` carries a
+    composed term (a :class:`~somax._src.core.terms.Sum` of physics
+    contributions). ``vector_field`` evaluates the tree, and
+    ``build_terms`` delegates to
+    :func:`~somax._src.core.terms.build_diffrax_terms`, which returns a
+    :class:`diffrax.MultiTerm` when the tree mixes explicit and implicit
+    summands — so an IMEX solver can route each physics term through the
+    appropriate stage.
+
+    Subclasses still own ``apply_boundary_conditions``. The base
+    implementation here is a pass-through; override it to enforce BCs.
+
+    Args:
+        terms: The assembled right-hand-side term tree.
+
+    Example:
+        >>> rhs = AdvectionTerm(grid) + diffusivity * DiffusionTerm(grid)
+        >>> model = MyTermModel(terms=rhs)
+        >>> sol = model.integrate(state0, t0=0.0, t1=1.0, dt=0.01)
+    """
+
+    terms: Term
+
+    def vector_field(
+        self, t: float, state: PyTree, args: PyTree | None = None
+    ) -> PyTree:
+        """Evaluate the assembled term tree at ``(t, state, args)``."""
+        return self.terms(t, state, args)
+
+    def apply_boundary_conditions(self, state: PyTree) -> PyTree:
+        """Pass-through by default; override to enforce boundary conditions."""
+        return state
+
+    def build_terms(self) -> dfx.AbstractTerm:
+        """Build IMEX-aware diffrax terms from the term tree.
+
+        Boundary conditions are applied before each term-tree evaluation,
+        mirroring :meth:`SomaxModel.build_terms`. The explicit / implicit
+        split (when present) is preserved so an IMEX solver integrates
+        each part with the appropriate stage.
+        """
+        from somax._src.core.terms import build_diffrax_terms
+
+        return build_diffrax_terms(self.terms, state_fn=self.apply_boundary_conditions)

--- a/somax/_src/core/terms.py
+++ b/somax/_src/core/terms.py
@@ -1,0 +1,411 @@
+"""Composable term algebra for somax model right-hand sides.
+
+A PDE right-hand side is additive::
+
+    d(state)/dt = advection(state) + diffusion(state) + coriolis(state) + forcing(t)
+
+This module makes that decomposition first-class. Each additive
+contribution is a :class:`Term` — an ``eqx.Module`` mapping
+``(t, state, args) -> tendency`` (a pytree with the same structure as
+``state``). Terms form a small closed algebra:
+
+- ``a + b``            → :class:`Sum`     (additive composition)
+- ``c * a`` / ``a * c``→ :class:`Scaled`  (scalar coefficient; differentiable)
+- ``-a`` / ``a - b``   → sugar over ``Scaled`` / ``Sum``
+- ``a @ b``            → :class:`Compose` (operator composition: ``a(b(state))``)
+
+Terms are the somax-internal protocol; the *assembled* term tree is what
+a :class:`~somax._src.core.model.SomaxModel` evaluates in its
+``vector_field``, so the composed object satisfies the
+``pipekit_cycle.ForwardModel`` protocol (via ``SomaxModel.step``) without
+the algebra itself importing pipekit.
+
+IMEX / operator splitting
+-------------------------
+Every term carries a ``kind`` label — ``"explicit"`` (default) or
+``"implicit"``. Use :func:`implicit` / :func:`explicit` to tag a term.
+:func:`partition` flattens a (possibly nested) :class:`Sum` and groups
+its summands by kind, and :func:`build_diffrax_terms` assembles the
+appropriate diffrax term object:
+
+- a single :class:`diffrax.ODETerm` when every summand shares a kind, or
+- a :class:`diffrax.MultiTerm` of (explicit, implicit) ``ODETerm`` s,
+
+which an IMEX solver (``diffrax.KenCarp3``, ``diffrax.Sil3``, …) can
+integrate by routing the stiff implicit part through its implicit stage.
+This is the seam that lets a model "mix and match which time stepper
+handles which term".
+
+The coefficients on :class:`Scaled` are ordinary JAX leaves, so a term
+tree is differentiable end-to-end — ``jax.grad`` of a loss with respect
+to a diffusion coefficient flows straight through ``Scaled.coeff``.
+"""
+
+from __future__ import annotations
+
+import abc
+from collections.abc import Callable, Iterator
+
+import diffrax as dfx
+import equinox as eqx
+import jax.tree_util as jtu
+from jaxtyping import PyTree
+
+
+Kind = str  # "explicit" | "implicit"
+
+EXPLICIT: Kind = "explicit"
+IMPLICIT: Kind = "implicit"
+MIXED: Kind = "mixed"
+
+
+class Term(eqx.Module):
+    """A single additive contribution to a model right-hand side.
+
+    Subclasses implement :meth:`__call__` with the signature
+    ``(t, state, args=None) -> tendency`` where ``tendency`` is a pytree
+    matching the structure of ``state``.
+
+    Terms compose via the arithmetic operators (:meth:`__add__`,
+    :meth:`__mul__`, :meth:`__sub__`, :meth:`__neg__`, :meth:`__matmul__`).
+    The :attr:`kind` property drives IMEX partitioning; leaf terms are
+    ``"explicit"`` by default — wrap with :func:`implicit` to mark a term
+    for the implicit stage of a splitting integrator.
+    """
+
+    @abc.abstractmethod
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        """Return this term's contribution to the tendency at time ``t``."""
+        ...
+
+    # -- IMEX label ----------------------------------------------------
+
+    @property
+    def kind(self) -> Kind:
+        """Integration kind for IMEX splitting (``"explicit"`` by default)."""
+        return EXPLICIT
+
+    # -- algebra -------------------------------------------------------
+
+    def __add__(self, other: Term) -> Term:
+        if other is _ZERO:
+            return self
+        return Sum.of(self, other)
+
+    def __radd__(self, other: Term) -> Term:
+        # Enables ``sum(terms)`` which seeds with the int 0.
+        if other == 0 or other is _ZERO:
+            return self
+        return Sum.of(other, self)
+
+    def __mul__(self, coeff: float) -> Term:
+        return Scaled(self, coeff)
+
+    def __rmul__(self, coeff: float) -> Term:
+        return Scaled(self, coeff)
+
+    def __neg__(self) -> Term:
+        return Scaled(self, -1.0)
+
+    def __sub__(self, other: Term) -> Term:
+        return Sum.of(self, Scaled(other, -1.0))
+
+    def __matmul__(self, inner: Term) -> Term:
+        """Operator composition: ``(self @ inner)(state) == self(inner(state))``."""
+        return Compose(self, inner)
+
+
+class TermFn(Term):
+    """Adapt a plain callable into a :class:`Term`.
+
+    Useful for wrapping an existing model's per-physics function, or for
+    quick composition in tests. The callable must accept
+    ``(t, state, args)`` and return a tendency pytree.
+
+    Args:
+        fn: The vector-field callable.
+        kind: IMEX label for the wrapped function. Defaults to
+            ``"explicit"``.
+    """
+
+    fn: Callable[[float, PyTree, PyTree | None], PyTree]
+    _kind: Kind = eqx.field(static=True, default=EXPLICIT)
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        return self.fn(t, state, args)
+
+    @property
+    def kind(self) -> Kind:
+        return self._kind
+
+
+class Sum(Term):
+    """Additive composition of terms: ``sum_i terms[i](t, state, args)``.
+
+    Construct via the ``+`` operator or :meth:`of` (which flattens nested
+    sums so ``(a + b) + c`` and ``a + (b + c)`` yield the same flat tree).
+
+    Args:
+        terms: The summands. Leaves are added leaf-wise across the pytree.
+    """
+
+    terms: tuple[Term, ...]
+
+    @classmethod
+    def of(cls, *terms: Term) -> Term:
+        """Build a flattened :class:`Sum`, dropping :data:`_ZERO` summands.
+
+        Returns the lone term unchanged when only one survives, so the
+        algebra stays free of redundant single-element ``Sum`` nodes.
+        """
+        flat: list[Term] = []
+        for t in terms:
+            if t is _ZERO:
+                continue
+            if isinstance(t, Sum):
+                flat.extend(t.terms)
+            else:
+                flat.append(t)
+        if not flat:
+            return _ZERO
+        if len(flat) == 1:
+            return flat[0]
+        return cls(tuple(flat))
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        contributions = [term(t, state, args) for term in self.terms]
+        acc = contributions[0]
+        for contribution in contributions[1:]:
+            acc = jtu.tree_map(lambda a, b: a + b, acc, contribution)
+        return acc
+
+    @property
+    def kind(self) -> Kind:
+        kinds = {term.kind for term in self.terms}
+        if len(kinds) == 1:
+            return kinds.pop()
+        return MIXED
+
+
+class Scaled(Term):
+    """A term multiplied by a scalar coefficient.
+
+    The coefficient is an ordinary (non-static) field, so it is a JAX
+    leaf visible to ``jax.grad`` / ``jax.jit`` — coefficients can be
+    optimised or swept. Scaling delegates its :attr:`kind` to the inner
+    term.
+
+    Args:
+        term: The term to scale.
+        coeff: Scalar multiplier (may be a Python float or a JAX scalar).
+    """
+
+    term: Term
+    coeff: float
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        inner = self.term(t, state, args)
+        return jtu.tree_map(lambda leaf: self.coeff * leaf, inner)
+
+    @property
+    def kind(self) -> Kind:
+        return self.term.kind
+
+
+class Compose(Term):
+    """Operator composition: ``Compose(outer, inner)(state) = outer(inner(state))``.
+
+    This is the multiplicative ("product") side of the algebra, in the
+    operator-composition sense rather than a pointwise product —
+    e.g. a biharmonic operator is ``Compose(laplacian, laplacian)``.
+
+    The inner term's output is fed back in as the ``state`` argument of
+    the outer term (both must map a field to a like-shaped field). ``t``
+    and ``args`` are threaded through unchanged.
+
+    Args:
+        outer: Applied second (to the inner result).
+        inner: Applied first (to the incoming state).
+    """
+
+    outer: Term
+    inner: Term
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        return self.outer(t, self.inner(t, state, args), args)
+
+    @property
+    def kind(self) -> Kind:
+        # Composition is treated as a single atomic leaf for IMEX
+        # partitioning; if either factor is implicit the whole composite
+        # routes to the implicit stage.
+        if self.outer.kind == IMPLICIT or self.inner.kind == IMPLICIT:
+            return IMPLICIT
+        return EXPLICIT
+
+
+class _Zero(Term):
+    """The additive identity term (returns a zeros-like tendency).
+
+    Singleton; use the module-level :data:`_ZERO`. Adding it to any term
+    is a no-op, which keeps :meth:`Sum.of` and ``sum(...)`` clean.
+    """
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        return jtu.tree_map(lambda leaf: leaf * 0.0, state)
+
+
+_ZERO = _Zero()
+
+
+# ----------------------------------------------------------------------
+# IMEX tagging
+# ----------------------------------------------------------------------
+
+
+class _Kinded(Term):
+    """Wrap a term to override its IMEX :attr:`kind` label.
+
+    Produced by :func:`implicit` / :func:`explicit`. Evaluation is a
+    transparent pass-through to the wrapped term.
+    """
+
+    term: Term
+    _kind: Kind = eqx.field(static=True)
+
+    def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
+        return self.term(t, state, args)
+
+    @property
+    def kind(self) -> Kind:
+        return self._kind
+
+
+def implicit(term: Term) -> Term:
+    """Tag ``term`` for the implicit stage of an IMEX integrator."""
+    return _Kinded(term, IMPLICIT)
+
+
+def explicit(term: Term) -> Term:
+    """Tag ``term`` for the explicit stage of an IMEX integrator."""
+    return _Kinded(term, EXPLICIT)
+
+
+# ----------------------------------------------------------------------
+# Partitioning + diffrax bridge
+# ----------------------------------------------------------------------
+
+
+def _iter_summands(term: Term) -> Iterator[Term]:
+    """Yield the flat additive summands of ``term`` (recursing into Sum)."""
+    if isinstance(term, Sum):
+        for sub in term.terms:
+            yield from _iter_summands(sub)
+    else:
+        yield term
+
+
+def partition(term: Term) -> tuple[Term | None, Term | None]:
+    """Split ``term`` into ``(explicit, implicit)`` sub-terms by kind.
+
+    Flattens nested :class:`Sum` nodes and groups the summands by their
+    :attr:`Term.kind`. A non-Sum term is treated as a single summand.
+
+    Args:
+        term: The (possibly composite) term to split.
+
+    Returns:
+        ``(explicit_part, implicit_part)``. Either element is ``None``
+        when no summand of that kind is present.
+    """
+    explicit_terms: list[Term] = []
+    implicit_terms: list[Term] = []
+    for summand in _iter_summands(term):
+        if summand.kind == IMPLICIT:
+            implicit_terms.append(summand)
+        else:
+            explicit_terms.append(summand)
+
+    explicit_part = Sum.of(*explicit_terms) if explicit_terms else None
+    implicit_part = Sum.of(*implicit_terms) if implicit_terms else None
+    return explicit_part, implicit_part
+
+
+def _as_vector_field(
+    term: Term,
+    state_fn: Callable[[PyTree], PyTree] | None,
+) -> Callable[[float, PyTree, PyTree | None], PyTree]:
+    """Wrap a term as a diffrax-style ``f(t, y, args)`` vector field.
+
+    When ``state_fn`` is given it is applied to ``y`` before the term is
+    evaluated — used to enforce boundary conditions at every stage of
+    every (explicit / implicit) sub-term.
+    """
+    if state_fn is None:
+
+        def _vf(t, y, args=None):
+            return term(t, y, args)
+    else:
+
+        def _vf(t, y, args=None):
+            return term(t, state_fn(y), args)
+
+    return _vf
+
+
+def build_diffrax_terms(
+    term: Term,
+    *,
+    state_fn: Callable[[PyTree], PyTree] | None = None,
+) -> dfx.AbstractTerm:
+    """Build the diffrax term object for ``term``, IMEX-aware.
+
+    - If every summand shares a single kind, returns one
+      :class:`diffrax.ODETerm`.
+    - If the term mixes explicit and implicit summands, returns a
+      :class:`diffrax.MultiTerm` whose first element is the explicit
+      ``ODETerm`` and whose second is the implicit ``ODETerm`` — the
+      ordering expected by diffrax IMEX solvers
+      (``KenCarp3``/``KenCarp4``/``Sil3``/``KenCarp5``).
+
+    Args:
+        term: The assembled right-hand-side term.
+        state_fn: Optional state preprocessor applied to ``y`` before
+            each sub-term evaluation (e.g. boundary-condition
+            enforcement). Applied uniformly to the explicit and implicit
+            parts so both integrator stages see a BC-consistent state.
+
+    Returns:
+        A diffrax term suitable for ``diffrax.diffeqsolve``.
+
+    Raises:
+        ValueError: If ``term`` has no summands (e.g. the zero term).
+    """
+    explicit_part, implicit_part = partition(term)
+
+    if explicit_part is not None and implicit_part is not None:
+        return dfx.MultiTerm(
+            dfx.ODETerm(_as_vector_field(explicit_part, state_fn)),
+            dfx.ODETerm(_as_vector_field(implicit_part, state_fn)),
+        )
+    single = explicit_part if explicit_part is not None else implicit_part
+    if single is None:
+        raise ValueError("cannot build diffrax terms from an empty term")
+    return dfx.ODETerm(_as_vector_field(single, state_fn))
+
+
+__all__ = [
+    "EXPLICIT",
+    "IMPLICIT",
+    "MIXED",
+    "Compose",
+    "Kind",
+    "Scaled",
+    "Sum",
+    "Term",
+    "TermFn",
+    "build_diffrax_terms",
+    "explicit",
+    "implicit",
+    "partition",
+]

--- a/somax/_src/core/terms.py
+++ b/somax/_src/core/terms.py
@@ -49,7 +49,7 @@ from collections.abc import Callable, Iterator
 import diffrax as dfx
 import equinox as eqx
 import jax.tree_util as jtu
-from jaxtyping import PyTree
+from jaxtyping import Array, PyTree
 
 
 Kind = str  # "explicit" | "implicit"
@@ -98,10 +98,10 @@ class Term(eqx.Module):
             return self
         return Sum.of(other, self)
 
-    def __mul__(self, coeff: float) -> Term:
+    def __mul__(self, coeff: float | Array) -> Term:
         return Scaled(self, coeff)
 
-    def __rmul__(self, coeff: float) -> Term:
+    def __rmul__(self, coeff: float | Array) -> Term:
         return Scaled(self, coeff)
 
     def __neg__(self) -> Term:
@@ -201,7 +201,7 @@ class Scaled(Term):
     """
 
     term: Term
-    coeff: float
+    coeff: float | Array
 
     def __call__(self, t: float, state: PyTree, args: PyTree | None = None) -> PyTree:
         inner = self.term(t, state, args)

--- a/somax/_src/models/pde2d/__init__.py
+++ b/somax/_src/models/pde2d/__init__.py
@@ -4,6 +4,11 @@ from somax._src.models.pde2d.burgers import (
     Burgers2DParams,
     Burgers2DState,
 )
+from somax._src.models.pde2d.burgers_terms import (
+    Burgers2DAdvection,
+    Burgers2DDiffusion,
+    Burgers2DTermModel,
+)
 from somax._src.models.pde2d.diffusion import (
     Diffusion2D,
     Diffusion2DDiagnostics,
@@ -36,9 +41,12 @@ from somax._src.models.pde2d.poisson import (
 
 __all__ = [
     "Burgers2D",
+    "Burgers2DAdvection",
     "Burgers2DDiagnostics",
+    "Burgers2DDiffusion",
     "Burgers2DParams",
     "Burgers2DState",
+    "Burgers2DTermModel",
     "Diffusion2D",
     "Diffusion2DDiagnostics",
     "Diffusion2DParams",

--- a/somax/_src/models/pde2d/burgers_terms.py
+++ b/somax/_src/models/pde2d/burgers_terms.py
@@ -1,0 +1,244 @@
+"""2D Burgers equation expressed as a composable :class:`Term` algebra.
+
+This is the worked example for the term-kernel decomposition (the
+pipekit-refactor "Level 3" idea). The canonical :class:`Burgers2D`
+hand-writes its right-hand side as one ``vector_field`` method::
+
+    du/dt = -advection(u, v) + nu * laplacian(u)        (and likewise v)
+
+Here the same physics is split into two reusable kernels —
+:class:`Burgers2DAdvection` and :class:`Burgers2DDiffusion` — that
+compose into the RHS::
+
+    rhs = advection + nu * diffusion
+
+Both kernels are :class:`~somax._src.core.terms.Term` instances, so the
+assembled tree is differentiable end to end (the viscosity ``nu`` enters
+as a :class:`~somax._src.core.terms.Scaled` coefficient, a JAX leaf) and
+the assembled :class:`Burgers2DTermModel` still satisfies the somax model
+contract (and hence ``pipekit_cycle.ForwardModel`` via ``step``).
+
+The kernels are *integration-strategy neutral*: the same advection and
+diffusion terms can be summed for a fully-explicit solve, or the
+diffusion term can be tagged :func:`~somax._src.core.terms.implicit` so a
+splitting (IMEX) solver routes the stiff Laplacian through its implicit
+stage. ``Burgers2DTermModel.create(..., imex=True)`` does exactly that —
+something the monolithic model cannot express without rewriting its
+``build_terms``.
+
+The accompanying tests assert this model is numerically identical to the
+canonical :class:`Burgers2D` (same tendencies, same explicit trajectory),
+which is the evidence that the decomposition is faithful.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from finitevolx import (
+    Advection2D as FVXAdvection2D,
+    CartesianGrid2D,
+    Difference2D,
+    Interpolation2D,
+    Mask2D,
+    enforce_periodic,
+)
+from jaxtyping import Array, PyTree
+
+from somax._src.core.model import TermModel
+from somax._src.core.terms import IMPLICIT, Kind, Term, implicit
+from somax._src.models.pde2d.burgers import Burgers2D, Burgers2DState
+
+
+class Burgers2DAdvection(Term):
+    r"""Advective tendency kernel ``-(u·∂x + v·∂y)`` for both velocities.
+
+    Reproduces the advection half of :meth:`Burgers2D.vector_field`: the
+    transport velocities are interpolated to faces and the C-grid
+    advection operator is applied to each component. Marked explicit
+    (the default) — advection is non-stiff.
+
+    Args:
+        advection: finitevolx C-grid advection operator.
+        interp: finitevolx interpolation operator (T→U, T→V).
+        method: Reconstruction method passed to the advection operator.
+    """
+
+    advection: FVXAdvection2D
+    interp: Interpolation2D
+    method: str = eqx.field(static=True, default="upwind1")
+
+    def __call__(
+        self, t: float, state: Burgers2DState, args: PyTree | None = None
+    ) -> Burgers2DState:
+        u_on_U = self.interp.T_to_U(state.u)
+        v_on_V = self.interp.T_to_V(state.v)
+        adv_u = self.advection(state.u, u_on_U, v_on_V, method=self.method)
+        adv_v = self.advection(state.v, u_on_U, v_on_V, method=self.method)
+        return Burgers2DState(u=adv_u, v=adv_v)
+
+
+class Burgers2DDiffusion(Term):
+    r"""Diffusive tendency kernel ``laplacian(·)`` for both velocities.
+
+    Reproduces the (unscaled) diffusion half of
+    :meth:`Burgers2D.vector_field`. The viscosity ``nu`` is *not* baked
+    in here — it is applied by scaling this term (``nu * diffusion``) so
+    the coefficient stays a differentiable JAX leaf and the kernel itself
+    is reusable across models.
+
+    Args:
+        diff: finitevolx C-grid difference operator (provides
+            ``laplacian``).
+        kind: IMEX integration label. Defaults to ``"explicit"``;
+            :meth:`Burgers2DTermModel.create` tags it implicit when
+            ``imex=True``.
+    """
+
+    diff: Difference2D
+    _kind: Kind = eqx.field(static=True, default="explicit")
+
+    def __call__(
+        self, t: float, state: Burgers2DState, args: PyTree | None = None
+    ) -> Burgers2DState:
+        return Burgers2DState(
+            u=self.diff.laplacian(state.u),
+            v=self.diff.laplacian(state.v),
+        )
+
+    @property
+    def kind(self) -> Kind:
+        return self._kind
+
+
+class Burgers2DTermModel(TermModel):
+    r"""2D Burgers model assembled from composable term kernels.
+
+    A faithful, term-based reconstruction of :class:`Burgers2D`. The RHS
+    is ``advection + nu * diffusion``; periodic boundary conditions are
+    enforced before each term evaluation (matching the canonical model).
+
+    The viscosity is **not** stored as a separate field — it lives inside
+    the term tree as the :class:`~somax._src.core.terms.Scaled`
+    coefficient on the diffusion kernel, which is the single source of
+    truth for the dynamics (and the leaf ``jax.grad`` flows to). The
+    :attr:`nu` property reads it back for inspection / diagnostics. This
+    avoids duplicating a parameter outside the tree that actually drives
+    integration — a leaf stored twice would let the two copies diverge
+    and silently disconnect gradients.
+
+    Args:
+        terms: The assembled RHS term tree (built by :meth:`create`).
+        grid: The Arakawa C-grid (static; used for diagnostics).
+    """
+
+    grid: CartesianGrid2D = eqx.field(static=True)
+
+    def apply_boundary_conditions(self, state: Burgers2DState) -> Burgers2DState:
+        """Enforce periodic boundary conditions on both velocity fields."""
+        return Burgers2DState(
+            u=enforce_periodic(state.u),
+            v=enforce_periodic(state.v),
+        )
+
+    @property
+    def nu(self) -> Array:
+        """Kinematic viscosity, read back from the diffusion kernel's coeff.
+
+        Walks the assembled term tree to the
+        :class:`~somax._src.core.terms.Scaled` wrapping the
+        :class:`Burgers2DDiffusion` kernel and returns its coefficient.
+        On a gradient pytree this returns the gradient w.r.t. ``nu``.
+        """
+        from somax._src.core.terms import Scaled, _Kinded
+
+        def _find(term: Term) -> Array | None:
+            if isinstance(term, Scaled) and isinstance(term.term, Burgers2DDiffusion):
+                return term.coeff
+            if isinstance(term, Scaled | _Kinded):
+                return _find(term.term)
+            return None
+
+        for summand in self.terms.terms:
+            coeff = _find(summand)
+            if coeff is not None:
+                return coeff
+        raise ValueError("no diffusion kernel found in term tree")
+
+    @staticmethod
+    def create(
+        nx: int = 64,
+        ny: int = 64,
+        Lx: float = 2.0,
+        Ly: float = 2.0,
+        nu: float = 0.01,
+        method: str = "upwind1",
+        mask: Mask2D | None = None,
+        *,
+        imex: bool = False,
+    ) -> Burgers2DTermModel:
+        """Build a term-based Burgers model.
+
+        Args mirror :meth:`Burgers2D.create`, plus:
+
+        Args:
+            imex: When ``True``, tag the diffusion term implicit so that
+                :func:`~somax._src.core.terms.build_diffrax_terms`
+                produces a ``diffrax.MultiTerm`` and a splitting solver
+                (e.g. ``diffrax.KenCarp3``) integrates the stiff Laplacian
+                implicitly. When ``False`` (default) the whole RHS is one
+                explicit ``ODETerm`` — numerically identical to
+                :class:`Burgers2D`.
+
+        Returns:
+            A ``Burgers2DTermModel`` instance.
+        """
+        grid = CartesianGrid2D.from_interior(nx, ny, Lx, Ly)
+        nu_arr = jnp.asarray(nu)
+
+        advection = Burgers2DAdvection(
+            advection=FVXAdvection2D(grid=grid, mask=mask),
+            interp=Interpolation2D(grid=grid, mask=mask),
+            method=method,
+        )
+        diffusion = Burgers2DDiffusion(
+            diff=Difference2D(grid=grid, mask=mask),
+            _kind=IMPLICIT if imex else "explicit",
+        )
+
+        scaled_diffusion = nu_arr * diffusion
+        rhs: Term = advection + (
+            implicit(scaled_diffusion) if imex else scaled_diffusion
+        )
+
+        return Burgers2DTermModel(terms=rhs, grid=grid)
+
+    @staticmethod
+    def from_model(model: Burgers2D, *, imex: bool = False) -> Burgers2DTermModel:
+        """Build a term model matching an existing :class:`Burgers2D`.
+
+        Reuses the source model's grid, mask, and advection method so the
+        two are numerically comparable.
+
+        Args:
+            model: A canonical Burgers2D instance.
+            imex: Tag diffusion implicit (see :meth:`create`).
+
+        Returns:
+            A ``Burgers2DTermModel`` mirroring ``model``.
+        """
+        nu_arr = jnp.asarray(model.params.nu)
+        advection = Burgers2DAdvection(
+            advection=model.advection,
+            interp=model.interp,
+            method=model.method,
+        )
+        diffusion = Burgers2DDiffusion(
+            diff=model.diff,
+            _kind=IMPLICIT if imex else "explicit",
+        )
+        scaled_diffusion = nu_arr * diffusion
+        rhs: Term = advection + (
+            implicit(scaled_diffusion) if imex else scaled_diffusion
+        )
+        return Burgers2DTermModel(terms=rhs, grid=model.grid)

--- a/somax/_src/models/pde2d/burgers_terms.py
+++ b/somax/_src/models/pde2d/burgers_terms.py
@@ -46,7 +46,7 @@ from finitevolx import (
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import TermModel
-from somax._src.core.terms import IMPLICIT, Kind, Term, implicit
+from somax._src.core.terms import IMPLICIT, Kind, Scaled, Term, implicit
 from somax._src.models.pde2d.burgers import Burgers2D, Burgers2DState
 
 
@@ -206,7 +206,7 @@ class Burgers2DTermModel(TermModel):
             _kind=IMPLICIT if imex else "explicit",
         )
 
-        scaled_diffusion = nu_arr * diffusion
+        scaled_diffusion = Scaled(diffusion, nu_arr)
         rhs: Term = advection + (
             implicit(scaled_diffusion) if imex else scaled_diffusion
         )
@@ -237,7 +237,7 @@ class Burgers2DTermModel(TermModel):
             diff=model.diff,
             _kind=IMPLICIT if imex else "explicit",
         )
-        scaled_diffusion = nu_arr * diffusion
+        scaled_diffusion = Scaled(diffusion, nu_arr)
         rhs: Term = advection + (
             implicit(scaled_diffusion) if imex else scaled_diffusion
         )

--- a/somax/_src/models/swm/linear_swm_terms.py
+++ b/somax/_src/models/swm/linear_swm_terms.py
@@ -1,0 +1,297 @@
+"""2D linear shallow water as a composable :class:`Term` algebra.
+
+The second worked example of the term-kernel decomposition (after
+:mod:`somax._src.models.pde2d.burgers_terms`). Where Burgers split into
+two terms, the linear shallow water right-hand side splits cleanly into
+*four* distinct physics kernels::
+
+    gravity wave : dh/dt = -H0 * div(u, v)
+                   du/dt = -g * dh/dx,   dv/dt = -g * dh/dy
+    coriolis     : du/dt += f*v,         dv/dt -= f*u
+    diffusion    : du/dt += nu*lap(u),   dv/dt += nu*lap(v)
+    drag         : du/dt -= kappa*u,     dv/dt -= kappa*v
+
+which compose into the RHS::
+
+    rhs = gravity_wave + coriolis + nu * diffusion + (-kappa) * drag
+
+The differentiable parameters enter as
+:class:`~somax._src.core.terms.Scaled` coefficients (``nu`` on diffusion,
+``-kappa`` on drag), so they stay JAX leaves; ``g``/``H0``/``f`` are
+frozen constants baked into their kernels.
+
+Two of the four terms are stiff — the gravity-wave operator (fast surface
+waves) and the Laplacian diffusion — making this a richer IMEX showcase
+than Burgers. ``LinearSWM2DTermModel.create(..., imex=True)`` tags the
+diffusion term implicit so a splitting solver integrates it through its
+implicit stage; the gravity-wave term is a further candidate.
+
+The assembled :class:`LinearSWM2DTermModel` reproduces
+:class:`~somax._src.models.swm.linear_2d.LinearShallowWater2D` exactly
+(the tests assert identical tendencies and explicit trajectories).
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from finitevolx import CartesianGrid2D, Coriolis2D, Difference2D, enforce_periodic
+from jaxtyping import Array, PyTree
+
+from somax._src.core.model import TermModel
+from somax._src.core.terms import (
+    IMPLICIT,
+    Kind,
+    Scaled,
+    Sum,
+    Term,
+    _Kinded,
+    implicit,
+)
+from somax._src.models.swm.linear_2d import LinearShallowWater2D, LinearSW2DState
+
+
+class LinearSWMGravityWave(Term):
+    r"""Gravity-wave / pressure kernel of the linear shallow water RHS.
+
+    ``dh/dt = -H0 * div(u, v)``, ``du/dt = -g * dh/dx``,
+    ``dv/dt = -g * dh/dy``. The fast surface-wave operator; the natural
+    candidate for the implicit stage of a semi-implicit scheme.
+
+    Args:
+        diff: finitevolx C-grid difference operator.
+        g: Gravitational acceleration (frozen).
+        H0: Mean layer depth (frozen).
+    """
+
+    diff: Difference2D
+    g: float = eqx.field(static=True)
+    H0: float = eqx.field(static=True)
+
+    def __call__(
+        self, t: float, state: LinearSW2DState, args: PyTree | None = None
+    ) -> LinearSW2DState:
+        return LinearSW2DState(
+            h=-self.H0 * self.diff.divergence(state.u, state.v),
+            u=-self.g * self.diff.diff_x_T_to_U(state.h),
+            v=-self.g * self.diff.diff_y_T_to_V(state.h),
+        )
+
+
+class LinearSWMCoriolis(Term):
+    r"""Coriolis kernel: ``du/dt += f*v``, ``dv/dt -= f*u`` (no height term).
+
+    Args:
+        coriolis: finitevolx C-grid Coriolis operator.
+        f_field: Precomputed Coriolis parameter field ``f(y)``.
+    """
+
+    coriolis: Coriolis2D
+    f_field: Array
+
+    def __call__(
+        self, t: float, state: LinearSW2DState, args: PyTree | None = None
+    ) -> LinearSW2DState:
+        du_cor, dv_cor = self.coriolis(state.u, state.v, self.f_field)
+        return LinearSW2DState(h=jnp.zeros_like(state.h), u=du_cor, v=dv_cor)
+
+
+class LinearSWMDiffusion(Term):
+    r"""Lateral diffusion kernel: ``laplacian(u)``, ``laplacian(v)``.
+
+    Unscaled (the viscosity ``nu`` is applied via
+    :class:`~somax._src.core.terms.Scaled` so it stays a differentiable
+    leaf). Stiff — tag implicit for IMEX integration.
+
+    Args:
+        diff: finitevolx C-grid difference operator.
+        kind: IMEX integration label (``"explicit"`` by default).
+    """
+
+    diff: Difference2D
+    _kind: Kind = eqx.field(static=True, default="explicit")
+
+    def __call__(
+        self, t: float, state: LinearSW2DState, args: PyTree | None = None
+    ) -> LinearSW2DState:
+        return LinearSW2DState(
+            h=jnp.zeros_like(state.h),
+            u=self.diff.laplacian(state.u),
+            v=self.diff.laplacian(state.v),
+        )
+
+    @property
+    def kind(self) -> Kind:
+        return self._kind
+
+
+class LinearSWMDrag(Term):
+    r"""Linear bottom-drag kernel returning ``(0, u, v)``.
+
+    Unscaled; the drag coefficient ``kappa`` enters via a ``Scaled`` with
+    a negative coefficient (``-kappa * drag``) so it stays differentiable.
+    """
+
+    def __call__(
+        self, t: float, state: LinearSW2DState, args: PyTree | None = None
+    ) -> LinearSW2DState:
+        return LinearSW2DState(h=jnp.zeros_like(state.h), u=state.u, v=state.v)
+
+
+def _assemble(
+    *,
+    diff: Difference2D,
+    coriolis: Coriolis2D,
+    f_field: Array,
+    g: float,
+    H0: float,
+    nu: Array,
+    kappa: Array,
+    imex: bool,
+) -> Term:
+    """Build the ``gravity + coriolis + nu*diffusion - kappa*drag`` tree."""
+    gravity = LinearSWMGravityWave(diff=diff, g=g, H0=H0)
+    coriolis_term = LinearSWMCoriolis(coriolis=coriolis, f_field=f_field)
+    diffusion = LinearSWMDiffusion(diff=diff, _kind=IMPLICIT if imex else "explicit")
+    scaled_diffusion: Term = Scaled(diffusion, nu)
+    if imex:
+        scaled_diffusion = implicit(scaled_diffusion)
+    drag = Scaled(LinearSWMDrag(), -kappa)
+    return gravity + coriolis_term + scaled_diffusion + drag
+
+
+class LinearSWM2DTermModel(TermModel):
+    r"""2D linear shallow water assembled from composable term kernels.
+
+    A faithful, term-based reconstruction of
+    :class:`~somax._src.models.swm.linear_2d.LinearShallowWater2D`: same
+    RHS, same boundary conditions. The viscosity / drag coefficients live
+    in the term tree (as ``Scaled`` coefficients) and are read back via
+    :attr:`nu` / :attr:`kappa`.
+
+    Args:
+        terms: The assembled RHS term tree (built by :meth:`create` /
+            :meth:`from_model`).
+        grid: The Arakawa C-grid (static; for diagnostics).
+        bc_type: ``"periodic"`` or ``"wall"`` (static).
+    """
+
+    grid: CartesianGrid2D = eqx.field(static=True)
+    bc_type: str = eqx.field(static=True, default="periodic")
+
+    def apply_boundary_conditions(self, state: LinearSW2DState) -> LinearSW2DState:
+        """Apply boundary conditions (periodic or free-slip wall).
+
+        Mirrors :meth:`LinearShallowWater2D.apply_boundary_conditions`.
+        """
+        if self.bc_type == "periodic":
+            return LinearSW2DState(
+                h=enforce_periodic(state.h),
+                u=enforce_periodic(state.u),
+                v=enforce_periodic(state.v),
+            )
+        h, u, v = state.h, state.u, state.v
+        # No normal flow: wall faces AND ghost faces.
+        u = u.at[:, 0].set(0.0).at[:, -2].set(0.0).at[:, -1].set(0.0)
+        v = v.at[0, :].set(0.0).at[-2, :].set(0.0).at[-1, :].set(0.0)
+        # Free-slip: tangential velocity ghost = adjacent interior.
+        u = u.at[0, :].set(u[1, :]).at[-1, :].set(u[-2, :])
+        v = v.at[:, 0].set(v[:, 1]).at[:, -1].set(v[:, -2])
+        # Height: zero-gradient at ghost cells.
+        h = h.at[0, :].set(h[1, :]).at[-1, :].set(h[-2, :])
+        h = h.at[:, 0].set(h[:, 1]).at[:, -1].set(h[:, -2])
+        return LinearSW2DState(h=h, u=u, v=v)
+
+    @property
+    def nu(self) -> Array:
+        """Lateral viscosity, read back from the diffusion kernel's coeff."""
+        return _coeff_of(self.terms, LinearSWMDiffusion)
+
+    @property
+    def kappa(self) -> Array:
+        """Bottom drag, read back as ``-`` the drag kernel's coeff."""
+        return -_coeff_of(self.terms, LinearSWMDrag)
+
+    @staticmethod
+    def from_model(
+        model: LinearShallowWater2D, *, imex: bool = False
+    ) -> LinearSWM2DTermModel:
+        """Build a term model matching an existing ``LinearShallowWater2D``.
+
+        Reuses the source model's operators, Coriolis field, constants,
+        and BC type so the two are numerically comparable.
+
+        Args:
+            model: A canonical LinearShallowWater2D instance.
+            imex: Tag diffusion implicit (see module docstring).
+
+        Returns:
+            A ``LinearSWM2DTermModel`` mirroring ``model``.
+        """
+        rhs = _assemble(
+            diff=model.diff,
+            coriolis=model.coriolis,
+            f_field=model.f_field,
+            g=model.consts.gravity,
+            H0=model.consts.H0,
+            nu=jnp.asarray(model.params.lateral_viscosity),
+            kappa=jnp.asarray(model.params.bottom_drag),
+            imex=imex,
+        )
+        return LinearSWM2DTermModel(terms=rhs, grid=model.grid, bc_type=model.bc_type)
+
+    @staticmethod
+    def create(
+        nx: int = 64,
+        ny: int = 64,
+        Lx: float = 1e6,
+        Ly: float = 1e6,
+        g: float = 9.81,
+        f0: float = 1e-4,
+        beta: float = 0.0,
+        H0: float = 100.0,
+        lateral_viscosity: float = 0.0,
+        bottom_drag: float = 0.0,
+        bc: str = "periodic",
+        *,
+        imex: bool = False,
+    ) -> LinearSWM2DTermModel:
+        """Build a term-based linear SWM model.
+
+        Args mirror :meth:`LinearShallowWater2D.create`, plus ``imex``
+        (tag the diffusion term implicit). Delegates construction to the
+        canonical model's factory, then wraps it via :meth:`from_model`,
+        so the operators and Coriolis field match exactly.
+        """
+        base = LinearShallowWater2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=Lx,
+            Ly=Ly,
+            g=g,
+            f0=f0,
+            beta=beta,
+            H0=H0,
+            lateral_viscosity=lateral_viscosity,
+            bottom_drag=bottom_drag,
+            bc=bc,
+        )
+        return LinearSWM2DTermModel.from_model(base, imex=imex)
+
+
+def _coeff_of(root: Term, kernel_cls: type) -> Array:
+    """Return the ``Scaled`` coefficient wrapping a ``kernel_cls`` kernel."""
+
+    def _find(term: Term) -> Array | None:
+        if isinstance(term, Scaled) and isinstance(term.term, kernel_cls):
+            return term.coeff
+        if isinstance(term, Scaled | _Kinded):
+            return _find(term.term)
+        return None
+
+    summands = root.terms if isinstance(root, Sum) else (root,)
+    for summand in summands:
+        coeff = _find(summand)
+        if coeff is not None:
+            return coeff
+    raise ValueError(f"no {kernel_cls.__name__} kernel found in term tree")

--- a/somax/_src/operators.py
+++ b/somax/_src/operators.py
@@ -9,17 +9,25 @@ exposes somax models as first-class :class:`pipekit.Operator` s.
 Why a companion Operator instead of making the model itself an Operator?
 A somax model is an ``eqx.Module`` whose fields are grids, finitevolx
 operators, and assembled term trees — none of them JSON primitives, so
-the model can't round-trip through ``pipekit.serial``. The Operator here
-instead carries the model's *flat primitive construction recipe*
-(``nx``, ``nu``, ``dt``, …). Because every config value is a primitive,
-:func:`pipekit.dumps` / :func:`pipekit.loads` round-trips the Operator
-faithfully — it rebuilds the model on construction. This is the
-serializable counterpart to the eqx.Module numeric core.
+the model can't round-trip through ``pipekit.serial``. Two forms bridge
+the gap:
 
-Each Operator is also a stepping stage: ``op(state) -> next_state``
-advances the wrapped model by one ``dt``, so models compose with the
-rest of pipekit (``op | op``, graphs) and drive ``pipekit_cycle.Cycle``.
-The Operator additionally satisfies ``ForwardModel`` via :meth:`step`.
+- :class:`SomaxModelOp` wraps *any* built model
+  (``SomaxModelOp(model, dt)`` or :meth:`SomaxModelOp.from_registry`).
+  It is a stepping stage / ForwardModel / Cycle driver, but — holding a
+  non-primitive ``eqx.Module`` — is **not** serial-round-trippable
+  (``forbid_in_yaml = True``).
+- Flat-recipe subclasses (e.g. :class:`Burgers2DOp`) instead carry the
+  model's *flat primitive construction recipe* (``nx``, ``nu``, ``dt``,
+  …). Because every config value is a primitive,
+  :func:`pipekit.dumps` / :func:`pipekit.loads` round-trips them
+  faithfully — rebuilding the model on construction. This is the
+  serializable counterpart to the eqx.Module numeric core.
+
+Every Operator is a stepping stage: ``op(state) -> next_state`` advances
+the wrapped model by one ``dt``, so models compose with the rest of
+pipekit (``op | op``, graphs) and drive ``pipekit_cycle.Cycle``. All
+satisfy ``ForwardModel`` via :meth:`step` / ``dt`` / ``state_signature``.
 
 This module imports pipekit at module load, so it must not be imported
 from ``somax``'s core import path — keep it behind ``import
@@ -36,27 +44,73 @@ from somax._src.models.pde2d.burgers_terms import Burgers2DTermModel
 
 
 class SomaxModelOp(Operator):
-    """Base pipekit Operator wrapping a somax forward model.
+    """A pipekit Operator wrapping *any* built somax forward model.
 
-    Subclasses set two instance attributes in ``__init__``:
+    Construct directly from a built model (``SomaxModelOp(model, dt)``)
+    or from a scenario x model pair via :meth:`from_registry`. The
+    Operator is a one-step stage (``op(state) -> next_state`` advances by
+    ``dt``) so models compose with the rest of pipekit (``op | op``,
+    graphs) and drive ``pipekit_cycle.Cycle``; it also satisfies the
+    ``pipekit_cycle.ForwardModel`` protocol (``step`` / ``dt`` /
+    ``state_signature``).
 
-    - ``_model``: the built somax model (an ``eqx.Module`` exposing
-      ``step(state, dt)``), and
-    - ``dt``: the default step size used by :meth:`_apply`.
+    Serialization: the wrapped model is an ``eqx.Module`` (grids,
+    finitevolx operators, term trees — not JSON primitives), so this
+    general form is **not** faithfully round-trippable through
+    ``pipekit.serial`` — it sets ``forbid_in_yaml = True`` and an empty
+    auto-config. Subclasses whose construction is a *flat primitive
+    recipe* (e.g. :class:`Burgers2DOp`) re-enable the round-trip by
+    rebuilding the model from those primitives.
 
-    Subclasses store their constructor kwargs as same-named attributes
-    (the ConfigMixin convention) so :meth:`pipekit.ConfigMixin.get_config`
-    auto-derives the flat primitive config that ``pipekit.serial``
-    round-trips. ``_model`` is intentionally not a constructor parameter,
-    so it is excluded from the config and rebuilt on ``loads``.
-
-    The Operator is a one-step stage (``op(state) -> next_state``) and
-    satisfies the ``pipekit_cycle.ForwardModel`` protocol via
-    :meth:`step`.
+    Args:
+        model: A built somax model exposing ``step(state, dt)``.
+        dt: Default step size used by :meth:`_apply`.
     """
 
-    _model: Any
-    dt: float
+    forbid_in_yaml = True
+    # The general wrapper holds a non-primitive eqx.Module, so there's no
+    # faithful auto-config. Flat-recipe subclasses set this back to True.
+    __config_mixin_auto__ = False
+
+    def __init__(self, model: Any, dt: float) -> None:
+        self._model = model
+        self.dt = dt
+
+    @classmethod
+    def from_registry(
+        cls,
+        scenario_name: str,
+        model_name: str,
+        *,
+        dt: float,
+        scenario_params: dict[str, Any] | None = None,
+        model_params: dict[str, Any] | None = None,
+    ) -> tuple[SomaxModelOp, Any]:
+        """Build an Operator for a scenario x model pair via the dispatcher.
+
+        Wraps :func:`somax._src.cli._factories.build`, so any compatible
+        registered pair becomes a Cycle-driveable ForwardModel Operator.
+
+        Args:
+            scenario_name: Key in the scenarios registry.
+            model_name: Key in the models registry.
+            dt: Default step size for the Operator.
+            scenario_params: YAML ``scenario:`` knobs (grid, consts, …).
+            model_params: YAML ``model:`` knobs (params, stratification).
+
+        Returns:
+            ``(op, state0)`` — the wrapping Operator and the registry's
+            initial state, ready to drive ``pipekit_cycle.Cycle``.
+        """
+        from somax._src.cli._factories import build
+
+        model, state0 = build(
+            scenario_name,
+            model_name,
+            scenario_params=scenario_params,
+            model_params=model_params,
+        )
+        return cls(model, dt), state0
 
     def _apply(self, state: Any) -> Any:
         """Advance ``state`` by one default ``dt`` step (pipeline stage)."""
@@ -65,6 +119,11 @@ class SomaxModelOp(Operator):
     def step(self, state: Any, dt: float) -> Any:
         """Advance ``state`` by ``dt`` (``pipekit_cycle.ForwardModel``)."""
         return self._model.step(state, dt)
+
+    @property
+    def model(self) -> Any:
+        """The wrapped, built somax model."""
+        return self._model
 
     @property
     def state_signature(self) -> Any:
@@ -102,6 +161,11 @@ class Burgers2DOp(SomaxModelOp):
         dt: Default step size for :meth:`_apply`.
     """
 
+    # Flat primitive recipe → faithful serial round-trip (unlike the
+    # general SomaxModelOp wrapper).
+    forbid_in_yaml = False
+    __config_mixin_auto__ = True
+
     def __init__(
         self,
         nx: int = 64,
@@ -130,11 +194,6 @@ class Burgers2DOp(SomaxModelOp):
             method=method,
             imex=imex,
         )
-
-    @property
-    def model(self) -> Burgers2DTermModel:
-        """The built term-based Burgers model."""
-        return self._model
 
 
 __all__ = [

--- a/somax/_src/operators.py
+++ b/somax/_src/operators.py
@@ -1,0 +1,143 @@
+"""pipekit ``Operator`` bridge for somax forward models.
+
+somax's core stays pipekit-free — models satisfy ``pipekit_cycle``'s
+``ForwardModel`` *structurally* (via ``SomaxModel.step``) without importing
+pipekit. This module is the opposite end: an opt-in integration layer
+(available under the ``somax[sim]`` extra, which carries pipekit) that
+exposes somax models as first-class :class:`pipekit.Operator` s.
+
+Why a companion Operator instead of making the model itself an Operator?
+A somax model is an ``eqx.Module`` whose fields are grids, finitevolx
+operators, and assembled term trees — none of them JSON primitives, so
+the model can't round-trip through ``pipekit.serial``. The Operator here
+instead carries the model's *flat primitive construction recipe*
+(``nx``, ``nu``, ``dt``, …). Because every config value is a primitive,
+:func:`pipekit.dumps` / :func:`pipekit.loads` round-trips the Operator
+faithfully — it rebuilds the model on construction. This is the
+serializable counterpart to the eqx.Module numeric core.
+
+Each Operator is also a stepping stage: ``op(state) -> next_state``
+advances the wrapped model by one ``dt``, so models compose with the
+rest of pipekit (``op | op``, graphs) and drive ``pipekit_cycle.Cycle``.
+The Operator additionally satisfies ``ForwardModel`` via :meth:`step`.
+
+This module imports pipekit at module load, so it must not be imported
+from ``somax``'s core import path — keep it behind ``import
+somax.operators`` (or the ``somax[sim]`` extra).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pipekit import Operator
+
+from somax._src.models.pde2d.burgers_terms import Burgers2DTermModel
+
+
+class SomaxModelOp(Operator):
+    """Base pipekit Operator wrapping a somax forward model.
+
+    Subclasses set two instance attributes in ``__init__``:
+
+    - ``_model``: the built somax model (an ``eqx.Module`` exposing
+      ``step(state, dt)``), and
+    - ``dt``: the default step size used by :meth:`_apply`.
+
+    Subclasses store their constructor kwargs as same-named attributes
+    (the ConfigMixin convention) so :meth:`pipekit.ConfigMixin.get_config`
+    auto-derives the flat primitive config that ``pipekit.serial``
+    round-trips. ``_model`` is intentionally not a constructor parameter,
+    so it is excluded from the config and rebuilt on ``loads``.
+
+    The Operator is a one-step stage (``op(state) -> next_state``) and
+    satisfies the ``pipekit_cycle.ForwardModel`` protocol via
+    :meth:`step`.
+    """
+
+    _model: Any
+    dt: float
+
+    def _apply(self, state: Any) -> Any:
+        """Advance ``state`` by one default ``dt`` step (pipeline stage)."""
+        return self.step(state, self.dt)
+
+    def step(self, state: Any, dt: float) -> Any:
+        """Advance ``state`` by ``dt`` (``pipekit_cycle.ForwardModel``)."""
+        return self._model.step(state, dt)
+
+    @property
+    def state_signature(self) -> Any:
+        """No named-dimension signature — somax states are bare pytrees.
+
+        Part of the ``pipekit_cycle.ForwardModel`` protocol (which
+        requires ``step``, ``dt``, and ``state_signature``); ``None``
+        means the model doesn't advertise a shape/dtype signature.
+        """
+        return None
+
+
+class Burgers2DOp(SomaxModelOp):
+    """Serializable pipekit Operator for the term-based 2D Burgers model.
+
+    Wraps :class:`~somax._src.models.pde2d.burgers_terms.Burgers2DTermModel`.
+    All constructor arguments are JSON primitives, so::
+
+        op = Burgers2DOp(nx=32, ny=32, nu=0.05, dt=1e-3)
+        assert pipekit.loads(pipekit.dumps(op)).get_config() == op.get_config()
+
+    round-trips the build recipe. ``op(state)`` advances the Burgers
+    state by one ``dt`` step; the Operator drives ``pipekit_cycle.Cycle``
+    and composes with the rest of pipekit.
+
+    Args:
+        nx: Interior cells in x.
+        ny: Interior cells in y.
+        Lx: Domain length in x.
+        Ly: Domain length in y.
+        nu: Kinematic viscosity (diffusion coefficient).
+        method: Advection reconstruction method.
+        imex: Tag diffusion implicit for IMEX integration (see
+            :meth:`Burgers2DTermModel.create`).
+        dt: Default step size for :meth:`_apply`.
+    """
+
+    def __init__(
+        self,
+        nx: int = 64,
+        ny: int = 64,
+        Lx: float = 2.0,
+        Ly: float = 2.0,
+        nu: float = 0.01,
+        method: str = "upwind1",
+        imex: bool = False,
+        dt: float = 0.001,
+    ) -> None:
+        self.nx = nx
+        self.ny = ny
+        self.Lx = Lx
+        self.Ly = Ly
+        self.nu = nu
+        self.method = method
+        self.imex = imex
+        self.dt = dt
+        self._model = Burgers2DTermModel.create(
+            nx=nx,
+            ny=ny,
+            Lx=Lx,
+            Ly=Ly,
+            nu=nu,
+            method=method,
+            imex=imex,
+        )
+
+    @property
+    def model(self) -> Burgers2DTermModel:
+        """The built term-based Burgers model."""
+        return self._model
+
+
+__all__ = [
+    "Burgers2DOp",
+    "SomaxModelOp",
+]

--- a/somax/_src/operators.py
+++ b/somax/_src/operators.py
@@ -3,7 +3,8 @@
 somax's core stays pipekit-free — models satisfy ``pipekit_cycle``'s
 ``ForwardModel`` *structurally* (via ``SomaxModel.step``) without importing
 pipekit. This module is the opposite end: an opt-in integration layer
-(available under the ``somax[sim]`` extra, which carries pipekit) that
+(available with the ``sim`` dependency group, ``uv sync --group sim``,
+which carries pipekit) that
 exposes somax models as first-class :class:`pipekit.Operator` s.
 
 Why a companion Operator instead of making the model itself an Operator?
@@ -31,7 +32,8 @@ satisfy ``ForwardModel`` via :meth:`step` / ``dt`` / ``state_signature``.
 
 This module imports pipekit at module load, so it must not be imported
 from ``somax``'s core import path — keep it behind ``import
-somax.operators`` (or the ``somax[sim]`` extra).
+somax.operators`` (or installing the ``sim`` dependency group,
+``uv sync --group sim``).
 """
 
 from __future__ import annotations

--- a/somax/_src/operators.py
+++ b/somax/_src/operators.py
@@ -1,11 +1,10 @@
 """pipekit ``Operator`` bridge for somax forward models.
 
-somax's core stays pipekit-free — models satisfy ``pipekit_cycle``'s
-``ForwardModel`` *structurally* (via ``SomaxModel.step``) without importing
-pipekit. This module is the opposite end: an opt-in integration layer
-(available with the ``sim`` dependency group, ``uv sync --group sim``,
-which carries pipekit) that
-exposes somax models as first-class :class:`pipekit.Operator` s.
+somax's *core* never imports pipekit — models satisfy ``pipekit_cycle``'s
+``ForwardModel`` *structurally* (via ``SomaxModel.step``). pipekit is a
+base dependency (always installed), so this module — the opposite end —
+is always available: it exposes somax models as first-class
+:class:`pipekit.Operator` s.
 
 Why a companion Operator instead of making the model itself an Operator?
 A somax model is an ``eqx.Module`` whose fields are grids, finitevolx
@@ -30,10 +29,10 @@ the wrapped model by one ``dt``, so models compose with the rest of
 pipekit (``op | op``, graphs) and drive ``pipekit_cycle.Cycle``. All
 satisfy ``ForwardModel`` via :meth:`step` / ``dt`` / ``state_signature``.
 
-This module imports pipekit at module load, so it must not be imported
-from ``somax``'s core import path — keep it behind ``import
-somax.operators`` (or installing the ``sim`` dependency group,
-``uv sync --group sim``).
+This module imports pipekit at module load. It's kept out of ``somax``'s
+top-level ``__init__`` so plain ``import somax`` stays pipekit-import-free
+(the core's structural-only contract) — import it explicitly via ``import
+somax.operators``.
 """
 
 from __future__ import annotations

--- a/somax/core/__init__.py
+++ b/somax/core/__init__.py
@@ -13,12 +13,24 @@ from somax._src.core.helmholtz import (
     NeumannHelmholtzCache,
     PeriodicHelmholtzCache,
 )
-from somax._src.core.model import SomaxModel
+from somax._src.core.model import SomaxModel, TermModel
+from somax._src.core.terms import (
+    Compose,
+    Scaled,
+    Sum,
+    Term,
+    TermFn,
+    build_diffrax_terms,
+    explicit,
+    implicit,
+    partition,
+)
 from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
 
 
 __all__ = [
+    "Compose",
     "ConstantForcing",
     "Diagnostics",
     "DirichletHelmholtzCache",
@@ -32,9 +44,18 @@ __all__ = [
     "Params",
     "PeriodicHelmholtzCache",
     "PhysConsts",
+    "Scaled",
     "SeasonalWindForcing",
     "SimulationCheckpointer",
     "SomaxModel",
     "State",
     "StratificationProfile",
+    "Sum",
+    "Term",
+    "TermFn",
+    "TermModel",
+    "build_diffrax_terms",
+    "explicit",
+    "implicit",
+    "partition",
 ]

--- a/somax/operators.py
+++ b/somax/operators.py
@@ -1,7 +1,8 @@
 """Public surface for somax's pipekit ``Operator`` bridge.
 
-Import this module (or install ``somax[sim]``) to expose somax forward
-models as :class:`pipekit.Operator` s with serializable flat configs.
+Import this module (after installing the ``sim`` dependency group,
+``uv sync --group sim``) to expose somax forward models as
+:class:`pipekit.Operator` s with serializable flat configs.
 Kept out of ``somax``'s top-level ``__init__`` so ``import somax`` does
 not require pipekit — only ``import somax.operators`` does.
 """

--- a/somax/operators.py
+++ b/somax/operators.py
@@ -1,10 +1,11 @@
 """Public surface for somax's pipekit ``Operator`` bridge.
 
-Import this module (after installing the ``sim`` dependency group,
-``uv sync --group sim``) to expose somax forward models as
-:class:`pipekit.Operator` s with serializable flat configs.
-Kept out of ``somax``'s top-level ``__init__`` so ``import somax`` does
-not require pipekit — only ``import somax.operators`` does.
+Import this module to expose somax forward models as
+:class:`pipekit.Operator` s with serializable flat configs. pipekit is a
+base dependency, so no extra install step is needed. Kept out of
+``somax``'s top-level ``__init__`` so plain ``import somax`` doesn't
+import pipekit (the core stays structural-only) — ``import
+somax.operators`` pulls it in.
 """
 
 from __future__ import annotations

--- a/somax/operators.py
+++ b/somax/operators.py
@@ -1,0 +1,17 @@
+"""Public surface for somax's pipekit ``Operator`` bridge.
+
+Import this module (or install ``somax[sim]``) to expose somax forward
+models as :class:`pipekit.Operator` s with serializable flat configs.
+Kept out of ``somax``'s top-level ``__init__`` so ``import somax`` does
+not require pipekit — only ``import somax.operators`` does.
+"""
+
+from __future__ import annotations
+
+from somax._src.operators import Burgers2DOp, SomaxModelOp
+
+
+__all__ = [
+    "Burgers2DOp",
+    "SomaxModelOp",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared pytest configuration for the somax test suite.
+
+Automatic marker assignment
+---------------------------
+To keep the PR CI job fast, the slow tests are split out via two markers
+(declared in ``pyproject.toml``):
+
+- ``integration`` — full-pipeline tests that drive the ``somax-sim``
+  runner end to end. Every test under a ``tests/**/test_cli_*.py`` module
+  is tagged ``integration`` (and ``slow``).
+- ``slow`` — heavy correctness tests dominated by JIT-compiled
+  differentiation or long integrations. Every test whose name begins with
+  ``test_grad`` is tagged ``slow``, as is every ``integration`` test.
+
+Markers are applied here (rather than by decorating each test) so the
+split stays correct as tests are added, without touching every module.
+
+The PR CI job runs ``pytest -m 'not slow'``; the full suite (including
+slow + integration) runs in the manual ``full-tests`` workflow.
+"""
+
+from __future__ import annotations
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-tag collected tests with ``integration`` / ``slow`` markers."""
+    import pytest
+
+    integration = pytest.mark.integration
+    slow = pytest.mark.slow
+
+    for item in items:
+        filename = item.path.name if hasattr(item, "path") else ""
+        is_cli = filename.startswith("test_cli_")
+        is_grad = (
+            item.originalname.startswith("test_grad")
+            if (getattr(item, "originalname", None))
+            else item.name.startswith("test_grad")
+        )
+
+        if is_cli:
+            item.add_marker(integration)
+            item.add_marker(slow)
+        elif is_grad:
+            item.add_marker(slow)

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -13,14 +13,20 @@ from somax.core import SomaxModel
 
 
 @runtime_checkable
-class _ForwardModelLike(Protocol):
-    """Local mirror of ``pipekit_cycle.ForwardModel``.
+class _ModelStepLike(Protocol):
+    """The model-supplied half of ``pipekit_cycle.ForwardModel``.
 
     Defined here so the structural-conformance test does not pull in a
-    dependency on pipekit; the contract under test is the ``step`` method.
+    dependency on pipekit. A bare ``SomaxModel`` provides ``step`` and
+    ``state_signature``; the third ``ForwardModel`` member (a default
+    ``dt``) is supplied by the ``somax.operators`` adapter, which is
+    tested against the real protocol in ``tests/test_operators.py``.
     """
 
     def step(self, state: Any, dt: float) -> Any: ...
+
+    @property
+    def state_signature(self) -> Any: ...
 
 
 class ExponentialDecay(SomaxModel):
@@ -132,12 +138,14 @@ def test_step_composes_to_integration_window():
     assert jnp.allclose(out, expected, rtol=1e-3)
 
 
-def test_model_satisfies_forward_model_protocol():
-    """A somax model structurally satisfies the ForwardModel protocol.
+def test_model_provides_forward_model_step_and_signature():
+    """A somax model provides the ``step`` + ``state_signature`` members.
 
     This is the pipekit-cycle / DA integration seam: any ``SomaxModel``
-    is usable as a ``ForwardModel`` (and as filterax dynamics) purely by
-    duck typing, with no subclassing.
+    supplies the model half of the ``ForwardModel`` contract purely by
+    duck typing, with no subclassing. The ``dt`` member is added by the
+    ``somax.operators`` adapter (see ``tests/test_operators.py``).
     """
     model = ExponentialDecay(rate=1.0)
-    assert isinstance(model, _ForwardModelLike)
+    assert isinstance(model, _ModelStepLike)
+    assert model.state_signature is None

--- a/tests/core/test_model.py
+++ b/tests/core/test_model.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+from typing import Any, Protocol, runtime_checkable
+
 import diffrax as dfx
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import pytest
 
 from somax.core import SomaxModel
+
+
+@runtime_checkable
+class _ForwardModelLike(Protocol):
+    """Local mirror of ``pipekit_cycle.ForwardModel``.
+
+    Defined here so the structural-conformance test does not pull in a
+    dependency on pipekit; the contract under test is the ``step`` method.
+    """
+
+    def step(self, state: Any, dt: float) -> Any: ...
 
 
 class ExponentialDecay(SomaxModel):
@@ -85,3 +99,45 @@ def test_missing_apply_bcs_raises():
     """Model missing apply_boundary_conditions cannot be instantiated."""
     with pytest.raises(TypeError):
         MissingBCs()
+
+
+def test_step_returns_bare_state():
+    """``step`` returns a bare state matching integrate's final state."""
+    model = ExponentialDecay(rate=1.0)
+    state0 = jnp.array([1.0, 2.0])
+
+    stepped = model.step(state0, dt=0.01)
+
+    sol = model.integrate(state0, t0=0.0, t1=0.01, dt=0.01)
+    final = jtu.tree_map(lambda x: x[-1], sol.ys)
+
+    # same pytree structure / shape as the input state (no leading time axis)
+    assert jtu.tree_structure(stepped) == jtu.tree_structure(state0)
+    assert stepped.shape == state0.shape
+    assert jnp.allclose(stepped, final)
+
+
+def test_step_composes_to_integration_window():
+    """Repeated ``step`` calls match the analytic decay over the window."""
+    model = ExponentialDecay(rate=1.0)
+    state = jnp.array([1.0, -2.0, 0.5])
+
+    dt = 0.05
+    out = state
+    for i in range(10):
+        out = model.step(out, dt=dt, t0=i * dt)
+
+    # dx/dt = -x integrated over 0.5 -> x * e^{-0.5}
+    expected = state * jnp.exp(-0.5)
+    assert jnp.allclose(out, expected, rtol=1e-3)
+
+
+def test_model_satisfies_forward_model_protocol():
+    """A somax model structurally satisfies the ForwardModel protocol.
+
+    This is the pipekit-cycle / DA integration seam: any ``SomaxModel``
+    is usable as a ``ForwardModel`` (and as filterax dynamics) purely by
+    duck typing, with no subclassing.
+    """
+    model = ExponentialDecay(rate=1.0)
+    assert isinstance(model, _ForwardModelLike)

--- a/tests/core/test_terms.py
+++ b/tests/core/test_terms.py
@@ -1,0 +1,266 @@
+"""Tests for the composable term algebra (somax._src.core.terms)."""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import jax
+import jax.numpy as jnp
+
+from somax._src.core.model import TermModel
+from somax._src.core.terms import (
+    EXPLICIT,
+    IMPLICIT,
+    MIXED,
+    Compose,
+    Scaled,
+    Sum,
+    Term,
+    TermFn,
+    build_diffrax_terms,
+    explicit,
+    implicit,
+    partition,
+)
+
+
+# ----------------------------------------------------------------------
+# Leaf terms used across the tests
+# ----------------------------------------------------------------------
+
+
+class Linear(Term):
+    """dx/dt contribution = rate * state (autonomous, explicit)."""
+
+    rate: float = 1.0
+
+    def __call__(self, t, state, args=None):
+        return jax.tree_util.tree_map(lambda x: self.rate * x, state)
+
+
+class ConstForce(Term):
+    """Constant additive tendency of ``amp`` (ignores state)."""
+
+    amp: float = 1.0
+
+    def __call__(self, t, state, args=None):
+        return jax.tree_util.tree_map(lambda x: self.amp * jnp.ones_like(x), state)
+
+
+# ----------------------------------------------------------------------
+# Evaluation + algebra
+# ----------------------------------------------------------------------
+
+
+def test_leaf_term_evaluates():
+    term = Linear(rate=2.0)
+    state = jnp.array([1.0, 3.0])
+    assert jnp.allclose(term(0.0, state), jnp.array([2.0, 6.0]))
+
+
+def test_sum_adds_contributions():
+    term = Linear(rate=2.0) + ConstForce(amp=1.0)
+    state = jnp.array([1.0, 3.0])
+    # 2*state + 1
+    assert jnp.allclose(term(0.0, state), jnp.array([3.0, 7.0]))
+
+
+def test_sum_flattens_nested():
+    a, b, c = Linear(1.0), Linear(2.0), Linear(3.0)
+    left = (a + b) + c
+    right = a + (b + c)
+    assert isinstance(left, Sum)
+    assert len(left.terms) == 3
+    assert len(right.terms) == 3
+
+
+def test_scaled_scales_output():
+    term = 3.0 * Linear(rate=2.0)
+    state = jnp.array([1.0, 1.0])
+    assert jnp.allclose(term(0.0, state), jnp.array([6.0, 6.0]))
+    # __rmul__ and __mul__ agree
+    assert jnp.allclose((Linear(2.0) * 3.0)(0.0, state), term(0.0, state))
+
+
+def test_neg_and_sub():
+    state = jnp.array([2.0])
+    neg = -Linear(rate=1.0)
+    assert jnp.allclose(neg(0.0, state), jnp.array([-2.0]))
+    diff = Linear(rate=3.0) - Linear(rate=1.0)
+    assert jnp.allclose(diff(0.0, state), jnp.array([4.0]))  # (3-1)*2
+
+
+def test_compose_is_operator_composition():
+    # Compose(double, increment): double(increment(state)).
+    double = Linear(rate=2.0)
+    increment = TermFn(lambda t, s, a: jax.tree_util.tree_map(lambda x: x + 1.0, s))
+    comp = double @ increment
+    state = jnp.array([3.0])
+    # double(state + 1) = 2 * (3 + 1) = 8
+    assert jnp.allclose(comp(0.0, state), jnp.array([8.0]))
+    assert isinstance(comp, Compose)
+
+
+def test_sum_with_zero_identity():
+    a = Linear(rate=1.0)
+    # builtin sum seeds with int 0 -> exercises __radd__
+    s = sum([a, Linear(rate=2.0)])
+    state = jnp.array([1.0])
+    assert jnp.allclose(s(0.0, state), jnp.array([3.0]))
+
+
+def test_pytree_state_added_leafwise():
+    term = Linear(rate=2.0) + ConstForce(amp=1.0)
+    state = {"u": jnp.array([1.0]), "v": jnp.array([5.0])}
+    out = term(0.0, state)
+    assert jnp.allclose(out["u"], jnp.array([3.0]))
+    assert jnp.allclose(out["v"], jnp.array([11.0]))
+
+
+# ----------------------------------------------------------------------
+# Differentiability of coefficients
+# ----------------------------------------------------------------------
+
+
+def test_scaled_coeff_is_differentiable():
+    state = jnp.array([1.0, 2.0, 3.0])
+
+    def loss(coeff):
+        term = Scaled(Linear(rate=1.0), coeff)
+        return jnp.sum(term(0.0, state) ** 2)
+
+    # loss(c) = sum((c*state)^2) = c^2 * sum(state^2); d/dc = 2c*sum(state^2)
+    g = jax.grad(loss)(2.0)
+    expected = 2.0 * 2.0 * jnp.sum(state**2)
+    assert jnp.allclose(g, expected)
+
+
+# ----------------------------------------------------------------------
+# IMEX tagging + partition
+# ----------------------------------------------------------------------
+
+
+def test_default_kind_is_explicit():
+    assert Linear().kind == EXPLICIT
+
+
+def test_implicit_tagging():
+    assert implicit(Linear()).kind == IMPLICIT
+    assert explicit(implicit(Linear())).kind == EXPLICIT
+
+
+def test_sum_kind_is_mixed_when_kinds_differ():
+    term = explicit(Linear(1.0)) + implicit(Linear(2.0))
+    assert term.kind == MIXED
+
+
+def test_sum_kind_uniform():
+    term = explicit(Linear(1.0)) + explicit(Linear(2.0))
+    assert term.kind == EXPLICIT
+
+
+def test_partition_splits_by_kind():
+    expl = Linear(rate=1.0)
+    impl = implicit(Linear(rate=5.0))
+    term = expl + impl
+    e_part, i_part = partition(term)
+    assert e_part is not None and i_part is not None
+
+    state = jnp.array([2.0])
+    assert jnp.allclose(e_part(0.0, state), jnp.array([2.0]))  # 1*2
+    assert jnp.allclose(i_part(0.0, state), jnp.array([10.0]))  # 5*2
+
+
+def test_partition_all_explicit():
+    e_part, i_part = partition(Linear(1.0) + Linear(2.0))
+    assert e_part is not None
+    assert i_part is None
+
+
+def test_partition_recurses_nested_sum():
+    term = (explicit(Linear(1.0)) + implicit(Linear(2.0))) + implicit(Linear(3.0))
+    e_part, i_part = partition(term)
+    state = jnp.array([1.0])
+    assert jnp.allclose(e_part(0.0, state), jnp.array([1.0]))
+    # implicit part = (2 + 3) * state
+    assert jnp.allclose(i_part(0.0, state), jnp.array([5.0]))
+
+
+# ----------------------------------------------------------------------
+# diffrax bridge
+# ----------------------------------------------------------------------
+
+
+def test_build_terms_single_kind_is_odeterm():
+    term = Linear(rate=1.0) + Linear(rate=2.0)
+    dterm = build_diffrax_terms(term)
+    assert isinstance(dterm, dfx.ODETerm)
+
+
+def test_build_terms_mixed_is_multiterm():
+    term = explicit(Linear(1.0)) + implicit(Linear(2.0))
+    dterm = build_diffrax_terms(term)
+    assert isinstance(dterm, dfx.MultiTerm)
+
+
+def test_zero_term_builds_explicit_odeterm():
+    # The zero term is a valid explicit summand: it builds an ODETerm
+    # (a zero RHS), it does not raise.
+    from somax._src.core.terms import _ZERO
+
+    dterm = build_diffrax_terms(_ZERO)
+    assert isinstance(dterm, dfx.ODETerm)
+    out = dterm.vector_field(0.0, jnp.array([3.0, 4.0]), None)
+    assert jnp.allclose(out, jnp.zeros(2))
+
+
+def test_state_fn_applied_before_term():
+    # state_fn zeroes the state; the term then sees zeros.
+    term = ConstForce(amp=1.0)
+    vf = build_diffrax_terms(term, state_fn=lambda y: jnp.zeros_like(y)).vector_field
+    out = vf(0.0, jnp.array([9.0, 9.0]), None)
+    # ConstForce returns ones_like(zeros) = ones regardless, but shape follows input
+    assert out.shape == (2,)
+
+
+# ----------------------------------------------------------------------
+# TermModel integration
+# ----------------------------------------------------------------------
+
+
+class DecayModel(TermModel):
+    """TermModel for dx/dt = -rate * x assembled from a single term."""
+
+
+def test_term_model_integrates_explicit():
+    # dx/dt = -x  ->  x(1) = x0 * e^{-1}
+    model = DecayModel(terms=Scaled(Linear(rate=1.0), -1.0))
+    state0 = jnp.array([1.0])
+    sol = model.integrate(state0, t0=0.0, t1=1.0, dt=0.01)
+    assert jnp.allclose(sol.ys[-1], jnp.exp(-1.0), atol=1e-3)
+
+
+def test_term_model_step_conforms():
+    model = DecayModel(terms=Scaled(Linear(rate=1.0), -1.0))
+    state0 = jnp.array([1.0, 2.0])
+    stepped = model.step(state0, dt=0.01)
+    assert stepped.shape == state0.shape
+
+
+def test_term_model_imex_integrates():
+    # Mixed explicit/implicit decay integrated with an IMEX solver.
+    # dx/dt = -x split as explicit(-0.5x) + implicit(-0.5x).
+    model = DecayModel(
+        terms=explicit(Scaled(Linear(1.0), -0.5)) + implicit(Scaled(Linear(1.0), -0.5))
+    )
+    state0 = jnp.array([1.0])
+    # Implicit solvers require an adaptive controller with tolerances.
+    sol = model.integrate(
+        state0,
+        t0=0.0,
+        t1=1.0,
+        dt=0.01,
+        solver=dfx.KenCarp3(),
+        stepsize_controller=dfx.PIDController(rtol=1e-5, atol=1e-7),
+        max_steps=10_000,
+    )
+    assert jnp.allclose(sol.ys[-1], jnp.exp(-1.0), atol=1e-3)

--- a/tests/models/test_burgers_terms.py
+++ b/tests/models/test_burgers_terms.py
@@ -1,0 +1,197 @@
+"""Term-based Burgers2D vs the canonical Burgers2D.
+
+These tests are the evidence that the term-kernel decomposition is
+*faithful*: the assembled ``advection + nu * diffusion`` tree reproduces
+the monolithic model's tendencies and explicit trajectory exactly, and
+additionally unlocks IMEX integration (diffusion implicit) that the
+monolithic model cannot express.
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+from somax._src.core.model import SomaxModel, TermModel
+from somax._src.models.pde2d.burgers import Burgers2D, Burgers2DState
+from somax._src.models.pde2d.burgers_terms import (
+    Burgers2DAdvection,
+    Burgers2DDiffusion,
+    Burgers2DTermModel,
+)
+
+
+def _gaussian_2d(x, y, mux, muy, sigma):
+    return jnp.exp(-0.5 * (((x - mux) / sigma) ** 2 + ((y - muy) / sigma) ** 2))
+
+
+def _make_coords(grid):
+    x = jnp.arange(grid.Nx) * grid.dx
+    y = jnp.arange(grid.Ny) * grid.dy
+    return jnp.meshgrid(x, y)
+
+
+def _gaussian_state(model) -> Burgers2DState:
+    X, Y = _make_coords(model.grid)
+    g = _gaussian_2d(X, Y, 1.0, 1.0, 0.3)
+    return Burgers2DState(u=g, v=g)
+
+
+# ----------------------------------------------------------------------
+# Type / protocol conformance
+# ----------------------------------------------------------------------
+
+
+def test_is_term_model_and_somax_model():
+    model = Burgers2DTermModel.create(nx=16, ny=16)
+    assert isinstance(model, TermModel)
+    assert isinstance(model, SomaxModel)
+
+
+def test_kernels_are_terms():
+    monolith = Burgers2D.create(nx=8, ny=8)
+    term = Burgers2DTermModel.from_model(monolith)
+    # advection (explicit) + scaled diffusion -> the assembled Sum
+    summands = term.terms.terms
+    assert any(isinstance(s, Burgers2DAdvection) for s in _leaf_terms(summands))
+
+
+def _leaf_terms(summands):
+    from somax._src.core.terms import Scaled
+
+    leaves = []
+    for s in summands:
+        leaves.append(s)
+        if isinstance(s, Scaled):
+            leaves.append(s.term)
+    return leaves
+
+
+# ----------------------------------------------------------------------
+# Faithfulness to the canonical model
+# ----------------------------------------------------------------------
+
+
+def test_tendency_matches_monolithic():
+    monolith = Burgers2D.create(nx=16, ny=16, nu=0.05)
+    term = Burgers2DTermModel.from_model(monolith)
+
+    state = _gaussian_state(monolith)
+    bc = monolith.apply_boundary_conditions(state)
+
+    mono_tend = monolith.vector_field(0.0, bc)
+    term_tend = term.terms(0.0, bc)
+
+    assert jnp.allclose(mono_tend.u, term_tend.u, atol=1e-12)
+    assert jnp.allclose(mono_tend.v, term_tend.v, atol=1e-12)
+
+
+def test_explicit_trajectory_matches_monolithic():
+    monolith = Burgers2D.create(nx=16, ny=16, nu=0.05)
+    term = Burgers2DTermModel.from_model(monolith)
+    state0 = _gaussian_state(monolith)
+
+    mono_sol = monolith.integrate(state0, t0=0.0, t1=0.02, dt=0.001)
+    term_sol = term.integrate(state0, t0=0.0, t1=0.02, dt=0.001)
+
+    assert jnp.allclose(mono_sol.ys.u, term_sol.ys.u, atol=1e-10)
+    assert jnp.allclose(mono_sol.ys.v, term_sol.ys.v, atol=1e-10)
+
+
+def test_step_conforms_to_forward_model():
+    model = Burgers2DTermModel.create(nx=16, ny=16, nu=0.05)
+    state0 = _gaussian_state(model)
+    stepped = model.step(state0, dt=0.001)
+    assert stepped.u.shape == state0.u.shape
+    assert stepped.v.shape == state0.v.shape
+    assert jnp.all(jnp.isfinite(stepped.u))
+
+
+# ----------------------------------------------------------------------
+# IMEX: the payoff of the decomposition
+# ----------------------------------------------------------------------
+
+
+def test_diffrax_terms_explicit_is_single_odeterm():
+    model = Burgers2DTermModel.create(nx=8, ny=8, imex=False)
+    assert isinstance(model.build_terms(), dfx.ODETerm)
+
+
+def test_diffrax_terms_imex_is_multiterm():
+    model = Burgers2DTermModel.create(nx=8, ny=8, imex=True)
+    assert isinstance(model.build_terms(), dfx.MultiTerm)
+
+
+def test_diffusion_kind_toggles_with_imex():
+    explicit_model = Burgers2DTermModel.create(nx=8, ny=8, imex=False)
+    imex_model = Burgers2DTermModel.create(nx=8, ny=8, imex=True)
+    # Pull the diffusion kernel out of each assembled tree.
+    assert _diffusion_kind(explicit_model) == "explicit"
+    assert _diffusion_kind(imex_model) == "implicit"
+
+
+def _diffusion_kind(model):
+    # terms = Sum(advection, <scaled or _Kinded> diffusion)
+    for summand in model.terms.terms:
+        for leaf in _all_leaves(summand):
+            if isinstance(leaf, Burgers2DDiffusion):
+                return leaf.kind
+    raise AssertionError("no diffusion kernel found")
+
+
+def _all_leaves(term):
+    from somax._src.core.terms import Scaled, _Kinded
+
+    out = [term]
+    if isinstance(term, Scaled | _Kinded):
+        out.extend(_all_leaves(term.term))
+    return out
+
+
+# Marked slow: the implicit KenCarp3 Newton solves dominate runtime
+# (~tens of seconds vs <1.5s for every other test here). Excluded from
+# the fast PR CI subset; runs in the manual full-suite workflow.
+@pytest.mark.slow
+def test_imex_integration_matches_explicit():
+    # Same physics, two integration strategies: the IMEX solve (diffusion
+    # implicit via KenCarp3) should agree with the explicit Tsit5 solve.
+    explicit_model = Burgers2DTermModel.create(nx=8, ny=8, nu=0.05, imex=False)
+    imex_model = Burgers2DTermModel.create(nx=8, ny=8, nu=0.05, imex=True)
+    state0 = _gaussian_state(explicit_model)
+
+    explicit_sol = explicit_model.integrate(state0, t0=0.0, t1=0.005, dt=0.001)
+    imex_sol = imex_model.integrate(
+        state0,
+        t0=0.0,
+        t1=0.005,
+        dt=0.001,
+        solver=dfx.KenCarp3(),
+        stepsize_controller=dfx.PIDController(rtol=1e-4, atol=1e-6),
+        max_steps=10_000,
+    )
+
+    assert jnp.allclose(explicit_sol.ys.u, imex_sol.ys.u, atol=1e-3)
+    assert jnp.allclose(explicit_sol.ys.v, imex_sol.ys.v, atol=1e-3)
+
+
+# ----------------------------------------------------------------------
+# Differentiability of the viscosity coefficient (Scaled.coeff)
+# ----------------------------------------------------------------------
+
+
+def test_grad_through_nu():
+    model = Burgers2DTermModel.create(nx=16, ny=16, nu=0.05)
+    state0 = _gaussian_state(model)
+
+    @eqx.filter_grad
+    def grad_fn(m):
+        sol = m.integrate(state0, t0=0.0, t1=0.01, dt=0.001)
+        return jnp.sum(sol.ys.u**2 + sol.ys.v**2)
+
+    grads = grad_fn(model)
+    # nu lives as the Scaled coefficient inside the term tree; the grad
+    # must flow back to it.
+    assert jnp.isfinite(grads.nu)
+    assert grads.nu != 0.0

--- a/tests/models/test_linear_swm_terms.py
+++ b/tests/models/test_linear_swm_terms.py
@@ -1,0 +1,193 @@
+"""Term-based LinearSWM2D vs the canonical LinearShallowWater2D.
+
+The second term-kernel worked example (after Burgers): a four-term
+decomposition — gravity-wave + Coriolis + diffusion + drag. These tests
+are the evidence the decomposition is faithful (identical tendencies and
+explicit trajectory) and that the richer term set still supports IMEX.
+"""
+
+from __future__ import annotations
+
+import diffrax as dfx
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+from somax._src.core.model import SomaxModel, TermModel
+from somax._src.models.swm.linear_2d import LinearShallowWater2D, LinearSW2DState
+from somax._src.models.swm.linear_swm_terms import (
+    LinearSWM2DTermModel,
+    LinearSWMCoriolis,
+    LinearSWMDiffusion,
+    LinearSWMDrag,
+    LinearSWMGravityWave,
+)
+
+
+def _gaussian_bump(model) -> LinearSW2DState:
+    grid = model.grid
+    x = jnp.arange(grid.Nx) * grid.dx
+    y = jnp.arange(grid.Ny) * grid.dy
+    X, Y = jnp.meshgrid(x, y)
+    cx = grid.Nx * grid.dx / 2
+    cy = grid.Ny * grid.dy / 2
+    sigma = grid.Nx * grid.dx / 8
+    h = jnp.exp(-0.5 * (((X - cx) / sigma) ** 2 + ((Y - cy) / sigma) ** 2))
+    return LinearSW2DState(h=h, u=jnp.zeros_like(h), v=jnp.zeros_like(h))
+
+
+def _matched_models(*, nu=50.0, kappa=1e-6, imex=False):
+    base = LinearShallowWater2D.create(
+        nx=16,
+        ny=16,
+        Lx=1e6,
+        Ly=1e6,
+        f0=1e-4,
+        beta=2e-11,
+        H0=100.0,
+        lateral_viscosity=nu,
+        bottom_drag=kappa,
+        bc="periodic",
+    )
+    term = LinearSWM2DTermModel.from_model(base, imex=imex)
+    return base, term
+
+
+# ----------------------------------------------------------------------
+# Type / conformance
+# ----------------------------------------------------------------------
+
+
+def test_is_term_model_and_somax_model():
+    model = LinearSWM2DTermModel.create(nx=8, ny=8)
+    assert isinstance(model, TermModel)
+    assert isinstance(model, SomaxModel)
+
+
+def test_four_kernels_present():
+    _base, term = _matched_models()
+    summands = term.terms.terms
+    flat = []
+    for s in summands:
+        flat.append(s)
+        if hasattr(s, "term"):  # Scaled wrappers
+            flat.append(s.term)
+    kinds = {type(t).__name__ for t in flat}
+    for cls in (
+        LinearSWMGravityWave,
+        LinearSWMCoriolis,
+        LinearSWMDiffusion,
+        LinearSWMDrag,
+    ):
+        assert cls.__name__ in kinds
+
+
+def test_nu_and_kappa_read_back():
+    _base, term = _matched_models(nu=50.0, kappa=1e-6)
+    assert jnp.allclose(term.nu, 50.0)
+    assert jnp.allclose(term.kappa, 1e-6)
+
+
+# ----------------------------------------------------------------------
+# Faithfulness to the canonical model
+# ----------------------------------------------------------------------
+
+
+def test_tendency_matches_monolithic():
+    base, term = _matched_models()
+    state = _gaussian_bump(base)
+    bc = base.apply_boundary_conditions(state)
+
+    mono = base.vector_field(0.0, bc)
+    got = term.terms(0.0, bc)
+
+    assert jnp.allclose(mono.h, got.h, atol=1e-10)
+    assert jnp.allclose(mono.u, got.u, atol=1e-10)
+    assert jnp.allclose(mono.v, got.v, atol=1e-10)
+
+
+def test_explicit_trajectory_matches_monolithic():
+    base, term = _matched_models()
+    state0 = _gaussian_bump(base)
+
+    mono_sol = base.integrate(state0, t0=0.0, t1=600.0, dt=30.0)
+    term_sol = term.integrate(state0, t0=0.0, t1=600.0, dt=30.0)
+
+    assert jnp.allclose(mono_sol.ys.h, term_sol.ys.h, atol=1e-6)
+    assert jnp.allclose(mono_sol.ys.u, term_sol.ys.u, atol=1e-6)
+
+
+def test_step_conforms_to_forward_model():
+    model = LinearSWM2DTermModel.create(nx=8, ny=8, lateral_viscosity=50.0)
+    state0 = _gaussian_bump(model)
+    stepped = model.step(state0, dt=30.0)
+    assert stepped.h.shape == state0.h.shape
+    assert jnp.all(jnp.isfinite(stepped.h))
+
+
+def test_wall_bc_matches_monolithic():
+    base = LinearShallowWater2D.create(nx=12, ny=12, bc="wall", lateral_viscosity=50.0)
+    term = LinearSWM2DTermModel.from_model(base)
+    state = _gaussian_bump(base)
+    assert jnp.allclose(
+        base.apply_boundary_conditions(state).u,
+        term.apply_boundary_conditions(state).u,
+        atol=1e-12,
+    )
+
+
+# ----------------------------------------------------------------------
+# IMEX: the four-term split
+# ----------------------------------------------------------------------
+
+
+def test_diffrax_terms_explicit_is_single_odeterm():
+    model = LinearSWM2DTermModel.create(nx=8, ny=8, lateral_viscosity=50.0, imex=False)
+    assert isinstance(model.build_terms(), dfx.ODETerm)
+
+
+def test_diffrax_terms_imex_is_multiterm():
+    model = LinearSWM2DTermModel.create(nx=8, ny=8, lateral_viscosity=50.0, imex=True)
+    assert isinstance(model.build_terms(), dfx.MultiTerm)
+
+
+@pytest.mark.slow
+def test_imex_integration_matches_explicit():
+    explicit_model = LinearSWM2DTermModel.create(
+        nx=12, ny=12, lateral_viscosity=200.0, imex=False
+    )
+    imex_model = LinearSWM2DTermModel.create(
+        nx=12, ny=12, lateral_viscosity=200.0, imex=True
+    )
+    state0 = _gaussian_bump(explicit_model)
+
+    explicit_sol = explicit_model.integrate(state0, t0=0.0, t1=300.0, dt=30.0)
+    imex_sol = imex_model.integrate(
+        state0,
+        t0=0.0,
+        t1=300.0,
+        dt=30.0,
+        solver=dfx.KenCarp3(),
+        stepsize_controller=dfx.PIDController(rtol=1e-5, atol=1e-7),
+        max_steps=10_000,
+    )
+    assert jnp.allclose(explicit_sol.ys.h, imex_sol.ys.h, atol=1e-2)
+
+
+# ----------------------------------------------------------------------
+# Differentiability of the viscosity coefficient
+# ----------------------------------------------------------------------
+
+
+def test_grad_through_nu():
+    model = LinearSWM2DTermModel.create(nx=12, ny=12, lateral_viscosity=100.0)
+    state0 = _gaussian_bump(model)
+
+    @eqx.filter_grad
+    def grad_fn(m):
+        sol = m.integrate(state0, t0=0.0, t1=120.0, dt=30.0)
+        return jnp.sum(sol.ys.h**2 + sol.ys.u**2 + sol.ys.v**2)
+
+    grads = grad_fn(model)
+    assert jnp.isfinite(grads.nu)
+    assert grads.nu != 0.0

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -4,7 +4,7 @@ Exercises the pipekit bridge (``somax.operators``): flat-primitive
 ``get_config``, faithful ``pipekit.serial`` round-trip, ForwardModel
 conformance, pipeline composition, and driving ``pipekit_cycle.Cycle``.
 
-These require pipekit (the ``somax[sim]`` extra); they're skipped if it
+These require pipekit (the ``sim`` dependency group); they're skipped if it
 isn't installed.
 """
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,148 @@
+"""somax models as pipekit Operators with serializable flat configs.
+
+Exercises the pipekit bridge (``somax.operators``): flat-primitive
+``get_config``, faithful ``pipekit.serial`` round-trip, ForwardModel
+conformance, pipeline composition, and driving ``pipekit_cycle.Cycle``.
+
+These require pipekit (the ``somax[sim]`` extra); they're skipped if it
+isn't installed.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+
+pytest.importorskip("pipekit")
+pytest.importorskip("pipekit_cycle")
+
+from pipekit import dumps, loads
+from pipekit_cycle import Cycle, ForwardModel
+
+from somax._src.models.pde2d.burgers import Burgers2DState
+from somax.operators import Burgers2DOp, SomaxModelOp
+
+
+def _gaussian_state(model) -> Burgers2DState:
+    grid = model.grid
+    x = jnp.arange(grid.Nx) * grid.dx
+    y = jnp.arange(grid.Ny) * grid.dy
+    X, Y = jnp.meshgrid(x, y)
+    g = jnp.exp(-0.5 * (((X - 1.0) / 0.3) ** 2 + ((Y - 1.0) / 0.3) ** 2))
+    return Burgers2DState(u=g, v=g)
+
+
+# ----------------------------------------------------------------------
+# Config: flat primitives only
+# ----------------------------------------------------------------------
+
+
+def test_get_config_is_flat_primitives():
+    op = Burgers2DOp(nx=16, ny=16, Lx=2.0, Ly=2.0, nu=0.05, dt=0.001)
+    config = op.get_config()
+    assert config == {
+        "nx": 16,
+        "ny": 16,
+        "Lx": 2.0,
+        "Ly": 2.0,
+        "nu": 0.05,
+        "method": "upwind1",
+        "imex": False,
+        "dt": 0.001,
+    }
+    # Every value is a JSON primitive (this is what makes serial work).
+    assert all(isinstance(v, int | float | str | bool) for v in config.values())
+
+
+def test_model_not_in_config():
+    op = Burgers2DOp(nx=8, ny=8)
+    assert "model" not in op.get_config()
+    assert "_model" not in op.get_config()
+
+
+# ----------------------------------------------------------------------
+# pipekit.serial round-trip
+# ----------------------------------------------------------------------
+
+
+def test_serial_round_trip_config():
+    op = Burgers2DOp(nx=16, ny=16, nu=0.05, method="upwind1", imex=False, dt=0.002)
+    restored = loads(dumps(op))
+    assert isinstance(restored, Burgers2DOp)
+    assert restored.get_config() == op.get_config()
+
+
+def test_serial_round_trip_steps_identically():
+    op = Burgers2DOp(nx=16, ny=16, nu=0.05, dt=0.001)
+    restored = loads(dumps(op))
+    state = _gaussian_state(op.model)
+    out_a = op(state)
+    out_b = restored(state)
+    assert jnp.allclose(out_a.u, out_b.u, atol=1e-12)
+    assert jnp.allclose(out_a.v, out_b.v, atol=1e-12)
+
+
+def test_imex_flag_round_trips():
+    op = Burgers2DOp(nx=8, ny=8, imex=True)
+    restored = loads(dumps(op))
+    assert restored.get_config()["imex"] is True
+    # The rebuilt model carries the IMEX split.
+    import diffrax as dfx
+
+    assert isinstance(restored.model.build_terms(), dfx.MultiTerm)
+
+
+# ----------------------------------------------------------------------
+# ForwardModel conformance + stepping
+# ----------------------------------------------------------------------
+
+
+def test_is_forward_model():
+    op = Burgers2DOp(nx=8, ny=8)
+    assert isinstance(op, ForwardModel)
+
+
+def test_apply_advances_one_dt():
+    op = Burgers2DOp(nx=16, ny=16, nu=0.05, dt=0.001)
+    state = _gaussian_state(op.model)
+    via_apply = op(state)
+    via_step = op.step(state, 0.001)
+    via_model = op.model.step(state, 0.001)
+    assert jnp.allclose(via_apply.u, via_step.u, atol=1e-12)
+    assert jnp.allclose(via_apply.u, via_model.u, atol=1e-12)
+
+
+def test_base_class_exported():
+    assert issubclass(Burgers2DOp, SomaxModelOp)
+
+
+# ----------------------------------------------------------------------
+# pipekit composition + Cycle
+# ----------------------------------------------------------------------
+
+
+def test_sequential_composition_is_two_steps():
+    op = Burgers2DOp(nx=16, ny=16, nu=0.05, dt=0.001)
+    state = _gaussian_state(op.model)
+    composed = (op | op)(state)
+    manual = op(op(state))
+    assert jnp.allclose(composed.u, manual.u, atol=1e-12)
+    assert jnp.allclose(composed.v, manual.v, atol=1e-12)
+
+
+def test_drives_pipekit_cycle():
+    op = Burgers2DOp(nx=16, ny=16, nu=0.05, dt=0.001)
+    state0 = _gaussian_state(op.model)
+
+    cycle = Cycle(step_op=op, n_steps=3, save_history=True)
+    carrier, _ = cycle(state0, None)
+
+    # Manual three-step reference.
+    manual = state0
+    for _ in range(3):
+        manual = op.step(manual, op.dt)
+
+    assert jnp.allclose(carrier.u, manual.u, atol=1e-10)
+    assert jnp.allclose(carrier.v, manual.v, atol=1e-10)
+    assert len(cycle.history) == 3

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -4,8 +4,8 @@ Exercises the pipekit bridge (``somax.operators``): flat-primitive
 ``get_config``, faithful ``pipekit.serial`` round-trip, ForwardModel
 conformance, pipeline composition, and driving ``pipekit_cycle.Cycle``.
 
-These require pipekit (the ``sim`` dependency group); they're skipped if it
-isn't installed.
+These require pipekit (a base somax dependency); the ``importorskip``
+guard below is belt-and-suspenders.
 """
 
 from __future__ import annotations

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -146,3 +146,57 @@ def test_drives_pipekit_cycle():
     assert jnp.allclose(carrier.u, manual.u, atol=1e-10)
     assert jnp.allclose(carrier.v, manual.v, atol=1e-10)
     assert len(cycle.history) == 3
+
+
+# ----------------------------------------------------------------------
+# General registry-driven wrapper (any scenario x model pair)
+# ----------------------------------------------------------------------
+
+
+def _small_linear_swm_op():
+    return SomaxModelOp.from_registry(
+        "double_gyre",
+        "linear_swm",
+        dt=30.0,
+        scenario_params={"grid": {"nx": 8, "ny": 8}},
+        model_params={"params": {"lateral_viscosity": 100.0, "bottom_drag": 1e-6}},
+    )
+
+
+def test_from_registry_wraps_any_model():
+    op, state0 = _small_linear_swm_op()
+    assert isinstance(op, SomaxModelOp)
+    assert type(op.model).__name__ == "LinearShallowWater2D"
+    # registry initial state has the SWM (h, u, v) structure
+    assert hasattr(state0, "h") and hasattr(state0, "u") and hasattr(state0, "v")
+
+
+def test_from_registry_op_is_forward_model_and_steps():
+    op, state0 = _small_linear_swm_op()
+    assert isinstance(op, ForwardModel)
+    stepped = op(state0)
+    assert jnp.all(jnp.isfinite(stepped.h))
+    # _apply == step(dt) == model.step(dt)
+    assert jnp.allclose(stepped.h, op.model.step(state0, op.dt).h, atol=1e-12)
+
+
+def test_from_registry_op_drives_cycle():
+    op, state0 = _small_linear_swm_op()
+    carrier, _ = Cycle(step_op=op, n_steps=2)(state0, None)
+    manual = op.step(op.step(state0, op.dt), op.dt)
+    assert jnp.allclose(carrier.h, manual.h, atol=1e-10)
+
+
+def test_general_wrapper_is_not_round_trippable():
+    # The general wrapper holds a non-primitive eqx.Module: no faithful
+    # serial round-trip (forbid_in_yaml), and an empty auto-config.
+    op, _ = _small_linear_swm_op()
+    assert op.forbid_in_yaml is True
+    assert op.get_config() == {}
+
+
+def test_flat_subclass_still_round_trips():
+    # Burgers2DOp re-enables the round-trip the general wrapper forgoes.
+    op = Burgers2DOp(nx=8, ny=8, nu=0.05, dt=0.001)
+    assert op.forbid_in_yaml is False
+    assert loads(dumps(op)).get_config() == op.get_config()


### PR DESCRIPTION
## Summary

Phased refactor aligning **somax** with the `jejjohnson` scientific stack (`pipekit` / `pipekit-cycle`, `finitevolx`/`spectraldiffx`, and the `vardax`/`filterax` DA consumers). Design note: `content/notes/ecosystem_refactor_plan.md`.

This PR covers **Phase 0, 1, and 2** plus follow-on generalizations. Highlights: a composable **term algebra** for model right-hand sides, a **pipekit Operator** bridge with `serial` round-trip, the somax-sim runner driven by **`pipekit_cycle.Cycle`**, and a fast/slow **test split**.

> ⚠️ `uv.lock` is gitignored, so CI resolves fresh from `pyproject.toml`. Lint/format (`ruff`) and typecheck (`ty`) were run locally and are clean; please confirm via CI.

---

## Phase 0 — dependency alignment
- Bump `finitevolx` `v0.0.40 → v0.0.41`.
- **`spectraldiffx` pinned to git tag `v0.0.10`** (not `0.0.12`): finitevolx v0.0.41 pins spectraldiffx to `v0.0.10`, and uv requires a single git ref per package across the graph — a `0.0.12` pin is unresolvable.
- No somax source changes required for the bump; full suite green on v0.0.41.

## Phase 1 — `ForwardModel` seam
- Add `SomaxModel.step(state, dt, *, t0=0.0)` — a thin wrapper over `integrate` returning a bare state pytree.
- **Accurate conformance:** the real `pipekit_cycle.ForwardModel` has three members (`step`, `dt`, `state_signature`). A bare model supplies `step` + `state_signature`; it has no inherent `dt`, so full conformance is provided by the Operator adapter (below), not a fake model `dt`.

## Phase 2 — term algebra, Operators, Cycle

**Term algebra** (`somax/_src/core/terms.py`) — a model RHS as a closed algebra:
- `a + b` → `Sum`, `c * a` → `Scaled` (differentiable coeff), `a @ b` → `Compose`.
- Per-term `explicit`/`implicit` `kind`; `partition` + `build_diffrax_terms` lower a mixed tree to a `diffrax.MultiTerm` so an **IMEX** solver (e.g. `KenCarp3`) routes stiff terms through its implicit stage.
- `TermModel(SomaxModel)` assembles a tree; still a `ForwardModel` via `step`.

**Term-kernel models** (faithful, tested identical to the monolithic versions):
- `Burgers2DTermModel` — `advection + nu·diffusion`.
- `LinearSWM2DTermModel` — four kernels: `gravity_wave + coriolis + nu·diffusion − kappa·drag` (two stiff terms → richer IMEX); matches periodic **and** wall BCs.

**pipekit Operator bridge** (`somax.operators`):
- `SomaxModelOp(model, dt)` wraps *any* built model as a pipeline stage + `ForwardModel`; `from_registry(scenario, model, …)` builds any scenario×model pair.
- `Burgers2DOp` carries a flat-primitive recipe → faithful `pipekit.dumps`/`loads` round-trip. The general wrapper holds a non-primitive `eqx.Module` (honestly `forbid_in_yaml=True`).

**Dependencies:** `pipekit` + `pipekit-cycle` are **base dependencies** (git-subdirectory `uv.sources`). somax's *core* still never imports pipekit — conformance is structural, and `somax/__init__` doesn't import the operators bridge, so plain `import somax` stays pipekit-import-free. (`sim` remains a `[dependency-groups]` group for the CLI's hydra/zarr/etc.)

**Runner on Cycle** (`somax/_src/cli/_run.py`):
- The chunked-integration loop is driven by `pipekit_cycle.Cycle`; the loop body is a `StatefulOperator` (`_ChunkStep`) with accumulators threaded through an immutable carry (snapshots appended to a list in place — amortized O(1)). Behaviour preserved exactly — same diagnostic log lines, non-finite abort, crash-recovery checkpoint cadence, and stacked `ys`. Validated by the full `test_cli_run.py` suite (26).
- Note: pipekit's per-step hooks are a reserved no-op today, so observability lives in the step operator (can move to hooks later).

**Config investigation:** `spec.py`/`RunSpec` is **kept**. pipekit's `serial` is primitives-only and can't round-trip the nested-dict YAML schema (its only nested path, the Hydra adapter, imposes a `_target_` schema). The pipekit dependency is spent where it fits — Operators + Cycle — not on the config layer.

## Test infrastructure
- `slow` / `integration` markers auto-applied in `tests/conftest.py` (no per-file decorating).
- PR CI runs `pytest -m "not slow"` (~2.5 min, 477 tests, 77% coverage); the full suite (incl. grad-through + end-to-end) runs in a new manual `full-tests.yml` workflow. `make test` / `make test-all`.

## Docs
- `content/tutorials/composable_models_terms_operators_cycles.{py,ipynb}` — end-to-end Terms → IMEX → Operators → `serial` → `Cycle` → registry, with an executed geostrophic-adjustment figure. Wired into `myst.yml`.

## Test status
Fast suite green locally (477 passed); slow/integration suites green; `ruff` + `ty` clean.

## Deferred to later phases
- **Phase 3** — `xrtoolz` for state↔Dataset IO + evaluation metrics.
- **Phase 4** — wire models into `vardax`/`filterax` DA cycles.
- **Phase 5** — training / experiment tracking via `pipekit-train`/`pipekit-experiment`.

https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr)_