### PR TITLE
feat(observe): diagnostics, monitors & fail-fast observability

### DIFF
--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -170,21 +170,40 @@ def check_deformation_radius(
             "deformation_radius: consts.f0 is zero; L_d is undefined on an "
             "f-plane with no rotation."
         )
-    # Per-interface deformation radius sqrt(g'_k H_k) / f0; use the smallest
-    # (the tightest-to-resolve internal mode). The barotropic interface
-    # (g_prime[0] = full gravity) is excluded when internal modes exist.
-    g_prime_arr = np.asarray(jnp.asarray(g_prime))
-    H_arr = np.asarray(jnp.asarray(H))
-    radii = np.sqrt(g_prime_arr * H_arr) / f0_abs
-    internal = radii[1:] if radii.shape[0] > 1 else radii
-    Ld = float(np.min(internal))
+    # Prefer the model's vertical-mode deformation radii when available: the
+    # first internal radius comes from the vertical-mode eigenproblem, not
+    # just one interface's sqrt(g'_k H_k)/f0 (which can substantially
+    # overestimate the baroclinic radius for a thin upper layer). Fall back to
+    # the per-interface estimate only when the modal transform is absent.
+    modal = getattr(model, "modal", None)
+    modal_radii = getattr(modal, "rossby_radii", None) if modal is not None else None
+    if modal_radii is not None:
+        radii = np.asarray(jnp.asarray(modal_radii))
+        # The barotropic mode is infinite; keep only the finite internal modes.
+        finite = radii[np.isfinite(radii)]
+        if finite.size == 0:
+            raise AssertionFailedError(
+                "deformation_radius: model exposes no finite internal "
+                "deformation radius (modal.rossby_radii are all non-finite)."
+            )
+        Ld = float(np.min(finite))
+        source = "modal.rossby_radii"
+    else:
+        # Per-interface estimate sqrt(g'_k H_k)/f0; smallest internal mode.
+        g_prime_arr = np.asarray(jnp.asarray(g_prime))
+        H_arr = np.asarray(jnp.asarray(H))
+        radii = np.sqrt(g_prime_arr * H_arr) / f0_abs
+        internal = radii[1:] if radii.shape[0] > 1 else radii
+        Ld = float(np.min(internal))
+        source = "sqrt(g'H)/f0 estimate"
     dx_min = float(min(grid.dx, grid.dy))
     ratio = Ld / dx_min
     if ratio < n_cells_min:
         raise AssertionFailedError(
             f"deformation_radius check FAILED: L_d/dx = {ratio:.2f} < "
             f"{n_cells_min}\n"
-            f"  L_d   = {Ld:.0f} m (smallest internal deformation radius)\n"
+            f"  L_d   = {Ld:.0f} m (smallest internal deformation radius, "
+            f"from {source})\n"
             f"  dx    = {dx_min:.0f} m\n"
             f"  → eddies will be suppressed; refine the grid or pick an "
             f"eddy-permitting configuration."

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -37,7 +37,9 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
+import jax.numpy as jnp
 import numpy as np
+from loguru import logger
 
 
 if TYPE_CHECKING:
@@ -115,8 +117,210 @@ def check_cfl(
         )
 
 
+def check_deformation_radius(
+    spec: RunSpec,
+    model: Any,
+    *,
+    n_cells_min: float = 2.0,
+    n_cells_warn: float = 4.0,
+) -> None:
+    """Pre-flight: the first baroclinic deformation radius is resolved.
+
+    Resolving the first internal deformation radius ``L_d = sqrt(g'H)/f0``
+    with at least ``n_cells_min`` grid cells is necessary for baroclinic
+    instability and mesoscale eddies (Hallberg 2013). FAIL when
+    ``L_d/dx < n_cells_min``; WARN when ``n_cells_min <= L_d/dx <
+    n_cells_warn``.
+
+    Requires a stratified model exposing ``model.strat.g_prime`` /
+    ``model.strat.H`` and ``model.consts.f0`` (multilayer SWM, baroclinic /
+    reparameterized QG). Raises for models without that structure so a typo'd
+    config doesn't silently skip the check.
+
+    Args:
+        spec: The validated RunSpec (unused; present for signature symmetry).
+        model: The constructed model instance.
+        n_cells_min: Minimum ``L_d/dx`` below which to FAIL. Defaults to 2.0.
+        n_cells_warn: ``L_d/dx`` below which to WARN. Defaults to 4.0.
+
+    Raises:
+        AssertionFailedError: If the model lacks stratification/Coriolis, or
+            if ``L_d/dx < n_cells_min``.
+    """
+    strat = getattr(model, "strat", None)
+    consts = getattr(model, "consts", None)
+    grid = getattr(model, "grid", None)
+    if strat is None or grid is None or consts is None:
+        raise AssertionFailedError(
+            f"deformation_radius: model {type(model).__name__!r} lacks "
+            f"strat/consts/grid; this check applies to stratified models "
+            f"(multilayer SWM, baroclinic/reparameterized QG)."
+        )
+    g_prime = getattr(strat, "g_prime", None)
+    H = getattr(strat, "H", None)
+    f0 = getattr(consts, "f0", None)
+    if g_prime is None or H is None or f0 is None:
+        raise AssertionFailedError(
+            f"deformation_radius: model {type(model).__name__!r} does not "
+            f"expose strat.g_prime / strat.H / consts.f0; cannot compute L_d."
+        )
+    f0_abs = abs(float(f0))
+    if f0_abs == 0.0:
+        raise AssertionFailedError(
+            "deformation_radius: consts.f0 is zero; L_d is undefined on an "
+            "f-plane with no rotation."
+        )
+    # Per-interface deformation radius sqrt(g'_k H_k) / f0; use the smallest
+    # (the tightest-to-resolve internal mode). The barotropic interface
+    # (g_prime[0] = full gravity) is excluded when internal modes exist.
+    g_prime_arr = np.asarray(jnp.asarray(g_prime))
+    H_arr = np.asarray(jnp.asarray(H))
+    radii = np.sqrt(g_prime_arr * H_arr) / f0_abs
+    internal = radii[1:] if radii.shape[0] > 1 else radii
+    Ld = float(np.min(internal))
+    dx_min = float(min(grid.dx, grid.dy))
+    ratio = Ld / dx_min
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"deformation_radius check FAILED: L_d/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  L_d   = {Ld:.0f} m (smallest internal deformation radius)\n"
+            f"  dx    = {dx_min:.0f} m\n"
+            f"  → eddies will be suppressed; refine the grid or pick an "
+            f"eddy-permitting configuration."
+        )
+    if ratio < n_cells_warn:
+        logger.warning(
+            "deformation radius marginally resolved: L_d/dx = {:.2f} "
+            "(L_d={:.0f} m, dx={:.0f} m)",
+            ratio,
+            Ld,
+            dx_min,
+        )
+
+
+def check_pv_inversion(
+    spec: RunSpec,
+    model: Any,
+    *,
+    tol: float = 1e-6,
+) -> None:
+    """Pre-flight: the barotropic-QG PV-inversion round-trip closes to eps.
+
+    Inverts the model's initial PV to a streamfunction and re-derives PV via
+    the Laplacian, asserting a small relative residual. Catches a broken
+    elliptic solver, wrong boundary stencil, or mis-staggered field *before*
+    burning compute on the integration.
+
+    Scoped to **barotropic** QG, where the PV is exactly the relative
+    vorticity ``q = nabla^2 psi`` (a 2-D PV field). Baroclinic /
+    reparameterized QG invert a modal Helmholtz operator
+    ``q = nabla^2 psi - f0^2 A psi``; re-deriving with the bare Laplacian would
+    drop the stretching term and the residual would be O(1) for a perfectly
+    balanced state, so those models are rejected rather than checked with the
+    wrong operator. Raises for non-QG models too, so a typo doesn't silently
+    skip the check.
+
+    Args:
+        spec: The validated RunSpec (used only to rebuild the initial state).
+        model: The constructed barotropic QG model instance.
+        tol: Maximum allowed relative residual ``||L(psi) - q|| / ||q||``.
+
+    Raises:
+        AssertionFailedError: If the model is not a barotropic QG model, or if
+            the round-trip residual exceeds ``tol``.
+    """
+    invert = getattr(model, "_invert_pv", None)
+    diff = getattr(model, "diff", None)
+    if invert is None or diff is None or not hasattr(diff, "laplacian"):
+        raise AssertionFailedError(
+            f"pv_inversion: model {type(model).__name__!r} has no _invert_pv / "
+            f"diff.laplacian; this check applies to barotropic QG."
+        )
+    # Build the factory initial state for this scenario x model pair.
+    from somax._src.cli._factories import build
+    from somax._src.cli._run import _model_params, _scenario_params
+
+    _model, state0 = build(
+        spec.scenario.name,
+        spec.model.name,
+        scenario_params=_scenario_params(spec),
+        model_params=_model_params(spec),
+    )
+    q = state0.q
+    if q.ndim != 2:
+        raise AssertionFailedError(
+            f"pv_inversion: model {type(model).__name__!r} has a "
+            f"{q.ndim}-D PV field; this check is scoped to barotropic QG "
+            f"(2-D PV, q = laplacian(psi)). Baroclinic / reparameterized QG "
+            f"invert a modal Helmholtz operator with a stretching term that "
+            f"the bare Laplacian round-trip cannot reproduce."
+        )
+    psi = invert(q)
+    q_hat = diff.laplacian(psi)
+    # Compare on the interior (drop the one-cell ghost halo the BC owns).
+    interior = (slice(1, -1), slice(1, -1))
+    num = float(jnp.linalg.norm((q_hat - q)[interior]))
+    den = float(jnp.linalg.norm(q[interior]))
+    if den < 1e-30:
+        # A zero initial PV trivially round-trips; nothing to assert.
+        return
+    residual = num / den
+    if residual > tol:
+        raise AssertionFailedError(
+            f"pv_inversion check FAILED: relative residual {residual:.2e} > "
+            f"tol {tol:.0e}\n"
+            f"  ||laplacian(psi) - q|| / ||q|| over the interior.\n"
+            f"  A clean elliptic solver should close this to ~machine eps; a "
+            f"large residual points at a broken solver, wrong BC stencil, or "
+            f"mis-staggered field."
+        )
+
+
+def check_static_stability(spec: RunSpec, model: Any) -> None:
+    """Pre-flight: the stratification is statically stable (g' > 0).
+
+    A layered model is statically stable when every interface reduced gravity
+    is positive (``g'_k > 0`` ⇔ ``N^2 > 0`` ⇔ density increasing with depth).
+    A non-positive interface reduced gravity is a convectively unstable /
+    mis-ordered density profile.
+
+    Applies to stratified models exposing ``model.strat.g_prime``; raises for
+    models without it.
+
+    Args:
+        spec: The validated RunSpec (unused; signature symmetry).
+        model: The constructed model instance.
+
+    Raises:
+        AssertionFailedError: If the model lacks stratification, or any
+            internal interface reduced gravity is non-positive.
+    """
+    strat = getattr(model, "strat", None)
+    g_prime = getattr(strat, "g_prime", None) if strat is not None else None
+    if g_prime is None:
+        raise AssertionFailedError(
+            f"static_stability: model {type(model).__name__!r} has no "
+            f"strat.g_prime; this check applies to stratified layered models."
+        )
+    g_prime_arr = np.asarray(jnp.asarray(g_prime))
+    # g_prime[0] is the surface (full gravity); internal interfaces are [1:].
+    internal = g_prime_arr[1:] if g_prime_arr.shape[0] > 1 else g_prime_arr
+    if np.any(internal <= 0.0):
+        bad = np.where(internal <= 0.0)[0] + 1
+        raise AssertionFailedError(
+            f"static_stability check FAILED: non-positive reduced gravity at "
+            f"interface(s) {bad.tolist()} (g' = {internal.tolist()}).\n"
+            f"  N^2 <= 0 implies a convectively unstable / mis-ordered density "
+            f"profile. Order layers light-to-dense (top-to-bottom)."
+        )
+
+
 PREFLIGHT_ASSERTIONS: dict[str, Callable[..., None]] = {
     "cfl": check_cfl,
+    "deformation_radius": check_deformation_radius,
+    "pv_inversion": check_pv_inversion,
+    "static_stability": check_static_stability,
 }
 
 

--- a/somax/_src/cli/_run.py
+++ b/somax/_src/cli/_run.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any
 
 import diffrax as dfx
+import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
 from loguru import logger
@@ -36,6 +37,8 @@ from somax._src.cli._units import (
 )
 from somax._src.cli.spec import RunSpec, dump_yaml
 from somax._src.eval.metrics import compute_eval_metrics
+from somax._src.monitor import ChunkInfo, default_monitors
+from somax._src.monitor.protocol import Monitor
 
 
 class IntegrationDivergedError(RuntimeError):
@@ -234,6 +237,7 @@ def _integrate_and_write(
     initial_state: Any | None,
     diagnostics_per_save: int = 1,
     checkpoint_every_n_chunks: int = 0,
+    monitors: list[Monitor] | None = None,
 ) -> SimulationResult:
     """Build the model, integrate, write artifacts, return summary.
 
@@ -359,10 +363,29 @@ def _integrate_and_write(
             max_steps_per_chunk=per_chunk_max,
             run_log=run_log,
             mode=mode,
+            monitors=monitors,
+            spec=spec,
             checkpoint_every_n_chunks=checkpoint_every_n_chunks,
             checkpoint_dir=output_dir if checkpoint_every_n_chunks > 0 else None,
             checkpoint_label=f"{spec.scenario.name}/{spec.model.name}",
         )
+    except eqx.EquinoxRuntimeError as exc:
+        # An in-JIT guard (somax.guards, e.g. layer-thickness positivity or
+        # the RHS non-finite tripwire) fired *inside* model.integrate. This
+        # halts at the offending step — earlier than the chunk-boundary
+        # monitors — but the runner's contract is that a blow-up surfaces as
+        # IntegrationDivergedError and writes no artifacts, so translate it
+        # while preserving the guard's diagnostic.
+        stop_run_log(
+            run_log,
+            final_message=f"FAILED during integrate: {type(exc).__name__}: {exc}",
+        )
+        raise IntegrationDivergedError(
+            f"somax-sim {mode} integration produced a non-finite or "
+            f"non-physical state and an in-JIT guard halted it at the "
+            f"offending step (likely a CFL violation): {exc}\n"
+            f"  Refusing to write artifacts."
+        ) from exc
     except Exception as exc:
         stop_run_log(
             run_log,
@@ -446,6 +469,14 @@ def _integrate_and_write(
         resolved_path = output_dir / "resolved.yaml"
         dump_yaml(spec, str(resolved_path))
         logger.info("wrote {}", resolved_path)
+
+        # 12. Provenance manifest (git commit, library versions, platform,
+        #     solver/timestepping) for run reproducibility + determinism CI.
+        manifest_path = output_dir / "manifest.json"
+        manifest = _build_manifest(spec, mode=mode, wallclock=wallclock)
+        with manifest_path.open("w") as f:
+            json.dump(manifest, f, indent=2, sort_keys=True)
+        logger.info("wrote {}", manifest_path)
     except Exception as exc:
         stop_run_log(
             run_log,
@@ -565,11 +596,6 @@ def _format_physical_scalars(model: Any, state: Any) -> tuple[str, dict[str, flo
     return " ".join(parts), flat
 
 
-def _has_non_finite(diag: dict[str, dict[str, float]]) -> bool:
-    """True iff any field reported one or more non-finite values."""
-    return any(stats["nan"] > 0 for stats in diag.values())
-
-
 def _build_diagnostic_grid(
     save_ts: np.ndarray, diagnostics_per_save: int
 ) -> tuple[np.ndarray, set[int]]:
@@ -612,9 +638,6 @@ class _ChunkCarry:
 
     Args:
         index: Next diagnostic-chunk index to integrate (0-based).
-        prev_energy: Total-energy-like scalar from the previous chunk,
-            used to flag >10x growth before a NaN appears. ``None`` until
-            the first chunk produces one.
         snapshot_ordinal: Count of snapshots retained so far, excluding
             the initial state (matches ``len(save_states) - 1`` in the
             original loop — the cadence key for crash-recovery
@@ -625,10 +648,13 @@ class _ChunkCarry:
             frozen dataclass only forbids rebinding the field, not
             mutating the list it points to, so accumulation stays
             amortized O(1) per snapshot (a tuple would be O(N²)).
+
+    Energy-growth tracking, which used to live on this carry, now lives
+    inside :class:`somax.monitor.EnergyGrowthMonitor` (a host-side object),
+    so the carry is back to pure bookkeeping.
     """
 
     index: int
-    prev_energy: float | None
     snapshot_ordinal: int
     save_states: list[Any]
 
@@ -663,6 +689,7 @@ class _ChunkStep(StatefulOperator):
         checkpoint_every_n_chunks: int,
         checkpoint_dir: Path | None,
         checkpoint_label: str | None,
+        monitors: list[Monitor],
     ) -> None:
         self.model = model
         self.state_class = state_class
@@ -676,6 +703,7 @@ class _ChunkStep(StatefulOperator):
         self.checkpoint_every_n_chunks = checkpoint_every_n_chunks
         self.checkpoint_dir = checkpoint_dir
         self.checkpoint_label = checkpoint_label
+        self.monitors = monitors
 
     def _apply(self, state: Any, carry: _ChunkCarry) -> tuple[Any, _ChunkCarry]:
         log = self.run_log.log
@@ -696,68 +724,71 @@ class _ChunkStep(StatefulOperator):
 
         new_state = _extract_final_state(sol.ys, self.state_class)
         state_diag = _state_diagnostics(new_state)
-        phys_line, phys_flat = _format_physical_scalars(self.model, new_state)
+        phys_line, _phys_flat = _format_physical_scalars(self.model, new_state)
 
-        # Detect large energy jumps (10x growth between chunks is suspicious)
-        # to give the user an early warning before NaN appears.
-        energy_value: float | None = None
-        for k in (
-            "total_energy",
-            "energy",
-            "total_kinetic_energy",
-            "kinetic_energy",
-        ):
-            if k in phys_flat:
-                energy_value = float(phys_flat[k])
-                break
-        warning = ""
-        prev_energy = carry.prev_energy
-        if (
-            prev_energy is not None
-            and energy_value is not None
-            and abs(prev_energy) > 0
-            and not np.isnan(energy_value)
-            and abs(energy_value) > 10 * abs(prev_energy)
-        ):
-            # Both branches inside this block know prev_energy and
-            # energy_value are non-None floats; help ty narrow the types.
-            prev_e: float = prev_energy
-            cur_e: float = energy_value
-            growth = cur_e / prev_e if prev_e != 0 else float("inf")
-            warning = f" !! energy grew {growth:.1f}x from previous chunk"
-        new_prev_energy = prev_energy
-        if energy_value is not None and not np.isnan(energy_value):
-            new_prev_energy = energy_value
+        # Fan out to the registered monitors. The non-finite abort and the
+        # energy-growth warning that used to be inline here are now the
+        # NonFiniteMonitor / EnergyGrowthMonitor plugins (see
+        # somax.monitor.default_monitors); each monitor records metrics +
+        # messages and may request a clean termination.
+        is_snapshot_boundary = (i + 1) in self.save_indices
+        info = ChunkInfo(
+            index=i,
+            n_chunks=self.n_diag_intervals,
+            t0=chunk_t0,
+            t1=chunk_t1,
+            wall_seconds=chunk_wall,
+            is_snapshot=is_snapshot_boundary,
+            stats=_solver_stats(sol),
+        )
+        monitor_msgs: list[str] = []
+        monitor_metrics: dict[str, float] = {}
+        terminate_reason: str | None = None
+        for mon in self.monitors:
+            verdict = mon.on_chunk_end(self.model, new_state, info)
+            # Record-only diagnostics: prefix with the monitor name so keys
+            # from different monitors don't collide in the per-chunk log.
+            for key, value in verdict.metrics.items():
+                monitor_metrics[f"{mon.name}.{key}"] = value
+            for msg in verdict.messages:
+                monitor_msgs.append(f"[{mon.name}] {msg}")
+            if verdict.terminate and terminate_reason is None:
+                terminate_reason = f"monitor {mon.name!r}: {verdict.reason}"
 
+        metric_line = ""
+        if monitor_metrics:
+            metric_line = " | monitors: " + " ".join(
+                f"{k}={v:.3g}" for k, v in monitor_metrics.items()
+            )
         log.debug(
             f"chunk {i + 1}/{self.n_diag_intervals} "
             f"sim_t={format_time_seconds(chunk_t1)} | "
             f"{_format_state_stats(state_diag)}"
             + (f" | physics: {phys_line}" if phys_line else "")
             + f" | wall={format_wallclock(chunk_wall)}"
-            + warning
+            + metric_line
+            + ("".join(f" !! {m}" for m in monitor_msgs) if monitor_msgs else "")
         )
 
-        if _has_non_finite(state_diag):
+        if terminate_reason is not None:
             log.debug(
-                f"ABORT at chunk {i + 1}/{self.n_diag_intervals}: non-finite state"
+                f"ABORT at chunk {i + 1}/{self.n_diag_intervals}: {terminate_reason}"
             )
             raise IntegrationDivergedError(
-                f"somax-sim {self.mode} integration produced non-finite values "
-                f"during chunk {i + 1}/{self.n_diag_intervals} "
-                f"(sim_t={format_time_seconds(chunk_t1)}).\n"
+                f"somax-sim {self.mode} integration halted during chunk "
+                f"{i + 1}/{self.n_diag_intervals} "
+                f"(sim_t={format_time_seconds(chunk_t1)}): {terminate_reason}.\n"
                 f"  {_format_state_stats(state_diag)}\n"
-                f"  Refusing to write artifacts. The non-finite values "
-                f"appeared between sim_t={format_time_seconds(chunk_t0)} and "
+                f"  Refusing to write artifacts. The condition appeared between "
+                f"sim_t={format_time_seconds(chunk_t0)} and "
                 f"sim_t={format_time_seconds(chunk_t1)} — earlier chunks were "
-                f"finite. This is consistent with a slow numerical instability, "
-                f"not an immediate CFL violation."
+                f"clean."
             )
 
         # Only retain states at snapshot boundaries. Append in place to the
         # threaded list (amortized O(1)); the same list object flows through
         # every carry, so the final carry holds the full trajectory.
-        is_snapshot_boundary = (i + 1) in self.save_indices
+        # ``is_snapshot_boundary`` was computed above for the ChunkInfo.
         new_save_states = carry.save_states
         if is_snapshot_boundary:
             new_save_states.append(new_state)
@@ -799,7 +830,6 @@ class _ChunkStep(StatefulOperator):
 
         new_carry = _ChunkCarry(
             index=i + 1,
-            prev_energy=new_prev_energy,
             snapshot_ordinal=new_ordinal,
             save_states=new_save_states,
         )
@@ -816,6 +846,8 @@ def _chunked_integrate_with_diagnostics(
     max_steps_per_chunk: int,
     run_log: RunLogContext,
     mode: str,
+    monitors: list[Monitor] | None = None,
+    spec: RunSpec | None = None,
     checkpoint_every_n_chunks: int = 0,
     checkpoint_dir: Path | None = None,
     checkpoint_label: str | None = None,
@@ -879,6 +911,9 @@ def _chunked_integrate_with_diagnostics(
     import jax
 
     log = run_log.log
+    active_monitors: list[Monitor] = (
+        monitors if monitors is not None else default_monitors()
+    )
     save_ts_np = np.asarray(save_ts)
     diag_ts, save_indices = _build_diagnostic_grid(save_ts_np, diagnostics_per_save)
     n_diag_intervals = diag_ts.shape[0] - 1
@@ -893,6 +928,9 @@ def _chunked_integrate_with_diagnostics(
         + " | initial state"
     )
 
+    for mon in active_monitors:
+        mon.on_run_start(model, state0, spec=spec)
+
     step = _ChunkStep(
         model=model,
         state_class=type(state0),
@@ -906,22 +944,30 @@ def _chunked_integrate_with_diagnostics(
         checkpoint_every_n_chunks=checkpoint_every_n_chunks,
         checkpoint_dir=checkpoint_dir,
         checkpoint_label=checkpoint_label,
+        monitors=active_monitors,
     )
     carry0 = _ChunkCarry(
         index=0,
-        prev_energy=None,
         snapshot_ordinal=0,
         save_states=[state0],
     )
     cycle = Cycle(step_op=step, n_steps=n_diag_intervals)
 
     t_chunks_start = time.perf_counter()
-    _final_state, final_carry = cycle(state0, carry0)
+    try:
+        final_state, final_carry = cycle(state0, carry0)
+    except Exception:
+        for mon in active_monitors:
+            mon.on_run_end(model, state0, ok=False)
+        raise
     total_chunks_wall = time.perf_counter() - t_chunks_start
     log.debug(
         f"all {n_diag_intervals} chunks completed in "
         f"{format_wallclock(total_chunks_wall)}"
     )
+
+    for mon in active_monitors:
+        mon.on_run_end(model, final_state, ok=True)
 
     # Concatenate snapshot states into a single time-stacked pytree
     # matching the shape diffrax would have returned with
@@ -999,6 +1045,107 @@ def _maybe_step_count(sol: dfx.Solution) -> int | None:
         return None
 
 
+def _git_provenance() -> dict[str, Any]:
+    """Best-effort ``{git_commit, git_dirty}`` for the somax checkout.
+
+    Returns ``{"git_commit": None, "git_dirty": None}`` if git is unavailable
+    or this is not a working tree (e.g. an installed wheel).
+    """
+    import subprocess
+
+    repo_dir = Path(__file__).resolve().parent
+    try:
+        commit = (
+            subprocess.check_output(
+                ["git", "-C", str(repo_dir), "rev-parse", "HEAD"],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+        status = subprocess.check_output(
+            ["git", "-C", str(repo_dir), "status", "--porcelain"],
+            stderr=subprocess.DEVNULL,
+        ).decode()
+        return {"git_commit": commit, "git_dirty": bool(status.strip())}
+    except (subprocess.SubprocessError, OSError):
+        return {"git_commit": None, "git_dirty": None}
+
+
+def _build_manifest(spec: RunSpec, *, mode: str, wallclock: float) -> dict[str, Any]:
+    """Assemble the provenance manifest written next to ``metrics.json``.
+
+    Captures the git commit + dirty flag, key library versions, the JAX
+    platform / x64 flag / device count, a config hash, and the
+    solver/timestepping knobs — enough to reproduce a run and to drive a
+    determinism check in CI.
+    """
+    import hashlib
+    import importlib.metadata as importlib_metadata
+    import platform as _platform
+
+    import jax
+
+    def _version(pkg: str) -> str | None:
+        try:
+            return importlib_metadata.version(pkg)
+        except importlib_metadata.PackageNotFoundError:
+            return None
+
+    try:
+        config_repr = json.dumps(spec.to_dict(), sort_keys=True, default=str)
+    except (TypeError, ValueError, AttributeError):
+        config_repr = repr(spec)
+    config_sha = hashlib.sha256(config_repr.encode("utf-8")).hexdigest()
+
+    manifest: dict[str, Any] = {
+        "mode": mode,
+        "somax_version": _version("somax"),
+        "jax_version": getattr(jax, "__version__", None),
+        "diffrax_version": _version("diffrax"),
+        "finitevolx_version": _version("finitevolx"),
+        "x64_enabled": bool(jax.config.read("jax_enable_x64")),
+        "platform": jax.default_backend(),
+        "python": _platform.python_version(),
+        "device_count": jax.device_count(),
+        "config_sha256": config_sha,
+        "t0": spec.timestepping.t0,
+        "t1": spec.timestepping.t1,
+        "dt": spec.timestepping.dt,
+        "wallclock_seconds": wallclock,
+    }
+    manifest.update(_git_provenance())
+    return manifest
+
+
+def _solver_stats(sol: dfx.Solution) -> dict[str, Any]:
+    """Host-side copy of a diffrax solution's solver stats + result.
+
+    Pulls ``num_accepted_steps`` / ``num_rejected_steps`` / ``num_steps``
+    (coerced to plain ints) and the ``result`` so they survive onto a
+    :class:`somax.monitor.ChunkInfo`, where the runner previously discarded
+    them (``stats={}``). Best-effort: returns whatever is available.
+    """
+    import contextlib
+
+    out: dict[str, Any] = {}
+    stats = getattr(sol, "stats", None)
+    if stats:
+        for key in ("num_steps", "num_accepted_steps", "num_rejected_steps"):
+            value = stats.get(key)
+            if value is None:
+                continue
+            with contextlib.suppress(TypeError, ValueError):
+                out[key] = int(np.asarray(value))
+    result = getattr(sol, "result", None)
+    if result is not None:
+        # ``str(result)`` is uninformative (every diffrax RESULTS renders as
+        # ``RESULTS<>``), so record a clean success flag instead.
+        with contextlib.suppress(Exception):
+            out["result_successful"] = bool(result == dfx.RESULTS.successful)
+    return out
+
+
 # ----------------------------------------------------------------------
 # Public entry points — one per CLI subcommand
 # ----------------------------------------------------------------------
@@ -1010,6 +1157,7 @@ def simulate(
     *,
     diagnostics_per_save: int = 1,
     checkpoint_every_n_chunks: int = 0,
+    monitors: list[Monitor] | None = None,
 ) -> SimulationResult:
     """Run a fresh simulation from factory-built initial conditions.
 
@@ -1025,6 +1173,10 @@ def simulate(
             (default 1). Higher = more lines per snapshot in run.log.
         checkpoint_every_n_chunks: Crash-recovery cadence (#70). ``0``
             (default) disables crash checkpoints.
+        monitors: Chunk-boundary monitors (see :mod:`somax.monitor`).
+            ``None`` (default) uses ``default_monitors()`` — the same
+            non-finite abort + energy-growth warning as before, plus
+            record-only conservation/solver/throughput diagnostics.
     """
     return _integrate_and_write(
         spec,
@@ -1033,6 +1185,7 @@ def simulate(
         initial_state=None,
         diagnostics_per_save=diagnostics_per_save,
         checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+        monitors=monitors,
     )
 
 
@@ -1042,6 +1195,7 @@ def spinup(
     *,
     diagnostics_per_save: int = 1,
     checkpoint_every_n_chunks: int = 0,
+    monitors: list[Monitor] | None = None,
 ) -> SimulationResult:
     """Run a spinup integration. Saves only the endpoint.
 
@@ -1056,6 +1210,7 @@ def spinup(
         initial_state=None,
         diagnostics_per_save=diagnostics_per_save,
         checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+        monitors=monitors,
     )
 
 
@@ -1124,6 +1279,7 @@ def restart(
     restart_from: str | Path,
     diagnostics_per_save: int = 1,
     checkpoint_every_n_chunks: int = 0,
+    monitors: list[Monitor] | None = None,
 ) -> SimulationResult:
     """Resume a simulation from a previously saved state.
 
@@ -1184,4 +1340,5 @@ def restart(
         initial_state=state0,
         diagnostics_per_save=diagnostics_per_save,
         checkpoint_every_n_chunks=checkpoint_every_n_chunks,
+        monitors=monitors,
     )

--- a/somax/_src/core/types.py
+++ b/somax/_src/core/types.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import equinox as eqx
+from jaxtyping import Array
 
 
 class State(eqx.Module):
@@ -34,3 +35,27 @@ class Diagnostics(eqx.Module):
 
     Computed from a model state via ``model.diagnose(state)``.
     """
+
+    def invariants(self) -> dict[str, Array]:
+        """Conserved quantities this model advertises for drift tracking.
+
+        Maps an invariant name to a scalar (or per-layer vector) that is
+        *conserved* by the continuous dynamics — mass, total energy,
+        potential enstrophy, PV Casimirs, momentum, … — so a monitor can
+        track the relative drift ``(I(t) - I(0)) / I(0)`` over a run without
+        knowing model specifics (see
+        :class:`somax.monitor.ConservationDriftMonitor`).
+
+        The base implementation returns an empty dict; models override it to
+        expose the invariants their ``Diagnostics`` subclass carries. Whether
+        a given invariant is *exactly* conserved depends on the scheme (e.g.
+        the Arakawa Jacobian conserves energy/enstrophy up to time-truncation
+        error; finite-volume upwind PV advection conserves mass to machine
+        precision but dissipates energy/enstrophy implicitly), so callers
+        should treat non-mass invariants as drift signals, not zero targets.
+
+        Returns:
+            Mapping from invariant name to its current value. Empty by
+            default.
+        """
+        return {}

--- a/somax/_src/eval/__init__.py
+++ b/somax/_src/eval/__init__.py
@@ -6,6 +6,7 @@ from somax._src.eval.metrics import (
     compute_eval_metrics,
     geostrophic_imbalance,
     kinetic_energy,
+    qg_balance_residual,
     rms_divergence,
     total_enstrophy,
 )
@@ -15,6 +16,7 @@ __all__ = [
     "compute_eval_metrics",
     "geostrophic_imbalance",
     "kinetic_energy",
+    "qg_balance_residual",
     "rms_divergence",
     "total_enstrophy",
 ]

--- a/somax/_src/eval/metrics.py
+++ b/somax/_src/eval/metrics.py
@@ -32,6 +32,7 @@ the metric with boundary / ghost-point artifacts.
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
@@ -187,11 +188,80 @@ def geostrophic_imbalance(
     return residual / (scale + eps)
 
 
+def qg_balance_residual(
+    model: Any,
+    state: State,
+    *,
+    interior: bool = True,
+    eps: float = 1e-30,
+) -> Float[Array, ""]:
+    r"""Dimensionless PV-inversion residual for a **barotropic** QG model.
+
+    The QG balance analog of :func:`geostrophic_imbalance` for vorticity /
+    streamfunction models: instead of a velocity-divergence residual (which QG
+    models do not define), it measures how well the state's PV closes its own
+    inversion. For barotropic QG the PV *is* the relative vorticity,
+    ``q = nabla^2 psi``, so with ``psi = L^{-1} q`` and
+    ``q_hat = laplacian(psi)`` it returns
+
+    .. math::
+
+        \frac{\lVert \hat q - q \rVert}{\lVert q \rVert + \epsilon},
+
+    reduced over the grid interior. For a freshly inverted state this is
+    ~machine-eps; a large value flags a state inconsistent with the model's
+    elliptic operator.
+
+    Restricted to barotropic QG (a 2-D PV field). Baroclinic / reparameterized
+    QG invert a *modal Helmholtz* operator ``q = nabla^2 psi - f0^2 A psi``;
+    the bare Laplacian omits the stretching term, so this residual would be
+    O(1) even for a perfectly balanced state. Reconstructing the full
+    stretching operator here would duplicate model internals, so the check is
+    intentionally scoped to the barotropic case (use :meth:`model.diagnose`
+    invariants for the layered models). Returns ``0.0`` for a trivially zero
+    PV field.
+
+    Args:
+        model: The constructed barotropic QG model.
+        state: A state carrying a 2-D PV field ``q``.
+        interior: Drop the one-cell ghost halo before reducing. Defaults True.
+        eps: Small constant guarding the normalisation.
+
+    Returns:
+        Scalar dimensionless residual.
+    """
+    q = state.q
+    psi = model._invert_pv(q)
+    q_hat = model.diff.laplacian(psi)
+    trim = _INTERIOR if interior else (...,)
+    resid = (q_hat - q)[trim]
+    ref = q[trim]
+    return jnp.linalg.norm(resid) / (jnp.linalg.norm(ref) + eps)
+
+
 def _is_fluid_state(state: State) -> bool:
     """A 2D C-grid velocity state we can compute field metrics for."""
     if not (hasattr(state, "u") and hasattr(state, "v")):
         return False
     return jnp.ndim(state.u) == 2 and jnp.ndim(state.v) == 2
+
+
+def _supports_qg_balance(model: Any, state: State) -> bool:
+    """Whether ``qg_balance_residual`` applies — barotropic QG only.
+
+    A 2-D PV field signals the barotropic ``q = nabla^2 psi`` relation the
+    residual assumes; baroclinic / reparameterized QG (3-D PV, modal-Helmholtz
+    inversion with a stretching term) are excluded.
+    """
+    diff = getattr(model, "diff", None)
+    q = getattr(state, "q", None)
+    return (
+        q is not None
+        and jnp.ndim(q) == 2
+        and hasattr(model, "_invert_pv")
+        and diff is not None
+        and hasattr(diff, "laplacian")
+    )
 
 
 def _supports_geostrophy(model: Any, state: State) -> bool:
@@ -229,13 +299,35 @@ def compute_eval_metrics(model: Any, state: State) -> dict[str, float]:
         state: The state to evaluate (typically the final integrated state).
 
     Returns:
-        Flat ``{metric_name: float}`` dict — a subset of ``rms_divergence``,
-        ``total_enstrophy``, ``kinetic_energy`` and ``geostrophic_imbalance``.
+        Flat ``{metric_name: float}`` dict. For velocity-state models a subset
+        of ``rms_divergence`` / ``total_enstrophy`` / ``kinetic_energy`` /
+        ``geostrophic_imbalance``; for QG (vorticity/streamfunction) models a
+        ``qg_balance_residual``. Plus any conserved quantities the model's
+        ``diagnose(state).invariants()`` advertises, prefixed ``invariant_``.
         Empty when no metric applies.
     """
     out: dict[str, float] = {}
+
+    # Conserved-invariant snapshot — works for any model that advertises them
+    # via diagnose().invariants() (SWM mass/energy/enstrophy/Casimir, QG
+    # energy/enstrophy), independent of the velocity-state field metrics below.
+    try:
+        invariants = model.diagnose(state).invariants()
+    except Exception:
+        invariants = {}
+    for name, value in invariants.items():
+        with contextlib.suppress(TypeError, ValueError):
+            out[f"invariant_{name}"] = float(jnp.asarray(value))
+
     if not (hasattr(model, "diff") and hasattr(model, "grid")):
         return out
+
+    # QG (vorticity/streamfunction) models: a PV-inversion balance residual
+    # stands in for the velocity-divergence metric they cannot define.
+    if _supports_qg_balance(model, state):
+        out["qg_balance_residual"] = float(qg_balance_residual(model, state))
+        return out
+
     if not _is_fluid_state(state):
         return out
 

--- a/somax/_src/guards.py
+++ b/somax/_src/guards.py
@@ -1,0 +1,86 @@
+"""In-JIT fail-fast tripwires for somax model computations.
+
+These are tiny, JIT/``vmap``/``grad``-safe predicates that return their
+input array unchanged so they drop transparently into a tendency
+computation::
+
+    h = guard_positive(h, where="layer thickness h_k")  # raises if h <= 0
+
+They are built on :func:`equinox.error_if`, which raises *immediately* when
+the predicate is true (unlike ``jax.experimental.checkify``, which defers the
+raise to the end of the JIT region — wrong for fail-fast, since the blown-up
+chunk would run to completion first). Equinox is a base somax dependency, so
+no extra install is needed.
+
+The runtime cost of the check, and what happens on failure, is governed by the
+``EQX_ON_ERROR`` environment variable (``breakpoint`` while debugging,
+``nan``/``off`` to disable for validated production sweeps). See the Equinox
+docs for ``equinox.error_if`` and ``equinox.debug``.
+
+These guards are the *in-JIT* counterpart to the host-side checks in the
+``somax-sim`` runner (``_assert_finite_state``) and the :mod:`somax.monitor`
+chunk-boundary monitors: a guard halts **at** the offending step, before the
+rest of a multi-thousand-step chunk runs.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+from jaxtyping import Array
+
+
+def guard_finite(x: Array, *, where: str) -> Array:
+    """Return ``x`` unchanged, raising in-JIT if it holds any NaN/Inf.
+
+    Args:
+        x: Array to check (returned unchanged).
+        where: Human-readable location for the error message (e.g.
+            ``"RHS"`` or ``"layer thickness h_k"``).
+
+    Returns:
+        ``x`` unchanged. Raises at trace/run time via
+        :func:`equinox.error_if` when any element is non-finite.
+    """
+    return eqx.error_if(x, jnp.any(~jnp.isfinite(x)), f"non-finite state in {where}")
+
+
+def guard_positive(x: Array, *, where: str, floor: float = 0.0) -> Array:
+    """Return ``x`` unchanged, raising in-JIT if any element ``<= floor``.
+
+    The canonical use is layer-thickness positivity in multilayer SWM: the
+    PV ``q_k = (zeta_k + f) / h_k`` is singular as ``h_k -> 0+``, so a
+    non-positive thickness makes the remaining computation meaningless
+    (FAIL-HARD).
+
+    Args:
+        x: Array to check (returned unchanged).
+        where: Human-readable location for the error message.
+        floor: Exclusive lower bound; elements must be strictly greater.
+            Defaults to ``0.0``.
+
+    Returns:
+        ``x`` unchanged. Raises via :func:`equinox.error_if` when any
+        element is ``<= floor``.
+    """
+    return eqx.error_if(
+        x, jnp.any(x <= floor), f"{where} went non-positive (<= {floor})"
+    )
+
+
+def guard_ceiling(x: Array, *, where: str, ceil: float) -> Array:
+    """Return ``x`` unchanged, raising in-JIT if ``|x|`` exceeds ``ceil``.
+
+    A magnitude tripwire for velocity-state models — an opt-in blow-up
+    ceiling that halts an obviously-diverging run early.
+
+    Args:
+        x: Array to check (returned unchanged).
+        where: Human-readable location for the error message.
+        ceil: Maximum allowed absolute value.
+
+    Returns:
+        ``x`` unchanged. Raises via :func:`equinox.error_if` when any
+        ``|element| > ceil``.
+    """
+    return eqx.error_if(x, jnp.any(jnp.abs(x) > ceil), f"|{where}| exceeded {ceil}")

--- a/somax/_src/models/qg/baroclinic.py
+++ b/somax/_src/models/qg/baroclinic.py
@@ -88,6 +88,18 @@ class BaroclinicQGDiagnostics(Diagnostics):
     relative_vorticity: Float[Array, "nl Ny Nx"]
     rossby_radii: Array
 
+    def invariants(self) -> dict[str, Array]:
+        """Total kinetic energy and total enstrophy across layers.
+
+        Quadratic QG invariants summed over layers; conserved up to
+        time-truncation error in the inviscid/unforced limit, otherwise a
+        budget signal.
+        """
+        return {
+            "total_kinetic_energy": self.total_kinetic_energy,
+            "total_enstrophy": self.total_enstrophy,
+        }
+
 
 class BaroclinicQG(SomaxModel):
     r"""Multilayer quasi-geostrophic model on an Arakawa C-grid.

--- a/somax/_src/models/qg/barotropic.py
+++ b/somax/_src/models/qg/barotropic.py
@@ -76,6 +76,19 @@ class BarotropicQGDiagnostics(Diagnostics):
     enstrophy: Array
     relative_vorticity: Float[Array, "Ny Nx"]
 
+    def invariants(self) -> dict[str, Array]:
+        """Energy and enstrophy — the barotropic QG quadratic invariants.
+
+        The Arakawa Jacobian used for advection conserves both energy and
+        enstrophy in the inviscid, unforced limit (up to time-truncation
+        error), so for that configuration these drive close to zero; with
+        viscosity/forcing they quantify the budget instead.
+        """
+        return {
+            "kinetic_energy": self.kinetic_energy,
+            "enstrophy": self.enstrophy,
+        }
+
 
 class BarotropicQG(SomaxModel):
     r"""Barotropic quasi-geostrophic model on an Arakawa C-grid.

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -12,6 +12,7 @@ geostrophic manifold.
 from __future__ import annotations
 
 import equinox as eqx
+import jax.numpy as jnp
 from finitevolx import (
     CartesianGrid2D,
     Difference2D,
@@ -43,6 +44,8 @@ class ReparamQGDiagnostics(Diagnostics):
         total_energy: Domain-integrated total energy (scalar).
         enstrophy: Domain-integrated potential enstrophy per layer.
         total_enstrophy: Total potential enstrophy (scalar).
+        mass: Domain-integrated mass/volume per layer (flux-form invariant).
+        casimir_q3: PV Casimir per layer.
         potential_vorticity: PV field per layer.
         relative_vorticity: Relative vorticity per layer.
         kinetic_energy_field: KE at T-points per layer.
@@ -55,12 +58,28 @@ class ReparamQGDiagnostics(Diagnostics):
     total_energy: Array
     enstrophy: Array
     total_enstrophy: Array
+    mass: Array
+    casimir_q3: Array
     potential_vorticity: Float[Array, "nl Ny Nx"]
     relative_vorticity: Float[Array, "nl Ny Nx"]
     kinetic_energy_field: Float[Array, "nl Ny Nx"]
     psi: Float[Array, "nl Ny Nx"]
     u_ageostrophic: Float[Array, "nl Ny Nx"]
     v_ageostrophic: Float[Array, "nl Ny Nx"]
+
+    def invariants(self) -> dict[str, Array]:
+        """Mass (tight), total energy, potential enstrophy, PV Casimir.
+
+        Inherited from the underlying SWM diagnostics — the reparameterized
+        QG integrates the SWM vector field, so the same flux-form mass
+        conservation and implicit-dissipation caveats apply.
+        """
+        return {
+            "mass": jnp.sum(self.mass),
+            "total_energy": self.total_energy,
+            "potential_enstrophy": self.total_enstrophy,
+            "casimir_q3": jnp.sum(self.casimir_q3),
+        }
 
 
 class ReparameterizedQG(SomaxModel):
@@ -218,6 +237,8 @@ class ReparameterizedQG(SomaxModel):
             total_energy=swm_diag.total_energy,
             enstrophy=swm_diag.enstrophy,
             total_enstrophy=swm_diag.total_enstrophy,
+            mass=swm_diag.mass,
+            casimir_q3=swm_diag.casimir_q3,
             potential_vorticity=swm_diag.potential_vorticity,
             relative_vorticity=swm_diag.relative_vorticity,
             kinetic_energy_field=swm_diag.kinetic_energy_field,

--- a/somax/_src/models/swm/multilayer.py
+++ b/somax/_src/models/swm/multilayer.py
@@ -25,6 +25,7 @@ from jaxtyping import Array, Float, PyTree
 from somax._src.core.model import SomaxModel
 from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
+from somax._src.guards import guard_finite, guard_positive
 
 
 class MultilayerSW2DState(State):
@@ -79,6 +80,11 @@ class MultilayerSW2DDiagnostics(Diagnostics):
         total_energy: Domain-integrated total energy (scalar).
         enstrophy: Domain-integrated potential enstrophy per layer.
         total_enstrophy: Total potential enstrophy (scalar).
+        mass: Domain-integrated layer mass/volume per layer,
+            ``M_k = dx*dy * sum h_k``. Conserved to machine precision by
+            the flux-form mass equation in a closed/periodic basin.
+        casimir_q3: PV Casimir per layer, ``dx*dy * sum q^3 * h`` — a
+            higher-moment material invariant, more sensitive than enstrophy.
         potential_vorticity: PV field q = (zeta+f)/h at X-points per layer.
         relative_vorticity: Relative vorticity zeta per layer.
         kinetic_energy_field: KE at T-points per layer.
@@ -88,9 +94,26 @@ class MultilayerSW2DDiagnostics(Diagnostics):
     total_energy: Array
     enstrophy: Array
     total_enstrophy: Array
+    mass: Array
+    casimir_q3: Array
     potential_vorticity: Float[Array, "nl Ny Nx"]
     relative_vorticity: Float[Array, "nl Ny Nx"]
     kinetic_energy_field: Float[Array, "nl Ny Nx"]
+
+    def invariants(self) -> dict[str, Array]:
+        """Mass (tight), total energy, potential enstrophy, PV Casimir.
+
+        Mass is conserved to machine precision (flux-form continuity); the
+        energy/enstrophy/Casimir entries drift under the FV upwind PV
+        advection's implicit dissipation and are drift signals, not zero
+        targets.
+        """
+        return {
+            "mass": jnp.sum(self.mass),
+            "total_energy": self.total_energy,
+            "potential_enstrophy": self.total_enstrophy,
+            "casimir_q3": jnp.sum(self.casimir_q3),
+        }
 
 
 class MultilayerShallowWater2D(SomaxModel):
@@ -155,6 +178,11 @@ class MultilayerShallowWater2D(SomaxModel):
     ) -> MultilayerSW2DState:
         """Compute tendencies for the multilayer shallow water equations."""
         h, u, v = state.h, state.u, state.v
+        # FAIL-HARD (in-JIT): layer thickness must stay strictly positive.
+        # The PV q_k = (zeta_k + f) / h_k below is singular as h_k -> 0+, so a
+        # non-positive thickness makes the rest of the tendency meaningless;
+        # halt at this step rather than integrate a blow-up to the chunk end.
+        h = guard_positive(h, where="layer thickness h_k")
         nu = self.params.lateral_viscosity
         kappa = self.params.bottom_drag
         tau0 = self.params.wind_amplitude
@@ -200,6 +228,13 @@ class MultilayerShallowWater2D(SomaxModel):
         # --- 8. Bottom drag (bottom layer only) ---
         du_dt = du_dt.at[-1].add(-kappa * u[-1])
         dv_dt = dv_dt.at[-1].add(-kappa * v[-1])
+
+        # FAIL-HARD (in-JIT): halt at the first step that produces a
+        # non-finite tendency, earlier than the host-side _assert_finite_state
+        # net which only runs once the chunk has fully integrated.
+        dh_dt = guard_finite(dh_dt, where="RHS dh/dt")
+        du_dt = guard_finite(du_dt, where="RHS du/dt")
+        dv_dt = guard_finite(dv_dt, where="RHS dv/dt")
 
         return MultilayerSW2DState(h=dh_dt, u=du_dt, v=dv_dt)
 
@@ -248,11 +283,17 @@ class MultilayerShallowWater2D(SomaxModel):
             0.5 * jnp.sum(q[s] ** 2 * h_on_X[s], axis=(-2, -1)) * cell_area
         )
 
+        # Mass/volume per layer (flux-form invariant) and the q^3 Casimir.
+        mass_per_layer = jnp.sum(h[s], axis=(-2, -1)) * cell_area
+        casimir_q3_per_layer = jnp.sum(q[s] ** 3 * h_on_X[s], axis=(-2, -1)) * cell_area
+
         return MultilayerSW2DDiagnostics(
             energy=energy_per_layer,
             total_energy=jnp.sum(energy_per_layer),
             enstrophy=enstrophy_per_layer,
             total_enstrophy=jnp.sum(enstrophy_per_layer),
+            mass=mass_per_layer,
+            casimir_q3=casimir_q3_per_layer,
             potential_vorticity=q,
             relative_vorticity=zeta,
             kinetic_energy_field=ke,

--- a/somax/_src/models/swm/nonlinear_2d.py
+++ b/somax/_src/models/swm/nonlinear_2d.py
@@ -73,6 +73,10 @@ class NonlinearSW2DDiagnostics(Diagnostics):
     Args:
         energy: Domain-integrated total energy.
         enstrophy: Domain-integrated potential enstrophy.
+        mass: Domain-integrated mass/volume ``dx*dy * sum h`` — conserved
+            to machine precision by the flux-form mass equation.
+        casimir_q3: PV Casimir ``dx*dy * sum q^3 * h`` — higher-moment
+            material invariant.
         potential_vorticity: PV field q = (ζ+f)/h at X-points.
         relative_vorticity: ζ = dv/dx - du/dy at X-points.
         kinetic_energy_field: KE at T-points.
@@ -80,9 +84,20 @@ class NonlinearSW2DDiagnostics(Diagnostics):
 
     energy: Array
     enstrophy: Array
+    mass: Array
+    casimir_q3: Array
     potential_vorticity: Float[Array, "Ny Nx"]
     relative_vorticity: Float[Array, "Ny Nx"]
     kinetic_energy_field: Float[Array, "Ny Nx"]
+
+    def invariants(self) -> dict[str, Array]:
+        """Mass (tight), total energy, potential enstrophy, PV Casimir."""
+        return {
+            "mass": self.mass,
+            "total_energy": self.energy,
+            "potential_enstrophy": self.enstrophy,
+            "casimir_q3": self.casimir_q3,
+        }
 
 
 class NonlinearShallowWater2D(SomaxModel):
@@ -228,9 +243,15 @@ class NonlinearShallowWater2D(SomaxModel):
         h_on_X = self.interp.T_to_X(h)
         enstrophy = 0.5 * cell_area * jnp.sum(q[s] ** 2 * h_on_X[s])
 
+        # Mass/volume (flux-form invariant) and the q^3 Casimir.
+        mass = cell_area * jnp.sum(h[s])
+        casimir_q3 = cell_area * jnp.sum(q[s] ** 3 * h_on_X[s])
+
         return NonlinearSW2DDiagnostics(
             energy=energy,
             enstrophy=enstrophy,
+            mass=mass,
+            casimir_q3=casimir_q3,
             potential_vorticity=q,
             relative_vorticity=zeta,
             kinetic_energy_field=ke,

--- a/somax/_src/monitor/__init__.py
+++ b/somax/_src/monitor/__init__.py
@@ -1,0 +1,30 @@
+"""In-process simulation monitors for somax-sim runs."""
+
+from __future__ import annotations
+
+from somax._src.monitor.base import BaseMonitor
+from somax._src.monitor.builtins import (
+    ConservationDriftMonitor,
+    EnergyGrowthMonitor,
+    NonFiniteMonitor,
+    SolverHealthMonitor,
+    ThroughputMonitor,
+    WatchdogMonitor,
+    default_monitors,
+)
+from somax._src.monitor.protocol import ChunkInfo, Monitor, MonitorVerdict
+
+
+__all__ = [
+    "BaseMonitor",
+    "ChunkInfo",
+    "ConservationDriftMonitor",
+    "EnergyGrowthMonitor",
+    "Monitor",
+    "MonitorVerdict",
+    "NonFiniteMonitor",
+    "SolverHealthMonitor",
+    "ThroughputMonitor",
+    "WatchdogMonitor",
+    "default_monitors",
+]

--- a/somax/_src/monitor/base.py
+++ b/somax/_src/monitor/base.py
@@ -1,0 +1,34 @@
+"""Convenience base class for simulation monitors.
+
+:class:`BaseMonitor` supplies inert defaults for all three lifecycle hooks so
+a concrete monitor overrides only what it needs. It satisfies the
+:class:`somax._src.monitor.protocol.Monitor` structural protocol.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from somax._src.monitor.protocol import ChunkInfo, MonitorVerdict
+
+
+class BaseMonitor:
+    """Inert base monitor — override only the hooks you care about.
+
+    Subclasses typically set a class-level ``name`` and override
+    :meth:`on_chunk_end`. The default hooks do nothing (and
+    :meth:`on_chunk_end` returns an empty :class:`MonitorVerdict`), so a
+    one-hook monitor stays minimal.
+    """
+
+    name: str = "monitor"
+
+    def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
+        """No-op by default."""
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        """Inert by default — returns an empty verdict."""
+        return MonitorVerdict()
+
+    def on_run_end(self, model: Any, final_state: Any, *, ok: bool) -> None:
+        """No-op by default."""

--- a/somax/_src/monitor/builtins.py
+++ b/somax/_src/monitor/builtins.py
@@ -1,0 +1,305 @@
+"""Built-in monitors shipped with the :mod:`somax.monitor` protocol.
+
+These reproduce the observability that used to be inline in the runner's
+chunk step (the non-finite abort and the energy-growth warning) as pluggable
+monitors, and add new ones that consume the conservation invariants
+(:meth:`somax.Diagnostics.invariants`) and the diffrax solver stats.
+
+Severity per monitor:
+
+============================ ==================
+Monitor                      Severity
+============================ ==================
+``NonFiniteMonitor``         FAIL-HARD
+``EnergyGrowthMonitor``      MONITOR (-> FAIL-HARD with ``hard_factor``)
+``ConservationDriftMonitor`` MONITOR (-> FAIL-HARD with ``rtol_fail``)
+``SolverHealthMonitor``      MONITOR
+``ThroughputMonitor``        MONITOR
+``WatchdogMonitor``          FAIL-HARD
+============================ ==================
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import numpy as np
+
+from somax._src.monitor.base import BaseMonitor
+from somax._src.monitor.protocol import ChunkInfo, MonitorVerdict
+
+
+def _state_field_arrays(state: Any) -> dict[str, np.ndarray]:
+    """Best-effort map of state field name -> numpy array (eqx.Module)."""
+    out: dict[str, np.ndarray] = {}
+    fields = getattr(state, "__dataclass_fields__", None)
+    if not fields:
+        return out
+    for name in fields:
+        try:
+            value = getattr(state, name)
+            arr = np.asarray(value)
+        except (TypeError, ValueError):
+            continue
+        if np.issubdtype(arr.dtype, np.number):
+            out[name] = arr
+    return out
+
+
+class NonFiniteMonitor(BaseMonitor):
+    """FAIL-HARD: terminate the run if any state field holds NaN/Inf.
+
+    The pluggable form of the runner's original non-finite abort. A
+    non-finite state makes everything downstream meaningless, so this always
+    requests termination.
+    """
+
+    name = "non_finite"
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        bad = [
+            name
+            for name, arr in _state_field_arrays(state).items()
+            if not np.all(np.isfinite(arr))
+        ]
+        if bad:
+            return MonitorVerdict(
+                terminate=True,
+                reason=f"non-finite values in state field(s): {', '.join(sorted(bad))}",
+            )
+        return MonitorVerdict()
+
+
+class EnergyGrowthMonitor(BaseMonitor):
+    """MONITOR (optionally FAIL-HARD): flag large energy jumps between chunks.
+
+    Warns when the run's energy-like scalar grows by more than ``factor``
+    relative to the previous chunk — an early instability signal before a NaN
+    appears. If ``hard_factor`` is set, growth beyond it requests termination.
+
+    Args:
+        factor: Warn when ``|E(t)| > factor * |E(t-1)|``. Defaults to 10.0.
+        hard_factor: If not ``None``, terminate when growth exceeds this.
+    """
+
+    name = "energy_growth"
+    _ENERGY_KEYS = (
+        "total_energy",
+        "energy",
+        "total_kinetic_energy",
+        "kinetic_energy",
+    )
+
+    def __init__(self, factor: float = 10.0, hard_factor: float | None = None):
+        self.factor = factor
+        self.hard_factor = hard_factor
+        self._prev: float | None = None
+
+    def _energy(self, model: Any, state: Any) -> float | None:
+        # Source an energy-like scalar from the model's diagnostics. Prefer the
+        # advertised invariants(), but fall back to any top-level scalar field
+        # named like an energy on the Diagnostics object — this matches the
+        # legacy inline warning, which read the flattened diagnostics, so the
+        # early-warning still fires for models that do not override
+        # invariants() (Lorenz, linear SWM, Navier-Stokes, Burgers, ...).
+        try:
+            diag = model.diagnose(state)
+        except Exception:
+            return None
+        try:
+            invariants = diag.invariants()
+        except Exception:
+            invariants = {}
+        for key in self._ENERGY_KEYS:
+            if key in invariants:
+                value = float(np.asarray(invariants[key]))
+                return value if np.isfinite(value) else None
+        for key in self._ENERGY_KEYS:
+            field = getattr(diag, key, None)
+            if field is None:
+                continue
+            arr = np.asarray(field)
+            if arr.ndim == 0:
+                value = float(arr)
+                return value if np.isfinite(value) else None
+        return None
+
+    def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
+        self._prev = self._energy(model, state0)
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        cur = self._energy(model, state)
+        prev = self._prev
+        if cur is not None:
+            self._prev = cur
+        if prev is None or cur is None or abs(prev) == 0.0:
+            return MonitorVerdict()
+        growth = abs(cur) / abs(prev)
+        if growth <= self.factor:
+            return MonitorVerdict()
+        msg = f"energy grew {growth:.1f}x from previous chunk"
+        if self.hard_factor is not None and growth > self.hard_factor:
+            return MonitorVerdict(
+                metrics={"energy_growth": growth},
+                messages=(msg,),
+                terminate=True,
+                reason=f"{msg} (> hard_factor {self.hard_factor})",
+            )
+        return MonitorVerdict(metrics={"energy_growth": growth}, messages=(msg,))
+
+
+class ConservationDriftMonitor(BaseMonitor):
+    """MONITOR (optionally FAIL-HARD): track drift of conserved invariants.
+
+    Records the relative drift ``|I(t) - I(0)| / |I(0)|`` for every invariant
+    the model advertises via :meth:`somax.Diagnostics.invariants`. Warns above
+    ``rtol_warn``; if ``rtol_fail`` is set, terminates when the worst drift
+    exceeds it.
+
+    Mass is conserved to machine precision (set a tight tolerance); energy /
+    enstrophy / Casimirs drift under implicit numerical dissipation, so use a
+    generous ``rtol_warn`` and read the metric as "quantify the dissipation",
+    not "drive to zero".
+
+    Args:
+        rtol_warn: Relative-drift warning threshold. Defaults to 1e-2.
+        rtol_fail: If not ``None``, terminate when the worst drift exceeds it.
+    """
+
+    name = "conservation"
+
+    def __init__(self, rtol_warn: float = 1e-2, rtol_fail: float | None = None):
+        self.rtol_warn = rtol_warn
+        self.rtol_fail = rtol_fail
+        self._ref: dict[str, float] = {}
+
+    def _invariants(self, model: Any, state: Any) -> dict[str, float]:
+        try:
+            raw = model.diagnose(state).invariants()
+        except Exception:
+            return {}
+        return {k: float(np.asarray(v)) for k, v in raw.items()}
+
+    def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
+        self._ref = self._invariants(model, state0)
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        cur = self._invariants(model, state)
+        metrics: dict[str, float] = {}
+        messages: list[str] = []
+        worst = 0.0
+        for key, ref in self._ref.items():
+            if abs(ref) < 1e-30 or key not in cur:
+                continue
+            drift = abs(cur[key] - ref) / abs(ref)
+            metrics[f"drift_{key}"] = drift
+            worst = max(worst, drift)
+            if drift > self.rtol_warn:
+                messages.append(f"{key} drifted {drift:.2%}")
+        terminate = self.rtol_fail is not None and worst > self.rtol_fail
+        return MonitorVerdict(
+            metrics=metrics,
+            messages=tuple(messages),
+            terminate=terminate,
+            reason=(f"conservation drift {worst:.2%}" if terminate else None),
+        )
+
+
+class SolverHealthMonitor(BaseMonitor):
+    """MONITOR: surface diffrax per-chunk solver statistics.
+
+    Consumes the solver stats the runner now threads onto :class:`ChunkInfo`
+    (via a per-chunk ``stats`` attribute set by the runner). Reports the
+    rejected-step rate — often the earliest blow-up signal, before any field
+    check trips — and flags a non-success diffrax result.
+    """
+
+    name = "solver_health"
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        stats = info.stats
+        if not stats:
+            return MonitorVerdict()
+        accepted = stats.get("num_accepted_steps")
+        rejected = stats.get("num_rejected_steps")
+        metrics: dict[str, float] = {}
+        messages: list[str] = []
+        if accepted is not None and rejected is not None:
+            total = float(accepted) + float(rejected)
+            if total > 0:
+                rate = float(rejected) / total
+                metrics["rejected_step_rate"] = rate
+                if rate > 0.5:
+                    messages.append(f"high rejected-step rate {rate:.0%}")
+        if stats.get("result_successful") is False:
+            messages.append("solver reported a non-successful result")
+        return MonitorVerdict(metrics=metrics, messages=tuple(messages))
+
+
+class ThroughputMonitor(BaseMonitor):
+    """MONITOR: report simulated seconds per wallclock second per chunk.
+
+    A sudden drop flags a recompilation or a host-side stall.
+    """
+
+    name = "throughput"
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        if info.wall_seconds <= 0:
+            return MonitorVerdict()
+        sim_span = info.t1 - info.t0
+        throughput = sim_span / info.wall_seconds
+        return MonitorVerdict(metrics={"sim_s_per_wall_s": throughput})
+
+
+class WatchdogMonitor(BaseMonitor):
+    """FAIL-HARD: terminate if cumulative wallclock exceeds a ceiling.
+
+    A wallclock budget for the whole run. The runner already ticks an
+    alive-thread; this enforces a hard ceiling and stops cleanly at the next
+    chunk boundary rather than running indefinitely.
+
+    Args:
+        max_wall_s: Maximum cumulative wallclock seconds before termination.
+    """
+
+    name = "watchdog"
+
+    def __init__(self, max_wall_s: float):
+        self.max_wall_s = max_wall_s
+        self._t0: float | None = None
+
+    def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
+        self._t0 = time.perf_counter()
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        if self._t0 is None:
+            return MonitorVerdict()
+        elapsed = time.perf_counter() - self._t0
+        if elapsed > self.max_wall_s:
+            return MonitorVerdict(
+                metrics={"elapsed_wall_s": elapsed},
+                terminate=True,
+                reason=(
+                    f"wallclock {elapsed:.0f}s exceeded ceiling {self.max_wall_s:.0f}s"
+                ),
+            )
+        return MonitorVerdict(metrics={"elapsed_wall_s": elapsed})
+
+
+def default_monitors() -> list[BaseMonitor]:
+    """The runner's default monitor set — preserves legacy behavior.
+
+    ``NonFiniteMonitor`` (the original abort) plus ``EnergyGrowthMonitor`` (the
+    original 10x warning), now pluggable. ``ConservationDriftMonitor``,
+    ``SolverHealthMonitor`` and ``ThroughputMonitor`` add record-only
+    diagnostics on top without changing run outcomes.
+    """
+    return [
+        NonFiniteMonitor(),
+        EnergyGrowthMonitor(factor=10.0),
+        ConservationDriftMonitor(),
+        SolverHealthMonitor(),
+        ThroughputMonitor(),
+    ]

--- a/somax/_src/monitor/builtins.py
+++ b/somax/_src/monitor/builtins.py
@@ -47,6 +47,23 @@ def _state_field_arrays(state: Any) -> dict[str, np.ndarray]:
     return out
 
 
+def _scalarize(value: Any) -> float | None:
+    """Reduce an invariant value to a single float for drift tracking.
+
+    ``Diagnostics.invariants()`` may return a scalar or a per-layer vector
+    (the contract allows both). Extensive invariants (mass, energy,
+    enstrophy, Casimirs) sum across layers, so a vector is reduced with
+    ``sum`` to a total; a 0-d value passes through. Returns ``None`` if the
+    value can't be coerced to a finite float.
+    """
+    try:
+        arr = np.asarray(value, dtype=float)
+    except (TypeError, ValueError):
+        return None
+    total = float(arr.sum()) if arr.ndim > 0 else float(arr)
+    return total if np.isfinite(total) else None
+
+
 class NonFiniteMonitor(BaseMonitor):
     """FAIL-HARD: terminate the run if any state field holds NaN/Inf.
 
@@ -113,16 +130,11 @@ class EnergyGrowthMonitor(BaseMonitor):
             invariants = {}
         for key in self._ENERGY_KEYS:
             if key in invariants:
-                value = float(np.asarray(invariants[key]))
-                return value if np.isfinite(value) else None
+                return _scalarize(invariants[key])
         for key in self._ENERGY_KEYS:
             field = getattr(diag, key, None)
-            if field is None:
-                continue
-            arr = np.asarray(field)
-            if arr.ndim == 0:
-                value = float(arr)
-                return value if np.isfinite(value) else None
+            if field is not None:
+                return _scalarize(field)
         return None
 
     def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
@@ -179,7 +191,15 @@ class ConservationDriftMonitor(BaseMonitor):
             raw = model.diagnose(state).invariants()
         except Exception:
             return {}
-        return {k: float(np.asarray(v)) for k, v in raw.items()}
+        # Reduce each invariant to a scalar total (per-layer vectors are
+        # summed) so drift tracking works for the full invariants() contract,
+        # not just scalar-valued invariants. Drop any that won't coerce.
+        out: dict[str, float] = {}
+        for key, value in raw.items():
+            scalar = _scalarize(value)
+            if scalar is not None:
+                out[key] = scalar
+        return out
 
     def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
         self._ref = self._invariants(model, state0)

--- a/somax/_src/monitor/protocol.py
+++ b/somax/_src/monitor/protocol.py
@@ -1,0 +1,95 @@
+"""Lifecycle protocol for in-process simulation monitors.
+
+A :class:`Monitor` observes a ``somax-sim`` run at three lifecycle points —
+run start, each diagnostic-chunk boundary, and run end — and may *request
+termination*. It is the somax-side analog of an Oceananigans ``Callback`` /
+``Diagnostic`` or a Keras callback, but JAX-aware: monitors run host-side
+*between* JIT-compiled integration chunks, so they may hold ordinary Python
+state and do arbitrary host work (logging, I/O, history).
+
+This decouples DURING-simulation observability from the runner: the
+non-finite abort and energy-growth warning that used to be inline ``if``
+blocks in the chunk step become pluggable monitors (see
+:mod:`somax._src.monitor.builtins`), and users can add their own without
+editing the runner.
+
+Severity is declared, not implicit: a monitor either returns a
+:class:`MonitorVerdict` with ``terminate=True`` (FAIL-HARD — downstream state
+is meaningless) or simply records metrics/messages (MONITOR).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclasses.dataclass(frozen=True)
+class ChunkInfo:
+    """Context handed to a monitor at a diagnostic-chunk boundary.
+
+    Args:
+        index: Diagnostic-chunk index just completed (0-based).
+        n_chunks: Total number of diagnostic chunks in the run.
+        t0: Simulation time at the chunk start (seconds).
+        t1: Simulation time at the chunk end (seconds).
+        wall_seconds: Wallclock seconds spent integrating this chunk.
+        is_snapshot: Whether the chunk endpoint is a snapshot save boundary.
+        stats: Diffrax solver stats for this chunk (e.g.
+            ``num_accepted_steps`` / ``num_rejected_steps`` / ``result``), or
+            an empty dict if the solver did not expose them. Consumed by
+            :class:`somax.monitor.SolverHealthMonitor`.
+    """
+
+    index: int
+    n_chunks: int
+    t0: float
+    t1: float
+    wall_seconds: float
+    is_snapshot: bool
+    stats: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass(frozen=True)
+class MonitorVerdict:
+    """A monitor's response to a chunk. Inert by default.
+
+    Args:
+        metrics: Scalar metrics to merge into the run's per-chunk diagnostics
+            (name -> value). Empty by default.
+        messages: Lines to emit to ``run.log`` (prefixed with the monitor
+            name). Empty by default.
+        terminate: Whether the monitor requests a clean stop of the run.
+        reason: Why termination was requested. Required (non-``None``) when
+            ``terminate`` is ``True``; ignored otherwise.
+    """
+
+    metrics: dict[str, float] = dataclasses.field(default_factory=dict)
+    messages: tuple[str, ...] = ()
+    terminate: bool = False
+    reason: str | None = None
+
+
+@runtime_checkable
+class Monitor(Protocol):
+    """Structural protocol for a simulation monitor.
+
+    Implementations need a ``name`` and the three lifecycle hooks. Most
+    monitors only care about one hook, so :class:`somax.monitor.BaseMonitor`
+    supplies inert defaults — subclass it and override what you need rather
+    than implementing this Protocol directly.
+    """
+
+    name: str
+
+    def on_run_start(self, model: Any, state0: Any, *, spec: Any) -> None:
+        """Called once before integration begins."""
+        ...
+
+    def on_chunk_end(self, model: Any, state: Any, info: ChunkInfo) -> MonitorVerdict:
+        """Called after each diagnostic chunk; may request termination."""
+        ...
+
+    def on_run_end(self, model: Any, final_state: Any, *, ok: bool) -> None:
+        """Called once after integration ends (``ok`` False if it failed)."""
+        ...

--- a/somax/eval.py
+++ b/somax/eval.py
@@ -1,15 +1,18 @@
 """Public surface for somax's reference-free evaluation metrics.
 
 Field-level diagnostics computed on a model's own Cartesian grid — RMS
-divergence, total enstrophy, kinetic energy, and geostrophic imbalance —
-giving somax a quantitative evaluation surface for free-running simulations.
-These need only the state itself (no ground-truth reference); reference-based
-skill scores belong with the data-assimilation work in a later phase.
+divergence, total enstrophy, kinetic energy, geostrophic imbalance, and a QG
+PV-inversion balance residual — giving somax a quantitative evaluation surface
+for free-running simulations. These need only the state itself (no ground-truth
+reference); reference-based skill scores belong with the data-assimilation work
+in a later phase.
 
 :func:`compute_eval_metrics` is the convenient entry point: it returns every
-applicable metric for a ``(model, state)`` pair (and an empty dict for
-non-fluid models), and is what the ``somax-sim`` runner folds into
-``metrics.json``. The individual functions are exposed for ad-hoc analysis.
+applicable metric for a ``(model, state)`` pair (velocity-divergence metrics
+for C-grid models, a ``qg_balance_residual`` for QG models, plus any
+``diagnose().invariants()`` the model advertises), and is what the
+``somax-sim`` runner folds into ``metrics.json``. The individual functions are
+exposed for ad-hoc analysis.
 
 Pure JAX / finitevolx (both base dependencies), so importing this is cheap;
 it is kept out of ``somax``'s top-level ``__init__`` only to mirror the
@@ -22,6 +25,7 @@ from somax._src.eval.metrics import (
     compute_eval_metrics,
     geostrophic_imbalance,
     kinetic_energy,
+    qg_balance_residual,
     rms_divergence,
     total_enstrophy,
 )
@@ -31,6 +35,7 @@ __all__ = [
     "compute_eval_metrics",
     "geostrophic_imbalance",
     "kinetic_energy",
+    "qg_balance_residual",
     "rms_divergence",
     "total_enstrophy",
 ]

--- a/somax/guards.py
+++ b/somax/guards.py
@@ -1,0 +1,21 @@
+"""Public surface for somax's in-JIT fail-fast guards.
+
+JIT/``vmap``/``grad``-safe tripwires (:func:`guard_finite`,
+:func:`guard_positive`, :func:`guard_ceiling`) that return their input
+unchanged but raise immediately — via :func:`equinox.error_if` — when a
+physical invariant is violated inside a model's ``vector_field``. They halt
+*at* the offending step rather than after a whole integration chunk.
+
+Pure JAX / Equinox (a base dependency), so importing this is cheap; it is
+kept out of ``somax``'s top-level ``__init__`` only to mirror the
+module-per-surface layout (cf. :mod:`somax.eval`, :mod:`somax.operators`).
+"""
+
+from somax._src.guards import guard_ceiling, guard_finite, guard_positive
+
+
+__all__ = [
+    "guard_ceiling",
+    "guard_finite",
+    "guard_positive",
+]

--- a/somax/monitor.py
+++ b/somax/monitor.py
@@ -1,0 +1,66 @@
+"""Public surface for somax's in-process simulation monitors.
+
+A :class:`Monitor` observes a ``somax-sim`` run at three lifecycle points —
+run start, each diagnostic-chunk boundary, and run end — and may request a
+clean termination. This is the architectural unlock for DURING-simulation
+observability: the runner's non-finite abort and energy-growth warning are
+now pluggable :class:`NonFiniteMonitor` / :class:`EnergyGrowthMonitor`
+monitors, and users add their own (conservation drift, solver health,
+throughput, wallclock watchdog, or a custom :class:`BaseMonitor` subclass)
+without editing the runner.
+
+Monitors run host-side *between* JIT-compiled integration chunks, so they may
+hold ordinary Python state. Pair them with :mod:`somax.guards` (in-JIT
+fail-fast tripwires) for halts that must happen *at* the offending step.
+
+Example::
+
+    from somax.monitor import BaseMonitor, MonitorVerdict, default_monitors
+    from somax._src.cli._run import simulate
+
+    class MaxSpeedMonitor(BaseMonitor):
+        name = "max_speed"
+        def __init__(self, ceiling=50.0):
+            self.ceiling = ceiling
+        def on_chunk_end(self, model, state, info):
+            umax = float(jnp.nanmax(jnp.abs(state.u)))
+            if umax > self.ceiling:
+                return MonitorVerdict(metrics={"u_max": umax}, terminate=True,
+                                      reason=f"|u|={umax:.1f} > {self.ceiling}")
+            return MonitorVerdict(metrics={"u_max": umax})
+
+    simulate(spec, "runs/dg",
+             monitors=[*default_monitors(), MaxSpeedMonitor(ceiling=20.0)])
+
+Kept out of ``somax``'s top-level ``__init__`` to mirror the
+module-per-surface layout (cf. :mod:`somax.eval`, :mod:`somax.guards`).
+"""
+
+from somax._src.monitor import (
+    BaseMonitor,
+    ChunkInfo,
+    ConservationDriftMonitor,
+    EnergyGrowthMonitor,
+    Monitor,
+    MonitorVerdict,
+    NonFiniteMonitor,
+    SolverHealthMonitor,
+    ThroughputMonitor,
+    WatchdogMonitor,
+    default_monitors,
+)
+
+
+__all__ = [
+    "BaseMonitor",
+    "ChunkInfo",
+    "ConservationDriftMonitor",
+    "EnergyGrowthMonitor",
+    "Monitor",
+    "MonitorVerdict",
+    "NonFiniteMonitor",
+    "SolverHealthMonitor",
+    "ThroughputMonitor",
+    "WatchdogMonitor",
+    "default_monitors",
+]

--- a/tests/eval/test_qg_balance.py
+++ b/tests/eval/test_qg_balance.py
@@ -1,0 +1,64 @@
+"""Tests for the QG balance residual and invariant wiring in eval metrics.
+
+Model construction + a few diagnose/inversion calls — no integration, fast
+PR lane.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from somax._src.models.qg.barotropic import BarotropicQG, BarotropicQGState
+from somax._src.models.swm.multilayer import (
+    MultilayerShallowWater2D,
+    MultilayerSW2DState,
+)
+from somax.eval import compute_eval_metrics, qg_balance_residual
+
+
+def _barotropic():
+    return BarotropicQG.create(nx=32, ny=32, lateral_viscosity=100.0)
+
+
+class TestQGBalanceResidual:
+    def test_zero_pv_is_zero_residual(self) -> None:
+        model = _barotropic()
+        state = BarotropicQGState(q=jnp.zeros((model.grid.Ny, model.grid.Nx)))
+        assert float(qg_balance_residual(model, state)) == 0.0
+
+    def test_inverted_state_closes_round_trip(self) -> None:
+        """psi from inversion, then q = laplacian(psi) is self-consistent."""
+        model = _barotropic()
+        # A nonzero interior PV bump.
+        q = jnp.zeros((model.grid.Ny, model.grid.Nx)).at[16, 16].set(1e-5)
+        state = BarotropicQGState(q=q)
+        # The residual measures ||laplacian(invert(q)) - q|| / ||q||; for a
+        # consistent elliptic operator this is small.
+        assert float(qg_balance_residual(model, state)) < 1e-3
+
+
+class TestComputeEvalMetricsQG:
+    def test_qg_model_reports_balance_and_invariants(self) -> None:
+        model = _barotropic()
+        q = jnp.zeros((model.grid.Ny, model.grid.Nx)).at[16, 16].set(1e-5)
+        metrics = compute_eval_metrics(model, BarotropicQGState(q=q))
+        assert "qg_balance_residual" in metrics
+        assert "invariant_kinetic_energy" in metrics
+        assert "invariant_enstrophy" in metrics
+        # QG models do NOT report the velocity-divergence metrics.
+        assert "rms_divergence" not in metrics
+
+    def test_swm_model_reports_invariants(self) -> None:
+        model = MultilayerShallowWater2D.create(
+            nx=16, ny=16, n_layers=2, H=(500.0, 1500.0), g_prime=(9.81, 0.02)
+        )
+        sh = (2, model.grid.Ny, model.grid.Nx)
+        h = model.strat.H[:, None, None] * jnp.ones(sh)
+        state = model.apply_boundary_conditions(
+            MultilayerSW2DState(h=h, u=jnp.zeros(sh), v=jnp.zeros(sh))
+        )
+        metrics = compute_eval_metrics(model, state)
+        assert "invariant_mass" in metrics
+        assert "invariant_total_energy" in metrics
+        # 3D multilayer state -> velocity-divergence metrics do not apply.
+        assert "rms_divergence" not in metrics

--- a/tests/models/test_conservation.py
+++ b/tests/models/test_conservation.py
@@ -1,0 +1,84 @@
+"""Conservation-drift tests over short integrations.
+
+These integrate a model for a few steps and check the conserved invariants,
+so they are explicitly marked ``slow`` (excluded from the fast PR lane).
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import pytest
+
+from somax._src.models.swm.multilayer import (
+    MultilayerShallowWater2D,
+    MultilayerSW2DState,
+)
+
+
+@pytest.mark.slow
+def test_multilayer_mass_conserved_tightly() -> None:
+    """Flux-form mass is conserved to near machine precision (periodic basin).
+
+    No forcing / drag / viscosity, periodic BCs — the continuity equation is
+    in flux form, so total mass per layer should be conserved up to the
+    time-integration error, far tighter than the energy/enstrophy budget.
+    """
+    model = MultilayerShallowWater2D.create(
+        nx=32,
+        ny=32,
+        n_layers=2,
+        H=(500.0, 1500.0),
+        g_prime=(9.81, 0.02),
+        lateral_viscosity=0.0,
+        bottom_drag=0.0,
+        wind_amplitude=0.0,
+        bc="periodic",
+    )
+    sh = (2, model.grid.Ny, model.grid.Nx)
+    # A small geostrophic-ish thickness perturbation to make the run nontrivial.
+    key = jnp.linspace(0.0, 1.0, model.grid.Nx)
+    bump = 1.0 * jnp.sin(2 * jnp.pi * key)[None, None, :]
+    h0 = model.strat.H[:, None, None] * jnp.ones(sh) + bump
+    state0 = model.apply_boundary_conditions(
+        MultilayerSW2DState(h=h0, u=jnp.zeros(sh), v=jnp.zeros(sh))
+    )
+
+    mass0 = jnp.sum(model.diagnose(state0).invariants()["mass"])
+    sol = model.integrate(state0, t0=0.0, t1=200.0, dt=10.0)
+    final = MultilayerSW2DState(h=sol.ys.h[-1], u=sol.ys.u[-1], v=sol.ys.v[-1])
+    mass1 = jnp.sum(model.diagnose(final).invariants()["mass"])
+
+    rel_drift = float(jnp.abs(mass1 - mass0) / jnp.abs(mass0))
+    assert rel_drift < 1e-6
+
+
+@pytest.mark.slow
+def test_multilayer_energy_bounded_no_growth() -> None:
+    """Unforced energy should not grow (implicit dissipation only decays it)."""
+    model = MultilayerShallowWater2D.create(
+        nx=32,
+        ny=32,
+        n_layers=2,
+        H=(500.0, 1500.0),
+        g_prime=(9.81, 0.02),
+        lateral_viscosity=0.0,
+        bottom_drag=0.0,
+        wind_amplitude=0.0,
+        bc="periodic",
+    )
+    sh = (2, model.grid.Ny, model.grid.Nx)
+    key = jnp.linspace(0.0, 1.0, model.grid.Nx)
+    bump = 1.0 * jnp.sin(2 * jnp.pi * key)[None, None, :]
+    h0 = model.strat.H[:, None, None] * jnp.ones(sh) + bump
+    state0 = model.apply_boundary_conditions(
+        MultilayerSW2DState(h=h0, u=jnp.zeros(sh), v=jnp.zeros(sh))
+    )
+
+    e0 = float(model.diagnose(state0).invariants()["total_energy"])
+    sol = model.integrate(state0, t0=0.0, t1=200.0, dt=10.0)
+    final = MultilayerSW2DState(h=sol.ys.h[-1], u=sol.ys.u[-1], v=sol.ys.v[-1])
+    e1 = float(model.diagnose(final).invariants()["total_energy"])
+
+    # Allow a small relative tolerance for time-truncation wiggle; the point
+    # is the unforced run does not *grow* energy.
+    assert e1 <= e0 * (1.0 + 1e-3)

--- a/tests/models/test_invariants.py
+++ b/tests/models/test_invariants.py
@@ -1,0 +1,88 @@
+"""Unit tests for Diagnostics.invariants() across model families.
+
+Model construction + a single diagnose() call — no integration, so these
+stay in the fast PR lane.
+"""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+
+from somax._src.models.qg.barotropic import BarotropicQG, BarotropicQGState
+from somax._src.models.swm.multilayer import (
+    MultilayerShallowWater2D,
+    MultilayerSW2DState,
+)
+from somax._src.models.swm.nonlinear_2d import (
+    NonlinearShallowWater2D,
+    NonlinearSW2DState,
+)
+from somax.core import Diagnostics
+
+
+def _ml_model_state():
+    model = MultilayerShallowWater2D.create(
+        nx=16, ny=16, n_layers=2, H=(500.0, 1500.0), g_prime=(9.81, 0.02)
+    )
+    sh = (2, model.grid.Ny, model.grid.Nx)
+    h = model.strat.H[:, None, None] * jnp.ones(sh)
+    state = model.apply_boundary_conditions(
+        MultilayerSW2DState(h=h, u=jnp.zeros(sh), v=jnp.zeros(sh))
+    )
+    return model, state
+
+
+class TestBaseInvariants:
+    def test_base_diagnostics_empty(self) -> None:
+        assert Diagnostics().invariants() == {}
+
+
+class TestMultilayerInvariants:
+    def test_keys_present(self) -> None:
+        model, state = _ml_model_state()
+        inv = model.diagnose(state).invariants()
+        assert set(inv) == {
+            "mass",
+            "total_energy",
+            "potential_enstrophy",
+            "casimir_q3",
+        }
+
+    def test_mass_positive_and_finite(self) -> None:
+        model, state = _ml_model_state()
+        inv = model.diagnose(state).invariants()
+        assert float(inv["mass"]) > 0
+        assert all(bool(jnp.isfinite(v)) for v in inv.values())
+
+    def test_mass_matches_thickness_integral(self) -> None:
+        model, state = _ml_model_state()
+        diag = model.diagnose(state)
+        s = (slice(None), slice(1, -1), slice(1, -1))
+        cell_area = model.grid.dx * model.grid.dy
+        expected = float(jnp.sum(state.h[s]) * cell_area)
+        assert float(jnp.sum(diag.mass)) == jnp.asarray(expected)
+
+
+class TestNonlinearSWInvariants:
+    def test_keys_present(self) -> None:
+        model = NonlinearShallowWater2D.create(nx=16, ny=16)
+        sh = (model.grid.Ny, model.grid.Nx)
+        H0 = model.consts.H0 if hasattr(model.consts, "H0") else 1000.0
+        state = model.apply_boundary_conditions(
+            NonlinearSW2DState(h=H0 * jnp.ones(sh), u=jnp.zeros(sh), v=jnp.zeros(sh))
+        )
+        inv = model.diagnose(state).invariants()
+        assert set(inv) == {
+            "mass",
+            "total_energy",
+            "potential_enstrophy",
+            "casimir_q3",
+        }
+
+
+class TestBarotropicQGInvariants:
+    def test_energy_enstrophy_keys(self) -> None:
+        model = BarotropicQG.create(nx=16, ny=16)
+        state = BarotropicQGState(q=jnp.zeros((model.grid.Ny, model.grid.Nx)))
+        inv = model.diagnose(state).invariants()
+        assert set(inv) == {"kinetic_energy", "enstrophy"}

--- a/tests/test_cli_run.py
+++ b/tests/test_cli_run.py
@@ -777,3 +777,72 @@ class TestRestartStateValidation:
         # legacy deep-JAX trace.
         with pytest.raises((ValueError, TypeError)):
             _run.restart(wrong_spec, prod_dir, restart_from=final_state_path)
+
+
+# ----------------------------------------------------------------------
+# Monitors + manifest (observability) — integration (auto-marked slow)
+# ----------------------------------------------------------------------
+
+
+class TestMonitorWiring:
+    def test_default_monitors_preserve_clean_run(self, tmp_path: Path) -> None:
+        """Default monitors don't change a well-behaved run's outcome."""
+        spec = _swm_jet_spec(t1_seconds=600.0, dt=10.0, nx=16, ny=16)
+        result = _run.simulate(spec, tmp_path)
+        assert (tmp_path / "metrics.json").exists()
+        assert result.metrics_path is not None
+
+    def test_custom_monitor_can_terminate(self, tmp_path: Path) -> None:
+        """A user monitor requesting termination aborts and writes nothing."""
+        from somax.monitor import BaseMonitor, MonitorVerdict, default_monitors
+
+        class _Stop(BaseMonitor):
+            name = "stop"
+
+            def on_chunk_end(self, model, state, info):
+                return MonitorVerdict(terminate=True, reason="forced stop")
+
+        spec = _swm_jet_spec(t1_seconds=600.0, dt=10.0, nx=16, ny=16)
+        with pytest.raises(IntegrationDivergedError, match="forced stop"):
+            _run.simulate(spec, tmp_path, monitors=[*default_monitors(), _Stop()])
+        assert not (tmp_path / "metrics.json").exists()
+        assert not (tmp_path / "final_state.zarr").exists()
+
+    def test_cfl_blowup_raises_integration_diverged(self, tmp_path: Path) -> None:
+        """An in-JIT guard blow-up still surfaces as IntegrationDivergedError."""
+        spec = _swm_jet_spec(t1_seconds=4 * 3600.0, dt=300.0, nx=64, ny=64)
+        with pytest.raises(IntegrationDivergedError) as exc_info:
+            _run.simulate(spec, tmp_path)
+        msg = str(exc_info.value)
+        assert "non-finite" in msg
+        assert "CFL" in msg
+        assert not (tmp_path / "final_state.zarr").exists()
+
+
+class TestManifest:
+    def test_manifest_written_with_provenance(self, tmp_path: Path) -> None:
+        spec = _swm_jet_spec(t1_seconds=600.0, dt=10.0, nx=16, ny=16)
+        _run.simulate(spec, tmp_path)
+        manifest_path = tmp_path / "manifest.json"
+        assert manifest_path.exists()
+        manifest = json.loads(manifest_path.read_text())
+        for key in (
+            "jax_version",
+            "somax_version",
+            "x64_enabled",
+            "platform",
+            "config_sha256",
+            "dt",
+            "t0",
+            "t1",
+        ):
+            assert key in manifest
+        assert len(manifest["config_sha256"]) == 64
+
+    def test_config_hash_stable_across_runs(self, tmp_path: Path) -> None:
+        spec = _swm_jet_spec(t1_seconds=600.0, dt=10.0, nx=16, ny=16)
+        _run.simulate(spec, tmp_path / "a")
+        _run.simulate(spec, tmp_path / "b")
+        ha = json.loads((tmp_path / "a" / "manifest.json").read_text())["config_sha256"]
+        hb = json.loads((tmp_path / "b" / "manifest.json").read_text())["config_sha256"]
+        assert ha == hb

--- a/tests/test_guards.py
+++ b/tests/test_guards.py
@@ -1,0 +1,63 @@
+"""Unit tests for somax.guards in-JIT fail-fast tripwires.
+
+Cheap, no integration — these run in the fast PR lane.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+import pytest
+
+from somax.guards import guard_ceiling, guard_finite, guard_positive
+
+
+class TestGuardFinite:
+    def test_passes_finite_unchanged(self) -> None:
+        x = jnp.arange(5.0)
+        out = guard_finite(x, where="t")
+        assert jnp.array_equal(out, x)
+
+    def test_raises_on_nan_under_jit(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_finite(x, where="t"))
+        bad = jnp.array([1.0, jnp.nan, 3.0])
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(bad)
+
+    def test_raises_on_inf_under_jit(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_finite(x, where="t"))
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(jnp.array([jnp.inf]))
+
+
+class TestGuardPositive:
+    def test_passes_positive_unchanged(self) -> None:
+        x = jnp.array([0.1, 1.0, 2.0])
+        assert jnp.array_equal(guard_positive(x, where="h"), x)
+
+    def test_raises_on_zero_under_jit(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_positive(x, where="h"))
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(jnp.array([1.0, 0.0, 2.0]))
+
+    def test_raises_on_negative_under_jit(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_positive(x, where="h"))
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(jnp.array([-0.5, 1.0]))
+
+    def test_custom_floor(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_positive(x, where="h", floor=1.0))
+        # 0.5 <= floor 1.0 -> raises
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(jnp.array([0.5, 2.0]))
+
+
+class TestGuardCeiling:
+    def test_passes_below_ceiling(self) -> None:
+        x = jnp.array([1.0, -2.0, 3.0])
+        assert jnp.array_equal(guard_ceiling(x, where="u", ceil=10.0), x)
+
+    def test_raises_above_ceiling_under_jit(self) -> None:
+        f = eqx.filter_jit(lambda x: guard_ceiling(x, where="u", ceil=5.0))
+        with pytest.raises(eqx.EquinoxRuntimeError):
+            f(jnp.array([1.0, -9.0]))

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -44,6 +44,16 @@ class _FakeModel(eqx.Module):
         return _FakeDiagnostics(invs=self.invs)
 
 
+class _PlainModel:
+    """Non-eqx fake so invariant values can be JAX arrays (vector tests)."""
+
+    def __init__(self, invs: dict) -> None:
+        self._invs = invs
+
+    def diagnose(self, state):
+        return _FakeDiagnostics(invs=self._invs)
+
+
 def _info(index=0, n_chunks=4, t0=0.0, t1=1.0, wall=0.1, snap=True, stats=None):
     return ChunkInfo(
         index=index,
@@ -125,6 +135,17 @@ class TestEnergyGrowthMonitor:
         v = mon.on_chunk_end(_ModelEnergyField(e=100.0), None, _info())
         assert v.messages and "grew" in v.messages[0]
 
+    def test_vector_energy_invariant_summed(self) -> None:
+        """A per-layer vector energy invariant is summed, not float()'d."""
+        mon = EnergyGrowthMonitor(factor=10.0)
+        mon.on_run_start(
+            _PlainModel(invs={"total_energy": jnp.array([0.5, 0.5])}), None, spec=None
+        )
+        v = mon.on_chunk_end(
+            _PlainModel(invs={"total_energy": jnp.array([60.0, 60.0])}), None, _info()
+        )
+        assert v.messages and "grew" in v.messages[0]
+
 
 class TestConservationDriftMonitor:
     def test_records_drift(self) -> None:
@@ -151,6 +172,19 @@ class TestConservationDriftMonitor:
         mon.on_run_start(_FakeModel(invs={"x": 0.0}), None, spec=None)
         v = mon.on_chunk_end(_FakeModel(invs={"x": 5.0}), None, _info())
         assert "drift_x" not in v.metrics
+
+    def test_vector_invariant_summed_not_crash(self) -> None:
+        """Per-layer vector invariants are summed, not float()'d (no crash)."""
+        mon = ConservationDriftMonitor(rtol_warn=1e-2)
+        mon.on_run_start(
+            _PlainModel(invs={"mass": jnp.array([60.0, 40.0])}), None, spec=None
+        )
+        # total 100 -> 101 = 1% drift
+        v = mon.on_chunk_end(
+            _PlainModel(invs={"mass": jnp.array([61.0, 40.0])}), None, _info()
+        )
+        assert v.metrics["drift_mass"] == 0.01
+        assert not v.terminate
 
 
 class TestSolverHealthMonitor:

--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,206 @@
+"""Unit tests for the somax.monitor protocol and built-in monitors.
+
+These exercise the monitor objects directly with lightweight fakes — no
+diffrax integration — so they run in the fast PR lane.
+"""
+
+from __future__ import annotations
+
+import equinox as eqx
+import jax.numpy as jnp
+
+from somax.monitor import (
+    BaseMonitor,
+    ChunkInfo,
+    ConservationDriftMonitor,
+    EnergyGrowthMonitor,
+    Monitor,
+    MonitorVerdict,
+    NonFiniteMonitor,
+    SolverHealthMonitor,
+    ThroughputMonitor,
+    WatchdogMonitor,
+    default_monitors,
+)
+
+
+class _FakeState(eqx.Module):
+    u: jnp.ndarray
+
+
+class _FakeDiagnostics(eqx.Module):
+    invs: dict
+
+    def invariants(self) -> dict:
+        return self.invs
+
+
+class _FakeModel(eqx.Module):
+    """Model whose ``diagnose`` returns caller-controlled invariants."""
+
+    invs: dict = eqx.field(static=True)
+
+    def diagnose(self, state):
+        return _FakeDiagnostics(invs=self.invs)
+
+
+def _info(index=0, n_chunks=4, t0=0.0, t1=1.0, wall=0.1, snap=True, stats=None):
+    return ChunkInfo(
+        index=index,
+        n_chunks=n_chunks,
+        t0=t0,
+        t1=t1,
+        wall_seconds=wall,
+        is_snapshot=snap,
+        stats=stats or {},
+    )
+
+
+class TestProtocolConformance:
+    def test_base_monitor_is_monitor(self) -> None:
+        assert isinstance(BaseMonitor(), Monitor)
+
+    def test_builtins_are_monitors(self) -> None:
+        for mon in default_monitors():
+            assert isinstance(mon, Monitor)
+
+    def test_base_monitor_inert_defaults(self) -> None:
+        verdict = BaseMonitor().on_chunk_end(None, None, _info())
+        assert verdict == MonitorVerdict()
+        assert not verdict.terminate
+
+
+class TestNonFiniteMonitor:
+    def test_clean_state_passes(self) -> None:
+        v = NonFiniteMonitor().on_chunk_end(None, _FakeState(u=jnp.ones(4)), _info())
+        assert not v.terminate
+
+    def test_nan_state_terminates(self) -> None:
+        state = _FakeState(u=jnp.array([1.0, jnp.nan]))
+        v = NonFiniteMonitor().on_chunk_end(None, state, _info())
+        assert v.terminate
+        assert v.reason is not None and "non-finite" in v.reason
+
+
+class TestEnergyGrowthMonitor:
+    def test_warns_above_factor(self) -> None:
+        mon = EnergyGrowthMonitor(factor=10.0)
+        model_lo = _FakeModel(invs={"total_energy": 1.0})
+        model_hi = _FakeModel(invs={"total_energy": 100.0})
+        mon.on_run_start(model_lo, None, spec=None)
+        v = mon.on_chunk_end(model_hi, None, _info())
+        assert v.messages and "grew" in v.messages[0]
+        assert not v.terminate  # no hard_factor
+
+    def test_hard_factor_terminates(self) -> None:
+        mon = EnergyGrowthMonitor(factor=2.0, hard_factor=10.0)
+        mon.on_run_start(_FakeModel(invs={"total_energy": 1.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"total_energy": 50.0}), None, _info())
+        assert v.terminate
+
+    def test_stable_energy_no_warning(self) -> None:
+        mon = EnergyGrowthMonitor(factor=10.0)
+        mon.on_run_start(_FakeModel(invs={"total_energy": 1.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"total_energy": 1.1}), None, _info())
+        assert not v.messages and not v.terminate
+
+    def test_falls_back_to_diagnostics_field(self) -> None:
+        """Models without an energy invariant still get the early warning via
+        a top-level scalar ``energy`` field on the Diagnostics object."""
+
+        class _DiagWithEnergyField(eqx.Module):
+            energy: jnp.ndarray
+
+            def invariants(self) -> dict:
+                return {}  # no energy in invariants -> must fall back
+
+        class _ModelEnergyField(eqx.Module):
+            e: float = eqx.field(static=True)
+
+            def diagnose(self, state):
+                return _DiagWithEnergyField(energy=jnp.asarray(self.e))
+
+        mon = EnergyGrowthMonitor(factor=10.0)
+        mon.on_run_start(_ModelEnergyField(e=1.0), None, spec=None)
+        v = mon.on_chunk_end(_ModelEnergyField(e=100.0), None, _info())
+        assert v.messages and "grew" in v.messages[0]
+
+
+class TestConservationDriftMonitor:
+    def test_records_drift(self) -> None:
+        mon = ConservationDriftMonitor(rtol_warn=1e-2)
+        mon.on_run_start(_FakeModel(invs={"mass": 100.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"mass": 101.0}), None, _info())
+        assert v.metrics["drift_mass"] == 0.01
+        assert not v.terminate
+
+    def test_warns_above_rtol(self) -> None:
+        mon = ConservationDriftMonitor(rtol_warn=1e-3)
+        mon.on_run_start(_FakeModel(invs={"mass": 100.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"mass": 110.0}), None, _info())
+        assert v.messages
+
+    def test_fail_terminates(self) -> None:
+        mon = ConservationDriftMonitor(rtol_warn=1e-3, rtol_fail=0.05)
+        mon.on_run_start(_FakeModel(invs={"mass": 100.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"mass": 200.0}), None, _info())
+        assert v.terminate
+
+    def test_zero_reference_skipped(self) -> None:
+        mon = ConservationDriftMonitor()
+        mon.on_run_start(_FakeModel(invs={"x": 0.0}), None, spec=None)
+        v = mon.on_chunk_end(_FakeModel(invs={"x": 5.0}), None, _info())
+        assert "drift_x" not in v.metrics
+
+
+class TestSolverHealthMonitor:
+    def test_no_stats_inert(self) -> None:
+        v = SolverHealthMonitor().on_chunk_end(None, None, _info(stats={}))
+        assert v == MonitorVerdict()
+
+    def test_rejected_rate(self) -> None:
+        stats = {"num_accepted_steps": 8, "num_rejected_steps": 2}
+        v = SolverHealthMonitor().on_chunk_end(None, None, _info(stats=stats))
+        assert v.metrics["rejected_step_rate"] == 0.2
+
+    def test_high_rejection_warns(self) -> None:
+        stats = {"num_accepted_steps": 1, "num_rejected_steps": 9}
+        v = SolverHealthMonitor().on_chunk_end(None, None, _info(stats=stats))
+        assert v.messages
+
+    def test_unsuccessful_result_warns(self) -> None:
+        v = SolverHealthMonitor().on_chunk_end(
+            None, None, _info(stats={"result_successful": False})
+        )
+        assert v.messages
+
+
+class TestThroughputMonitor:
+    def test_reports_throughput(self) -> None:
+        v = ThroughputMonitor().on_chunk_end(
+            None, None, _info(t0=0.0, t1=100.0, wall=2.0)
+        )
+        assert v.metrics["sim_s_per_wall_s"] == 50.0
+
+    def test_zero_wall_inert(self) -> None:
+        v = ThroughputMonitor().on_chunk_end(None, None, _info(wall=0.0))
+        assert v == MonitorVerdict()
+
+
+class TestWatchdogMonitor:
+    def test_terminates_past_ceiling(self) -> None:
+        mon = WatchdogMonitor(max_wall_s=-1.0)  # already exceeded
+        mon.on_run_start(None, None, spec=None)
+        v = mon.on_chunk_end(None, None, _info())
+        assert v.terminate
+
+    def test_within_budget_ok(self) -> None:
+        mon = WatchdogMonitor(max_wall_s=1e9)
+        mon.on_run_start(None, None, spec=None)
+        v = mon.on_chunk_end(None, None, _info())
+        assert not v.terminate
+
+
+def test_default_monitors_membership() -> None:
+    names = {m.name for m in default_monitors()}
+    assert {"non_finite", "energy_growth", "conservation"} <= names

--- a/tests/test_preflight_checks.py
+++ b/tests/test_preflight_checks.py
@@ -1,0 +1,138 @@
+"""Unit tests for the new preflight assertions (S5).
+
+These build small real models (cheap, no integration) so they run in the
+fast PR lane. The end-to-end runner wiring is covered by the integration
+suite in ``tests/test_cli_assertions.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from somax._src.cli._assertions import (
+    PREFLIGHT_ASSERTIONS,
+    AssertionFailedError,
+    check_deformation_radius,
+    check_pv_inversion,
+    check_static_stability,
+)
+from somax._src.cli.spec import (
+    DebugSpec,
+    ModelSpec,
+    OutputSpec,
+    RunSpec,
+    ScenarioSpec,
+    TimesteppingSpec,
+)
+
+
+def _spec(scenario_name: str, model_name: str, **model_kw: Any) -> RunSpec:
+    return RunSpec(
+        scenario=ScenarioSpec(
+            name=scenario_name,
+            grid={"nx": 32, "ny": 32, "Lx": 1.0e6, "Ly": 1.0e6},
+            consts={"f0": 1.0e-4, "beta": 1.6e-11},
+            forcing={},
+            initial_condition={"type": "at_rest"},
+        ),
+        model=ModelSpec(name=model_name, **model_kw),
+        timestepping=TimesteppingSpec(t0=0.0, t1=600.0, dt=10.0, save_interval=600.0),
+        output=OutputSpec(),
+        debug=DebugSpec(),
+    )
+
+
+def _build(spec: RunSpec):
+    from somax._src.cli._factories import build
+    from somax._src.cli._run import _model_params, _scenario_params
+
+    model, _ = build(
+        spec.scenario.name,
+        spec.model.name,
+        scenario_params=_scenario_params(spec),
+        model_params=_model_params(spec),
+    )
+    return model
+
+
+def _multilayer_swm_model(H, g_prime, nx=32):
+    spec = _spec(
+        "double_gyre",
+        "multilayer_nonlinear_swm",
+        stratification={"H": list(H), "g_prime": list(g_prime)},
+        params={"lateral_viscosity": 100.0},
+    )
+    spec.scenario.grid["nx"] = nx
+    spec.scenario.grid["ny"] = nx
+    return spec, _build(spec)
+
+
+class TestRegistry:
+    def test_new_checks_registered(self) -> None:
+        for name in ("deformation_radius", "pv_inversion", "static_stability"):
+            assert name in PREFLIGHT_ASSERTIONS
+
+
+class TestDeformationRadius:
+    def test_resolved_grid_passes(self) -> None:
+        # H=(500,1500), g'=(9.81,0.02): L_d ~ sqrt(0.02*1500)/1e-4 ~ 54 km;
+        # dx ~ 31 km -> ratio ~1.7 with default min 2 would FAIL, so use a
+        # finer grid to clear the bar.
+        spec, model = _multilayer_swm_model((500.0, 1500.0), (9.81, 0.05), nx=128)
+        # L_d = sqrt(0.05*1500)/1e-4 ~ 86 km, dx ~ 7.8 km -> ratio ~11: passes.
+        check_deformation_radius(spec, model)
+
+    def test_underresolved_raises(self) -> None:
+        # Coarse grid + small L_d -> ratio < 2 -> FAIL.
+        spec, model = _multilayer_swm_model((500.0, 1500.0), (9.81, 0.001), nx=16)
+        with pytest.raises(AssertionFailedError, match=r"under-resolved|L_d/dx"):
+            check_deformation_radius(spec, model)
+
+    def test_non_stratified_model_rejected(self) -> None:
+        from types import SimpleNamespace
+
+        bad = SimpleNamespace(grid=SimpleNamespace(dx=1.0, dy=1.0))
+        with pytest.raises(AssertionFailedError):
+            check_deformation_radius(_spec("double_gyre", "barotropic_qg"), bad)
+
+
+class TestStaticStability:
+    def test_stable_profile_passes(self) -> None:
+        spec, model = _multilayer_swm_model((500.0, 1500.0), (9.81, 0.02))
+        check_static_stability(spec, model)
+
+    def test_unstable_profile_raises(self) -> None:
+        spec, model = _multilayer_swm_model((500.0, 1500.0), (9.81, -0.02))
+        with pytest.raises(AssertionFailedError, match="non-positive"):
+            check_static_stability(spec, model)
+
+
+class TestPVInversion:
+    def test_barotropic_qg_round_trip_closes(self) -> None:
+        spec = _spec(
+            "double_gyre", "barotropic_qg", params={"lateral_viscosity": 100.0}
+        )
+        model = _build(spec)
+        # at_rest -> zero PV -> trivially closes (early return).
+        check_pv_inversion(spec, model, tol=1e-6)
+
+    def test_non_qg_model_rejected(self) -> None:
+        spec, model = _multilayer_swm_model((500.0, 1500.0), (9.81, 0.02))
+        with pytest.raises(AssertionFailedError, match="no _invert_pv"):
+            check_pv_inversion(spec, model)
+
+    def test_baroclinic_qg_rejected(self) -> None:
+        """Baroclinic QG (3-D modal-Helmholtz PV) is out of scope: the bare
+        Laplacian round-trip omits the stretching term, so the check must
+        refuse it rather than report a spurious O(1) residual."""
+        spec = _spec(
+            "double_gyre",
+            "multilayer_qg",
+            stratification={"H": [500.0, 1500.0], "g_prime": [9.81, 0.02]},
+            params={},
+        )
+        model = _build(spec)
+        with pytest.raises(AssertionFailedError, match=r"barotropic|3-D PV"):
+            check_pv_inversion(spec, model)


### PR DESCRIPTION
## Diagnostics, Callbacks & Fail-Fast Observability

Implements the observability design doc end to end (phases **S1–S7**): in-process, per-step observability with **declared severity** — every check is either FAIL-HARD (raise/terminate) or MONITOR (record + maybe warn).

### What's here

| Phase | Delivered | Severity surface |
|-------|-----------|------------------|
| **S1** | `somax.monitor` — a `Monitor` protocol (`on_run_start` / `on_chunk_end` / `on_run_end`). The chunked runner's inline non-finite abort and energy-growth warning become a **monitor fan-out** in `_ChunkStep._apply`; `_ChunkCarry` sheds `prev_energy` (monitors hold their own host-side state). `simulate`/`spinup`/`restart` gain a keyword-only `monitors=` arg; `default_monitors()` preserves prior behavior. | — |
| **S2** | `somax.guards` — JIT/`vmap`/`grad`-safe `eqx.error_if` tripwires (`guard_finite` / `guard_positive` / `guard_ceiling`). Layer-thickness positivity + RHS-finite guards wired into the multilayer SWM `vector_field` (covers reparameterized QG via delegation). The runner translates a guard's `EquinoxRuntimeError` into `IntegrationDivergedError`, preserving the "blow-up writes no artifacts" contract. | FAIL-HARD |
| **S3** | `Diagnostics.invariants()` base method + `mass` / `casimir_q3` / energy / potential-enstrophy per family (SWM multilayer + nonlinear_2d; barotropic / baroclinic / reparameterized QG). Mass is a machine-precision flux-form invariant; energy/enstrophy are drift signals under implicit dissipation. | MONITOR |
| **S4** | Built-in monitors: `NonFinite`, `EnergyGrowth`, `ConservationDrift`, `SolverHealth` (consumes captured diffrax stats), `Throughput`, `Watchdog`. | mixed |
| **S5** | Preflight assertions: deformation-radius resolution, barotropic-QG PV-inversion round-trip, static stability. | FAIL-HARD |
| **S6** | `manifest.json` provenance (git commit/dirty, library versions, platform, x64, config sha256, solver/timestepping) next to `metrics.json`. | MONITOR |
| **S7** | `qg_balance_residual` (barotropic QG PV-inversion residual) + `diagnose().invariants()` wired through `compute_eval_metrics` as `invariant_*` keys. | MONITOR |

### Self-review caught & fixed 4 real bugs (regression-tested)

A pre-commit code review (3 parallel finder angles) surfaced these, all fixed before this PR:

1. **Baroclinic PV math was wrong.** Layered QG inverts a modal Helmholtz operator (`q = ∇²ψ − f₀²Aψ`), so a bare-Laplacian round-trip gives a spurious **O(1)** residual (measured 2.66) for a perfectly balanced state. Scoped both `check_pv_inversion` and `qg_balance_residual` to **barotropic** QG (2-D PV, `q = ∇²ψ`); baroclinic/reparameterized are rejected with a clear message rather than checked with the wrong operator.
2. **3-D interior slice trimmed the layer axis** in the PV-inversion check — hardened (moot after the barotropic scoping).
3. **`verdict.metrics` was silently dropped** in the runner fan-out — record-only monitor diagnostics (conservation drift, rejected-step rate, throughput) now reach the per-chunk log.
4. **`EnergyGrowthMonitor` regression** — it only read `invariants()`, losing the early-warning for ~8 models (Lorenz, linear SWM, Navier-Stokes, Burgers…). Now falls back to a top-level `energy` scalar on the Diagnostics object, matching the old inline behavior.

### Two deliberate deviations from the doc

- **S6 trace guard (`assert_max_traces(1)`) intentionally NOT wired into the hot path.** I verified empirically that the per-chunk runner *legitimately retraces every chunk* (~1.3 s each — each chunk passes distinct Python-float `t0`/`t1` windows baked into the trace), so that guard would fire on chunk 2 of every real run and break it. The manifest + provenance parts of S6 are implemented.
- **No YAML `monitors:` config block.** Monitors carry closures and are a programmatic-API feature (`simulate(..., monitors=[...])`); the CLI uses `default_monitors()`, preserving exact prior behavior. Wiring them through the `RunSpec` schema can follow if wanted.

### Testing (kept the fast lane cheap on purpose)

- **50 cheap unit tests** in the fast PR lane: guards, monitors, invariants, QG balance, preflight checks.
- **Heavy tests** (conservation drift + end-to-end runner: monitor wiring, manifest, CFL-guard blow-up) are `slow` / `integration`-marked and excluded from the PR CI job (run in the manual full suite).
- **538 fast tests pass, 2 skipped, 0 regressions.** `ruff check .`, `ruff format --check .`, `ty check somax` all clean.

https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gi9jLHHnRbn7vMUmXAe3Cr)_