### PR TITLE
feat(eval): reference-free evaluation metrics on the model grid (Phase 3)

### DIFF
--- a/content/notes/ecosystem_refactor_plan.md
+++ b/content/notes/ecosystem_refactor_plan.md
@@ -6,8 +6,8 @@ stack and a phased plan for aligning **somax** with the framework
 (`finitevolx` / `spectraldiffx`), and the data-assimilation consumers
 (`vardax` / `filterax`).
 
-> **Status:** Phase 0 and Phase 1 are implemented (see
-> [What has been done](#what-has-been-done)). Phases 2–5 are proposed.
+> **Status:** Phases 0-2 are merged and Phase 3 is implemented (see
+> [What has been done](#what-has-been-done)). Phases 4-5 are proposed.
 
 ## The ecosystem at a glance
 
@@ -106,7 +106,14 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
 - *(Optional follow-up)* mix in `pipekit.ConfigMixin` so `get_config()` /
   `state` round-trip comes for free.
 
-### Phase 2 — Replace hand-rolled config / registry / runner with pipekit
+### Phase 2 — Replace hand-rolled config / registry / runner with pipekit *(done)*
+
+> **What actually shipped** (PR #124): the term algebra, the `somax.operators`
+> Operator bridge, and the `pipekit_cycle.Cycle`-driven runner all landed. The
+> config layer below was **investigated and kept**: `pipekit.serial` is
+> primitives-only and cannot round-trip somax's nested-dict YAML schema, so
+> `cli/spec.py` / `RunSpec` remain. The pipekit dependency is spent where it
+> fits — Operators + Cycle — not on (de)serialization.
 
 - Re-express `scenarios` and `models` as `pipekit.Operator`s (or registry
   entries) so construction params auto-serialize via `ConfigMixin`. Replace
@@ -120,19 +127,38 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
   stepping + history / `save_interval` for free) — the largest single LOC
   reduction. Keep `somax-sim` (cyclopts) as the thin CLI shell.
 
-### Phase 3 — Reuse xrtoolz for IO, evaluation, basin data
+### Phase 3 — somax-native evaluation surface *(done)*
 
-- Swap `_src/io/xarray.py` state↔Dataset plumbing onto
-  `xrtoolz.einx.pack_dataset` / `unpack_dataset` + xrtoolz io; keep a thin
-  somax-specific dim-naming adapter.
-- Replace `cli/_assertions.py` numeric checks with `xrtoolz.metrics` —
-  `geostrophic_balance_error`, `pv_conservation_error`, `divergence_error`,
-  plus `rmse` / `psd_score` for skill. This also gives somax a real evaluation
-  surface it currently lacks.
-- For the stubbed Phase 4/5 basin-data work (`scripts/data/build_basin.py`,
-  currently synthetic), use xrtoolz preprocessing — `regrid_like`,
-  `coarsen_conservative`, `fillnan_*`, CF validation, `CMEMSSource` /
-  `CDSSource` loaders — instead of building new ingestion.
+> **Revised after surveying xrtoolz's actual API.** The original plan was to
+> reuse `xrtoolz` for IO + metrics. On inspection that premise did not hold:
+> `xrtoolz.einx.pack_dataset`/`unpack_dataset` stack a Dataset's *variables*
+> into a channel axis (an ML-export op) — they are not a pytree-state↔Dataset
+> converter, and xrtoolz exposes no NetCDF/Zarr IO of its own (it defers to
+> xarray). So there is nothing for `_src/io/xarray.py` to swap onto; its
+> security-allowlisted class round-trip and zarr-v3 handling stay as-is.
+> xrtoolz's physical metrics (`geostrophic_balance_error`, `divergence_error`)
+> also assume lat/lon ocean observations with Coriolis derived from latitude,
+> whereas somax runs on idealised Cartesian f-/β-plane grids (metres, no
+> lat/lon coords); `pv_conservation_error` needs Lagrangian trajectories somax
+> does not produce. Finally xrtoolz is a heavy dependency (cartopy, pyproj,
+> rioxarray, xskillscore, …). Decision: give somax its own lightweight
+> evaluation surface on its native grid, with **no new dependency**.
+
+- New `somax.eval` (`_src/eval/metrics.py`): reference-free, Cartesian-grid
+  field diagnostics built on the finitevolx operators models already hold —
+  `rms_divergence`, `total_enstrophy`, `kinetic_energy` (generic to any C-grid
+  fluid model) and `geostrophic_imbalance` (model-aware; reuses the model's own
+  pressure-gradient + Coriolis operators, so it measures departure from exactly
+  the balance the model integrates around).
+- `compute_eval_metrics(model, state)` is a defensive dispatcher returning the
+  applicable metrics (empty for non-fluid models). The `somax-sim` runner folds
+  it into `metrics.json` under the existing `write_metrics` flag; the existing
+  generic `bounded_metric` postflight assertion already enforces tolerances on
+  any of these keys, so no new assertion code was needed.
+- **Deferred to Phase 4:** reference-based skill scores (RMSE, PSD score) need a
+  truth trajectory / observations and land alongside the data-assimilation
+  work. The xrtoolz `CMEMSSource` / `CDSSource` loaders remain the right tool
+  for real basin data if/when that work starts (kept out of somax's core).
 
 ### Phase 4 — Data-assimilation integration (vardax / filterax)
 
@@ -155,19 +181,25 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
 
 ## What has been done
 
-Phase 0 and Phase 1 are implemented on the
-`claude/somax-refactor-plan-SM3dT` branch:
+**Phases 0-2 are merged** (PR #124, squash-merged to `main`): the dependency
+alignment (`finitevolx` `v0.0.41`, `spectraldiffx` pinned to the git tag
+`v0.0.10`), `SomaxModel.step` for `ForwardModel` conformance, the composable
+term algebra (`Sum`/`Scaled`/`Compose`, IMEX lowering), the pipekit
+`Operator` bridge (`somax.operators`), and the `pipekit_cycle.Cycle`-driven
+runner. `pipekit` / `pipekit-cycle` are base dependencies; somax's core never
+imports them (conformance is structural).
 
-- **`pyproject.toml`** — `finitevolx` bumped to `v0.0.41`, `spectraldiffx` to
-  `>=0.0.12` (source pin moved to the un-prefixed `0.0.12` tag). No other
-  source changes were needed for the alignment.
-- **`somax/_src/core/model.py`** — new `SomaxModel.step(state, dt, *, t0=0.0)`
-  returning a bare state pytree, making every model a structural
-  `pipekit_cycle.ForwardModel`.
-- **`tests/core/test_model.py`** — tests covering `step`↔`integrate`
-  agreement, multi-step composition over a window, and structural
-  `ForwardModel` conformance (via a local Protocol mirror, so no new test
-  dependency).
+**Phase 3 (this branch)** adds the somax-native evaluation surface:
+
+- **`somax/_src/eval/metrics.py`** (public `somax.eval`) — reference-free
+  field diagnostics (`rms_divergence`, `total_enstrophy`, `kinetic_energy`,
+  `geostrophic_imbalance`) plus the `compute_eval_metrics` dispatcher.
+- **`somax/_src/cli/_run.py`** — folds `compute_eval_metrics` into
+  `metrics.json` (under `write_metrics`, try-wrapped so it never breaks a run).
+- **`tests/eval/test_diagnostics.py`** — analytic checks (divergence-free and
+  irrotational fields read ~0, closed-form kinetic energy, a uniform
+  geostrophic jet reads imbalance ~0, scale-invariance of the ratio, and the
+  dispatcher's fluid/non-fluid behaviour).
 
 The full test suite passes, and `ruff check`, `ruff format`, and `ty check`
 are clean on the changed files.

--- a/content/notes/ecosystem_refactor_plan.md
+++ b/content/notes/ecosystem_refactor_plan.md
@@ -155,6 +155,12 @@ the bulk cleanup; 4–5 are the future-facing payoff. Suggested order:
   it into `metrics.json` under the existing `write_metrics` flag; the existing
   generic `bounded_metric` postflight assertion already enforces tolerances on
   any of these keys, so no new assertion code was needed.
+- **Scope:** the metrics target velocity-state C-grid models (SWM, Burgers).
+  Vorticity / streamfunction models (`barotropic_qg`, vorticity NS) are
+  intentionally excluded — they evolve `q` / `omega` and never define a discrete
+  velocity divergence (non-divergence is only analytic, so a divergence metric
+  would be an operator-dependent artifact with no canonical zero). They already
+  surface `kinetic_energy` + `enstrophy` through their own `diagnose()`.
 - **Deferred to Phase 4:** reference-based skill scores (RMSE, PSD score) need a
   truth trajectory / observations and land alongside the data-assimilation
   work. The xrtoolz `CMEMSSource` / `CDSSource` loaders remain the right tool

--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -35,6 +35,7 @@ from somax._src.cli._units import (
     format_wallclock,
 )
 from somax._src.cli.spec import RunSpec, dump_yaml
+from somax._src.eval.metrics import compute_eval_metrics
 
 
 class IntegrationDivergedError(RuntimeError):
@@ -393,6 +394,10 @@ def _integrate_and_write(
                 logger.warning("model.diagnose failed: {}", exc)
                 diagnostics = None
             metrics = _flatten_diagnostics(diagnostics)
+            try:
+                metrics.update(compute_eval_metrics(model, final_state))
+            except Exception as exc:
+                logger.warning("compute_eval_metrics failed: {}", exc)
             metrics["wallclock_seconds"] = wallclock
             metrics["n_steps"] = _maybe_step_count(sol)
             metrics["t0"] = spec.timestepping.t0

--- a/somax/_src/eval/__init__.py
+++ b/somax/_src/eval/__init__.py
@@ -1,0 +1,20 @@
+"""Reference-free evaluation metrics for somax model states."""
+
+from __future__ import annotations
+
+from somax._src.eval.metrics import (
+    compute_eval_metrics,
+    geostrophic_imbalance,
+    kinetic_energy,
+    rms_divergence,
+    total_enstrophy,
+)
+
+
+__all__ = [
+    "compute_eval_metrics",
+    "geostrophic_imbalance",
+    "kinetic_energy",
+    "rms_divergence",
+    "total_enstrophy",
+]

--- a/somax/_src/eval/metrics.py
+++ b/somax/_src/eval/metrics.py
@@ -1,0 +1,238 @@
+"""Reference-free evaluation metrics for somax model states.
+
+These are *field-level diagnostics* computed on a model's own Cartesian
+grid — distinct from ``model.diagnose()`` (per-model conserved invariants)
+and from the per-field min/mean/max stats the runner already logs. They
+give somax a quantitative evaluation surface for free-running simulations:
+how divergent the flow is, how much enstrophy / kinetic energy it carries,
+and how far it sits from geostrophic balance.
+
+All metrics are **reference-free** — they need only the state itself, not a
+ground-truth field. Reference-based skill scores (RMSE, PSD score, …) need
+observations / a truth trajectory and belong with the data-assimilation
+work in a later phase.
+
+Design
+------
+- The generic metrics (:func:`rms_divergence`, :func:`total_enstrophy`,
+  :func:`kinetic_energy`) take raw velocity arrays plus the finitevolx
+  ``Difference2D`` / grid the model already holds, so they apply to any
+  Arakawa C-grid fluid model (SWM, QG, Navier-Stokes).
+- :func:`geostrophic_imbalance` is model-aware: it reuses the model's *own*
+  pressure-gradient and Coriolis operators, so it measures departure from
+  exactly the balance the model is built around.
+- :func:`compute_eval_metrics` is a defensive dispatcher: it returns the
+  applicable metrics for fluid models and an empty dict for everything else
+  (Lorenz, diffusion, …), so the runner can call it unconditionally.
+
+Reductions use the grid interior (dropping the one-cell ghost halo) to match
+the convention in the models' ``diagnose`` methods and avoid contaminating
+the metric with boundary / ghost-point artifacts.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import jax.numpy as jnp
+from jaxtyping import Array, Float
+
+
+if TYPE_CHECKING:
+    from somax._src.core.types import State
+
+
+# One-cell ghost halo dropped from every reduction (matches ``diagnose``).
+_INTERIOR = (slice(1, -1), slice(1, -1))
+
+
+def _interior(arr: Float[Array, "Ny Nx"], *, interior: bool) -> Array:
+    """Optionally trim the one-cell ghost halo before reducing."""
+    return arr[_INTERIOR] if interior else arr
+
+
+def rms_divergence(
+    u: Float[Array, "Ny Nx"],
+    v: Float[Array, "Ny Nx"],
+    diff: Any,
+    *,
+    interior: bool = True,
+) -> Float[Array, ""]:
+    r"""Root-mean-square horizontal divergence ``sqrt(<(∇·u)²>)``.
+
+    A diagnostic of how non-divergent the flow is. For incompressible /
+    geostrophic flow it should stay near zero; a growing value flags
+    spurious compressibility or numerical noise.
+
+    Args:
+        u: x-velocity field on its C-grid points, shape ``(Ny, Nx)``.
+        v: y-velocity field on its C-grid points, shape ``(Ny, Nx)``.
+        diff: A finitevolx ``Difference2D`` (the model's ``.diff``); its
+            :meth:`divergence` lowers ``(u, v)`` to ``∇·u`` at tracer points.
+        interior: Drop the one-cell ghost halo before reducing (default).
+
+    Returns:
+        Scalar RMS divergence (same units as ``∇·u``, i.e. 1/s for m/s
+        velocities on a metre grid).
+    """
+    div = _interior(diff.divergence(u, v), interior=interior)
+    return jnp.sqrt(jnp.mean(div**2))
+
+
+def total_enstrophy(
+    u: Float[Array, "Ny Nx"],
+    v: Float[Array, "Ny Nx"],
+    diff: Any,
+    grid: Any,
+    *,
+    interior: bool = True,
+) -> Float[Array, ""]:
+    r"""Domain-integrated enstrophy ``0.5 ∫ ζ² dA`` with ``ζ = ∂v/∂x - ∂u/∂y``.
+
+    Enstrophy is a robust health metric for 2D / quasi-2D turbulence: in the
+    inviscid limit it is bounded, so runaway growth signals instability.
+
+    Args:
+        u: x-velocity field, shape ``(Ny, Nx)``.
+        v: y-velocity field, shape ``(Ny, Nx)``.
+        diff: finitevolx ``Difference2D``; its :meth:`curl` returns ζ.
+        grid: The model's ``CartesianGrid2D`` (for the ``dx·dy`` cell area).
+        interior: Drop the one-cell ghost halo before reducing (default).
+
+    Returns:
+        Scalar total enstrophy.
+    """
+    zeta = _interior(diff.curl(u, v), interior=interior)
+    cell_area = grid.dx * grid.dy
+    return 0.5 * jnp.sum(zeta**2) * cell_area
+
+
+def kinetic_energy(
+    u: Float[Array, "Ny Nx"],
+    v: Float[Array, "Ny Nx"],
+    grid: Any,
+    *,
+    interior: bool = True,
+) -> Float[Array, ""]:
+    r"""Domain-integrated kinetic energy ``0.5 ∫ (u² + v²) dA``.
+
+    Mirrors the velocity term of the models' ``diagnose`` energy (summing the
+    staggered components directly), so it tracks consistently alongside the
+    model's own energy diagnostic.
+
+    Args:
+        u: x-velocity field, shape ``(Ny, Nx)``.
+        v: y-velocity field, shape ``(Ny, Nx)``.
+        grid: The model's ``CartesianGrid2D`` (for the ``dx·dy`` cell area).
+        interior: Drop the one-cell ghost halo before reducing (default).
+
+    Returns:
+        Scalar kinetic energy (per unit depth).
+    """
+    ui = _interior(u, interior=interior)
+    vi = _interior(v, interior=interior)
+    cell_area = grid.dx * grid.dy
+    return 0.5 * jnp.sum(ui**2 + vi**2) * cell_area
+
+
+def geostrophic_imbalance(
+    model: Any,
+    state: State,
+    *,
+    interior: bool = True,
+    eps: float = 1e-30,
+) -> Float[Array, ""]:
+    r"""Dimensionless ageostrophic fraction of a shallow-water-type state.
+
+    Geostrophic balance is ``f x u = -g ∇η`` — equivalently, the
+    pressure-gradient and Coriolis accelerations cancel. This metric forms
+    that residual using the model's *own* operators::
+
+        r_u = -g ∂η/∂x + f·v        (at U-points)
+        r_v = -g ∂η/∂y - f·u        (at V-points)
+
+    and returns ``rms(r) / rms(coriolis)`` — 0 for a perfectly geostrophic
+    flow, O(1) when ageostrophic accelerations rival the Coriolis term.
+    Reusing ``model.diff`` and ``model.coriolis`` keeps the residual exactly
+    consistent with the balance the model integrates around (staggering,
+    masks and the β-plane ``f`` field all included).
+
+    Args:
+        model: A shallow-water-type model exposing ``diff`` (with
+            ``diff_x_T_to_U`` / ``diff_y_T_to_V``), ``coriolis``,
+            ``f_field`` and ``consts.gravity``.
+        state: A state with ``h`` (height perturbation η), ``u`` and ``v``.
+        interior: Drop the one-cell ghost halo before reducing (default).
+        eps: Floor added to the denominator to keep a motionless state
+            (zero Coriolis term) finite.
+
+    Returns:
+        Scalar ageostrophic fraction in ``[0, ∞)``.
+    """
+    g = model.consts.gravity
+    h, u, v = state.h, state.u, state.v
+
+    # Leading-order momentum balance terms, on their native C-grid points.
+    pg_u = -g * model.diff.diff_x_T_to_U(h)
+    pg_v = -g * model.diff.diff_y_T_to_V(h)
+    cor_u, cor_v = model.coriolis(u, v, model.f_field)
+
+    res_u = _interior(pg_u + cor_u, interior=interior)
+    res_v = _interior(pg_v + cor_v, interior=interior)
+    cor_u_i = _interior(cor_u, interior=interior)
+    cor_v_i = _interior(cor_v, interior=interior)
+
+    residual = jnp.sqrt(jnp.mean(res_u**2) + jnp.mean(res_v**2))
+    scale = jnp.sqrt(jnp.mean(cor_u_i**2) + jnp.mean(cor_v_i**2))
+    return residual / (scale + eps)
+
+
+def _is_fluid_state(state: State) -> bool:
+    """A 2D C-grid velocity state we can compute field metrics for."""
+    if not (hasattr(state, "u") and hasattr(state, "v")):
+        return False
+    return jnp.ndim(state.u) == 2 and jnp.ndim(state.v) == 2
+
+
+def _supports_geostrophy(model: Any, state: State) -> bool:
+    """Whether the model exposes the pieces ``geostrophic_imbalance`` needs."""
+    consts = getattr(model, "consts", None)
+    return (
+        hasattr(state, "h")
+        and hasattr(model, "coriolis")
+        and hasattr(model, "f_field")
+        and consts is not None
+        and hasattr(consts, "gravity")
+    )
+
+
+def compute_eval_metrics(model: Any, state: State) -> dict[str, float]:
+    """Compute every applicable reference-free metric for ``(model, state)``.
+
+    A defensive dispatcher meant to be called unconditionally by the runner:
+    it inspects the model / state and returns only the metrics that make
+    sense. Non-fluid models (Lorenz, diffusion, …) and multilayer (3D) states
+    yield an empty dict rather than an error.
+
+    Args:
+        model: A constructed somax model.
+        state: The state to evaluate (typically the final integrated state).
+
+    Returns:
+        Flat ``{metric_name: float}`` dict — a subset of ``rms_divergence``,
+        ``total_enstrophy``, ``kinetic_energy`` and ``geostrophic_imbalance``.
+        Empty when no metric applies.
+    """
+    out: dict[str, float] = {}
+    if not (hasattr(model, "diff") and hasattr(model, "grid")):
+        return out
+    if not _is_fluid_state(state):
+        return out
+
+    u, v, diff, grid = state.u, state.v, model.diff, model.grid
+    out["rms_divergence"] = float(rms_divergence(u, v, diff))
+    out["total_enstrophy"] = float(total_enstrophy(u, v, diff, grid))
+    out["kinetic_energy"] = float(kinetic_energy(u, v, grid))
+    if _supports_geostrophy(model, state):
+        out["geostrophic_imbalance"] = float(geostrophic_imbalance(model, state))
+    return out

--- a/somax/_src/eval/metrics.py
+++ b/somax/_src/eval/metrics.py
@@ -214,6 +214,16 @@ def compute_eval_metrics(model: Any, state: State) -> dict[str, float]:
     sense. Non-fluid models (Lorenz, diffusion, …) and multilayer (3D) states
     yield an empty dict rather than an error.
 
+    Scope: this targets **velocity-state Arakawa C-grid models** — those whose
+    state carries 2D ``u`` / ``v`` (SWM, Burgers). **Vorticity / streamfunction
+    models** (``barotropic_qg``, the vorticity Navier-Stokes) are intentionally
+    *not* covered: they evolve ``q`` / ``omega`` and never define a discrete
+    velocity divergence (non-divergence is only an analytic property, so a
+    divergence metric would be operator-dependent with no canonical zero —
+    misleading rather than diagnostic). Those models already report
+    ``kinetic_energy`` and ``enstrophy`` through their own ``diagnose`` output,
+    so they are not metric-less.
+
     Args:
         model: A constructed somax model.
         state: The state to evaluate (typically the final integrated state).

--- a/somax/eval.py
+++ b/somax/eval.py
@@ -1,0 +1,36 @@
+"""Public surface for somax's reference-free evaluation metrics.
+
+Field-level diagnostics computed on a model's own Cartesian grid — RMS
+divergence, total enstrophy, kinetic energy, and geostrophic imbalance —
+giving somax a quantitative evaluation surface for free-running simulations.
+These need only the state itself (no ground-truth reference); reference-based
+skill scores belong with the data-assimilation work in a later phase.
+
+:func:`compute_eval_metrics` is the convenient entry point: it returns every
+applicable metric for a ``(model, state)`` pair (and an empty dict for
+non-fluid models), and is what the ``somax-sim`` runner folds into
+``metrics.json``. The individual functions are exposed for ad-hoc analysis.
+
+Pure JAX / finitevolx (both base dependencies), so importing this is cheap;
+it is kept out of ``somax``'s top-level ``__init__`` only to mirror the
+module-per-surface layout (cf. :mod:`somax.operators`).
+"""
+
+from __future__ import annotations
+
+from somax._src.eval.metrics import (
+    compute_eval_metrics,
+    geostrophic_imbalance,
+    kinetic_energy,
+    rms_divergence,
+    total_enstrophy,
+)
+
+
+__all__ = [
+    "compute_eval_metrics",
+    "geostrophic_imbalance",
+    "kinetic_energy",
+    "rms_divergence",
+    "total_enstrophy",
+]

--- a/tests/eval/test_diagnostics.py
+++ b/tests/eval/test_diagnostics.py
@@ -1,0 +1,167 @@
+"""Tests for the reference-free evaluation metrics in ``somax.eval``.
+
+States are built from a real ``LinearShallowWater2D`` so the metrics run
+against genuine finitevolx ``Difference2D`` / ``Coriolis2D`` operators and
+grid, not mocks.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from somax._src.eval.metrics import (
+    compute_eval_metrics,
+    geostrophic_imbalance,
+    kinetic_energy,
+    rms_divergence,
+    total_enstrophy,
+)
+from somax._src.models.swm.linear_2d import LinearShallowWater2D, LinearSW2DState
+
+
+@pytest.fixture
+def model() -> LinearShallowWater2D:
+    """A small f-plane shallow-water model (β=0 → constant Coriolis)."""
+    return LinearShallowWater2D.create(nx=32, ny=32, Lx=1e6, Ly=1e6, f0=1e-4, beta=0.0)
+
+
+def _state(model: LinearShallowWater2D, h, u, v) -> LinearSW2DState:
+    shape = (model.grid.Ny, model.grid.Nx)
+    return LinearSW2DState(
+        h=jnp.broadcast_to(jnp.asarray(h, dtype=float), shape),
+        u=jnp.broadcast_to(jnp.asarray(u, dtype=float), shape),
+        v=jnp.broadcast_to(jnp.asarray(v, dtype=float), shape),
+    )
+
+
+# ----------------------------------------------------------------------
+# rms_divergence
+# ----------------------------------------------------------------------
+
+
+def test_rms_divergence_zero_for_uniform_flow(model):
+    """A spatially constant velocity field is divergence-free."""
+    state = _state(model, h=0.0, u=1.3, v=-0.7)
+    assert float(rms_divergence(state.u, state.v, model.diff)) == pytest.approx(
+        0.0, abs=1e-12
+    )
+
+
+def test_rms_divergence_positive_for_diverging_flow(model):
+    """A flow that ramps in x has nonzero divergence."""
+    x = jnp.arange(model.grid.Nx, dtype=float) * model.grid.dx
+    u = jnp.broadcast_to(x[None, :], (model.grid.Ny, model.grid.Nx))
+    state = LinearSW2DState(h=jnp.zeros_like(u), u=u, v=jnp.zeros_like(u))
+    assert float(rms_divergence(state.u, state.v, model.diff)) > 1e-8
+
+
+# ----------------------------------------------------------------------
+# total_enstrophy
+# ----------------------------------------------------------------------
+
+
+def test_total_enstrophy_zero_for_irrotational_flow(model):
+    """A spatially constant velocity field has zero vorticity."""
+    state = _state(model, h=0.0, u=2.0, v=3.0)
+    enstrophy = float(total_enstrophy(state.u, state.v, model.diff, model.grid))
+    assert enstrophy == pytest.approx(0.0, abs=1e-9)
+
+
+def test_total_enstrophy_positive_for_sheared_flow(model):
+    """A flow sheared in y carries vorticity ⇒ positive enstrophy."""
+    y = jnp.arange(model.grid.Ny, dtype=float) * model.grid.dy
+    u = jnp.broadcast_to(y[:, None], (model.grid.Ny, model.grid.Nx))
+    state = LinearSW2DState(h=jnp.zeros_like(u), u=u, v=jnp.zeros_like(u))
+    assert float(total_enstrophy(state.u, state.v, model.diff, model.grid)) > 0.0
+
+
+# ----------------------------------------------------------------------
+# kinetic_energy
+# ----------------------------------------------------------------------
+
+
+def test_kinetic_energy_matches_closed_form(model):
+    """KE of a uniform field equals 0.5·(u²+v²)·(interior area)."""
+    u0, v0 = 2.0, 1.0
+    state = _state(model, h=0.0, u=u0, v=v0)
+    n_interior = (model.grid.Ny - 2) * (model.grid.Nx - 2)
+    cell_area = model.grid.dx * model.grid.dy
+    expected = 0.5 * (u0**2 + v0**2) * n_interior * cell_area
+    got = float(kinetic_energy(state.u, state.v, model.grid))
+    assert got == pytest.approx(expected, rel=1e-6)
+
+
+def test_kinetic_energy_zero_at_rest(model):
+    state = _state(model, h=0.0, u=0.0, v=0.0)
+    assert float(kinetic_energy(state.u, state.v, model.grid)) == 0.0
+
+
+# ----------------------------------------------------------------------
+# geostrophic_imbalance
+# ----------------------------------------------------------------------
+
+
+def test_geostrophic_imbalance_unity_for_pure_inertial_flow(model):
+    """With no pressure gradient (h=0) the residual *is* the Coriolis term,
+    so the ageostrophic fraction is exactly 1."""
+    state = _state(model, h=0.0, u=0.5, v=-0.3)
+    assert float(geostrophic_imbalance(model, state)) == pytest.approx(1.0, rel=1e-6)
+
+
+def test_geostrophic_imbalance_near_zero_for_balanced_jet(model):
+    """A uniform geostrophic jet is in exact discrete balance.
+
+    Height linear in x (so ∂ₓη is an exact constant and ∂_yη ≡ 0) balanced
+    by a constant along-jet velocity ``v = (g/f)·∂ₓη`` and ``u = 0`` satisfies
+    the C-grid momentum balance term-for-term, independent of staggering.
+    """
+    g, f0 = model.consts.gravity, model.consts.f0
+    ny, nx = model.grid.Ny, model.grid.Nx
+    slope = 1e-3  # ∂η/∂x  (m height per m)
+    x = jnp.arange(nx, dtype=float) * model.grid.dx
+    h = jnp.broadcast_to(slope * x[None, :], (ny, nx))
+    v = jnp.full((ny, nx), (g / f0) * slope)
+    u = jnp.zeros((ny, nx))
+    state = LinearSW2DState(h=h, u=u, v=v)
+    imbalance = float(geostrophic_imbalance(model, state))
+    assert imbalance < 1e-6
+
+
+def test_geostrophic_imbalance_scale_invariant(model):
+    """The imbalance is a ratio, so scaling the whole state leaves it fixed."""
+    base = _state(model, h=2.0, u=0.5, v=-0.3)
+    scaled = LinearSW2DState(h=3.0 * base.h, u=3.0 * base.u, v=3.0 * base.v)
+    assert float(geostrophic_imbalance(model, scaled)) == pytest.approx(
+        float(geostrophic_imbalance(model, base)), rel=1e-5
+    )
+
+
+# ----------------------------------------------------------------------
+# compute_eval_metrics dispatcher
+# ----------------------------------------------------------------------
+
+
+def test_compute_eval_metrics_fluid_model(model):
+    state = _state(model, h=1.0, u=0.5, v=0.25)
+    metrics = compute_eval_metrics(model, state)
+    assert set(metrics) == {
+        "rms_divergence",
+        "total_enstrophy",
+        "kinetic_energy",
+        "geostrophic_imbalance",
+    }
+    assert all(isinstance(value, float) for value in metrics.values())
+    assert all(jnp.isfinite(jnp.asarray(value)) for value in metrics.values())
+
+
+def test_compute_eval_metrics_empty_for_non_fluid_model():
+    """A model without C-grid velocity fields yields no metrics."""
+
+    class _Scalar:  # stand-in for a Lorenz-style state (no u/v)
+        x = jnp.array(1.0)
+
+    class _NonFluidModel:  # no .diff / .grid
+        pass
+
+    assert compute_eval_metrics(_NonFluidModel(), _Scalar()) == {}

--- a/tests/eval/test_diagnostics.py
+++ b/tests/eval/test_diagnostics.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import pytest
 
-from somax._src.eval.metrics import (
+from somax.eval import (
     compute_eval_metrics,
     geostrophic_imbalance,
     kinetic_energy,

--- a/tests/eval/test_diagnostics.py
+++ b/tests/eval/test_diagnostics.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import jax.numpy as jnp
 import pytest
 
+from somax._src.models.swm.linear_2d import LinearShallowWater2D, LinearSW2DState
 from somax.eval import (
     compute_eval_metrics,
     geostrophic_imbalance,
@@ -17,7 +18,6 @@ from somax.eval import (
     rms_divergence,
     total_enstrophy,
 )
-from somax._src.models.swm.linear_2d import LinearShallowWater2D, LinearSW2DState
 
 
 @pytest.fixture

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -186,6 +186,65 @@ class TestSimulateHappyPath:
             if isinstance(value, (int, float)):
                 assert np.isfinite(value), f"metric {key!r} is non-finite: {value}"
 
+    def test_eval_metrics_persisted_for_2d_fluid_run(self, tmp_path: Path) -> None:
+        """A single-layer (2D) SWM run writes the ``somax.eval`` metrics into
+        ``metrics.json``, and a ``bounded_metric`` postflight assertion can
+        gate one of them.
+
+        The happy-path test above uses ``multilayer_nonlinear_swm`` (a 3D
+        state), for which ``compute_eval_metrics`` returns ``{}``; this covers
+        the 2D fluid case where the eval keys are actually produced. The
+        ``bounded_metric`` assertion on ``rms_divergence`` would raise if the
+        key were absent, so a clean run also proves the assertion read it.
+        """
+        spec = RunSpec(
+            scenario=ScenarioSpec(
+                name="double_gyre",
+                grid={"nx": 32, "ny": 32, "Lx": 1.0e6, "Ly": 1.0e6},
+                consts={"f0": 1.0e-4, "beta": 1.6e-11},
+                forcing={},
+                initial_condition={
+                    "type": "jet",
+                    "params": {
+                        "jet_speed": 0.5,
+                        "jet_width": 5.0e4,
+                        "perturbation": 0.01,
+                    },
+                },
+            ),
+            model=ModelSpec(
+                name="nonlinear_swm",
+                stratification={},
+                params={
+                    "H0": 1000.0,
+                    "lateral_viscosity": 100.0,
+                    "bottom_drag": 1.0e-7,
+                },
+            ),
+            timestepping=TimesteppingSpec(
+                t0=0.0, t1=3600.0, dt=10.0, save_interval=3600.0
+            ),
+            output=OutputSpec(write_snapshots=False, write_metrics=True),
+            debug=DebugSpec(),
+            assertions={"bounded_metric": {"name": "rms_divergence", "min": 0.0}},
+        )
+        result = _run.simulate(spec, tmp_path)
+
+        assert result.metrics_path is not None
+        with result.metrics_path.open() as f:
+            metrics = json.load(f)
+        for key in (
+            "rms_divergence",
+            "total_enstrophy",
+            "kinetic_energy",
+            "geostrophic_imbalance",
+        ):
+            assert key in metrics, f"missing eval metric {key!r}; have {sorted(metrics)}"
+            assert np.isfinite(metrics[key]), f"eval metric {key!r} non-finite"
+        # The jet carries real flow, so kinetic energy is strictly positive
+        # (guards against a degenerate all-zero metric path).
+        assert metrics["kinetic_energy"] > 0.0
+
 
 # ----------------------------------------------------------------------
 # End-to-end: CFL violation

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -239,7 +239,9 @@ class TestSimulateHappyPath:
             "kinetic_energy",
             "geostrophic_imbalance",
         ):
-            assert key in metrics, f"missing eval metric {key!r}; have {sorted(metrics)}"
+            assert key in metrics, (
+                f"missing eval metric {key!r}; have {sorted(metrics)}"
+            )
             assert np.isfinite(metrics[key]), f"eval metric {key!r} non-finite"
         # The jet carries real flow, so kinetic energy is strictly positive
         # (guards against a degenerate all-zero metric path).


### PR DESCRIPTION
## Summary

**Phase 3** of the ecosystem refactor (follows #124). Gives somax a quantitative **evaluation surface** it previously lacked — reference-free field diagnostics computed on a model's own Cartesian grid — with **no new dependency**.

## Why not xrtoolz?

The roadmap originally proposed reusing `xrtoolz` for IO + metrics. A survey of its actual API showed that premise doesn't hold:

- **IO swap has no target.** `xrtoolz.einx.pack_dataset`/`unpack_dataset` stack a Dataset's *variables* into a channel axis (an ML-export op) — they are not a pytree-state↔Dataset converter. And xrtoolz ships no NetCDF/Zarr IO of its own (it defers to xarray). somax's `_src/io/xarray.py` (security-allowlisted class round-trip, zarr-v3 handling) has nothing to swap onto, so it stays as-is.
- **Physical metrics assume ocean observations.** `geostrophic_balance_error` / `divergence_error` require lat/lon coords in degrees with Coriolis derived from latitude; somax runs on idealised Cartesian **f-/β-plane** grids (metres, no lat/lon coords). `pv_conservation_error` needs Lagrangian trajectories somax doesn't produce.
- **Heavy dependency.** xrtoolz pulls cartopy, pyproj, rioxarray, xskillscore, … (+ system GEOS/PROJ).

Decision (with maintainer): build a lightweight, model-appropriate evaluation surface on somax's native grid instead.

## What's added

**`somax.eval`** (`somax/_src/eval/metrics.py`) — reference-free diagnostics built on the finitevolx operators models already hold:

| Metric | Scope | Notes |
|---|---|---|
| `rms_divergence` | any C-grid fluid model | `sqrt(<(∇·u)²>)` via `diff.divergence` |
| `total_enstrophy` | any C-grid fluid model | `0.5 ∫ ζ² dA` via `diff.curl` |
| `kinetic_energy` | any C-grid fluid model | `0.5 ∫ (u²+v²) dA` |
| `geostrophic_imbalance` | shallow-water-type | model-aware: reuses the model's **own** pressure-gradient + Coriolis operators, so it measures departure from exactly the balance the model integrates around |

- `compute_eval_metrics(model, state)` — a **defensive dispatcher** returning the applicable metrics, and an empty dict for non-fluid models (Lorenz, diffusion) and multilayer (3D) states.
- Reductions use the grid **interior** (drop the one-cell ghost halo), matching the convention in the models' `diagnose` methods.

**Runner wiring** (`_src/cli/_run.py`): `compute_eval_metrics` is folded into `metrics.json` under the existing `write_metrics` flag, **try-wrapped** so it can never break a run. The existing generic `bounded_metric` postflight assertion already enforces `[min,max]` tolerances on any of these keys — so configs can gate e.g. `rms_divergence` with **no new assertion code**.

## Deferred to Phase 4 (DA)

Reference-based skill scores (RMSE, PSD score) need a truth trajectory / observations, so they land alongside the data-assimilation work. The xrtoolz `CMEMSSource`/`CDSSource` loaders remain the right tool for real basin data if/when that starts (kept out of somax's core).

## Tests

`tests/eval/test_diagnostics.py`, built from a real `LinearShallowWater2D` (genuine finitevolx operators, not mocks):
- divergence-free (uniform) and irrotational fields read ~0; diverging/sheared fields read positive
- kinetic energy matches a closed-form value; zero at rest
- **uniform geostrophic jet** (height linear in x balanced by constant `v`, `u=0`) reads imbalance `< 1e-6`; pure-inertial (h=0) reads exactly `1.0`; the ratio is scale-invariant
- dispatcher returns all four keys for a fluid model and `{}` for a non-fluid one

## Verification

- **488 passed** (+11 new), 152 slow deselected — no regressions in the fast suite
- `ruff check`, `ruff format --check`, `ty check` all clean

Design note (`content/notes/ecosystem_refactor_plan.md`) updated to record the revised Phase 3 and refresh the Phase 2 / status sections.

https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr)_