### PR TITLE
feat(models): add BarotropicQG.from_nondimensional with boundary-layer guards

### DIFF
--- a/content/notes/quasigeostrophic.md
+++ b/content/notes/quasigeostrophic.md
@@ -64,17 +64,25 @@ model, so they apply to dimensional runs too:
 
 ```yaml
 assertions:
-  preflight:
-    munk_width: {n_cells_min: 2.0}
-    stommel_width: {n_cells_min: 1.0}
+  munk_width: {n_cells_min: 2.0}
+  stommel_width: {n_cells_min: 1.0}
 ```
+
+`assertions` is a flat `{name: params}` mapping — there is no
+`preflight:` level. Which phase a check runs in comes from the registry
+it is in, not from the config, and `run_preflight` treats every
+top-level key as an assertion name.
 
 The wind amplitude follows the Sverdrup balance. Left unspecified it is
 $\hat\tau = \hat\beta$, the amplitude whose Sverdrup interior velocity is
 exactly the velocity scale $U$; passing `delta_I` instead sets
 $\hat\tau = \delta_I^2 \hat\beta^2$.
 
-The returned `Scales` is the unit scale set the model runs in. Pair it
-with `StateAffine.from_scales` to move a dimensional state into these
-coordinates, and remember that times passed to the nondimensional model
-are in units of $T = L/U$.
+The returned `Scales` is the unit scale set the model runs in — $L = U
+= H = 1$ — so it is not by itself enough to convert a dimensional
+state: with $L = U = 1$ the vorticity scale is 1 and a
+`StateAffine.from_scales` built from it would leave a dimensional $q$
+untouched. Keep the *physical* scale set alongside it, the
+`Scales.advective(L=..., U=...)` describing the run being reproduced,
+and build the transform from that one. Times passed to the
+nondimensional model are in units of $T = L/U$.

--- a/content/notes/quasigeostrophic.md
+++ b/content/notes/quasigeostrophic.md
@@ -19,3 +19,62 @@ The multi-layer extension couples multiple fluid layers through the stretching t
 ## Implementation in somax
 
 somax uses a DST-based (Discrete Sine Transform) Poisson solver for the elliptic inversion $\nabla^2 \psi = q$ and the Arakawa Jacobian for the advection term.
+
+## Non-dimensional form
+
+`BarotropicQG.from_nondimensional` builds the model from dimensionless
+numbers instead of SI coefficients. It uses the **advective** scale set
+($L = U = H = 1$, so $T = L/U = 1$ and $f_0 = 1/Ro$), and in those units
+the equation reads
+
+$$
+\partial_t q + J(\psi,\, q + \hat\beta y)
+  = \delta_M^3 \hat\beta\, \nabla^2 q
+  - \delta_S \hat\beta\, \nabla^2 \psi
+  + \hat\tau\, \mathrm{curl}\,\tau .
+$$
+
+| Input | Definition | Sets |
+|---|---|---|
+| `rossby` | $Ro = U/(f_0 L)$ | `f0 = 1/Ro` |
+| `beta_hat` | $\hat\beta = \beta L^2/U$ | `beta` |
+| `delta_M` | $(\nu/\beta)^{1/3}/L$ | `lateral_viscosity` |
+| `delta_S` | $\kappa/(\beta L)$ | `bottom_drag` |
+| `delta_I` | $(U/\beta)^{1/2}/L$ | `wind_amplitude` |
+
+```python
+model, scales = BarotropicQG.from_nondimensional(
+    nx=128,
+    ny=128,
+    rossby=0.02,
+    beta_hat=50.0,
+    delta_M=0.03,
+    delta_S=0.01,
+)
+```
+
+The point of specifying $\delta_M$ and $\delta_S$ rather than $\nu$ and
+$\kappa$ is that the western-boundary-layer widths are what has to be
+resolved. Picking them directly replaces tuning two coefficients until a
+run is both stable and resolved, and it lets the factory check the grid:
+the `munk_width` and `stommel_width` preflight assertions fail when
+$\delta_M/\Delta x < 2$ or $\delta_S/\Delta x < 1$, and warn just above
+those thresholds. Both guards compare two lengths taken from the same
+model, so they apply to dimensional runs too:
+
+```yaml
+assertions:
+  preflight:
+    munk_width: {n_cells_min: 2.0}
+    stommel_width: {n_cells_min: 1.0}
+```
+
+The wind amplitude follows the Sverdrup balance. Left unspecified it is
+$\hat\tau = \hat\beta$, the amplitude whose Sverdrup interior velocity is
+exactly the velocity scale $U$; passing `delta_I` instead sets
+$\hat\tau = \delta_I^2 \hat\beta^2$.
+
+The returned `Scales` is the unit scale set the model runs in. Pair it
+with `StateAffine.from_scales` to move a dimensional state into these
+coordinates, and remember that times passed to the nondimensional model
+are in units of $T = L/U$.

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
 import numpy as np
+import paramax
 from loguru import logger
 
 
@@ -335,10 +336,171 @@ def check_static_stability(spec: RunSpec, model: Any) -> None:
         )
 
 
+def _boundary_layer_inputs(model: Any, check: str) -> tuple[Any, float, float]:
+    """Shared lookup for the western-boundary-layer guards.
+
+    Returns ``(params, beta, dx_min)`` with constrained parameters
+    already reconstituted, so a model carrying ``somax.positive``
+    wrappers is checked on its actual coefficient values.
+    """
+    model = paramax.unwrap(model)
+    consts = getattr(model, "consts", None)
+    grid = getattr(model, "grid", None)
+    params = getattr(model, "params", None)
+    if consts is None or grid is None or params is None:
+        raise AssertionFailedError(
+            f"{check}: model {type(model).__name__!r} lacks params/consts/grid; "
+            f"this check applies to beta-plane QG models."
+        )
+    beta = getattr(consts, "beta", None)
+    if beta is None:
+        raise AssertionFailedError(
+            f"{check}: model {type(model).__name__!r} does not expose "
+            f"consts.beta; the boundary-layer width is undefined without it."
+        )
+    beta = abs(float(beta))
+    if beta == 0.0:
+        raise AssertionFailedError(
+            f"{check}: consts.beta is zero. There is no western boundary "
+            f"layer on an f-plane, so this check does not apply."
+        )
+    return params, beta, float(min(grid.dx, grid.dy))
+
+
+def check_munk_width(
+    spec: RunSpec | None,
+    model: Any,
+    *,
+    n_cells_min: float = 2.0,
+    n_cells_warn: float = 4.0,
+) -> None:
+    """Pre-flight: the Munk (viscous) western boundary layer is resolved.
+
+    The Munk layer has width ``delta_M = (nu / beta)**(1/3)``. It is the
+    thinnest feature a viscous wind-driven gyre contains, so if the grid
+    cannot span it the western boundary current is wrong no matter what
+    the interior looks like. FAIL when ``delta_M/dx < n_cells_min``;
+    WARN below ``n_cells_warn``.
+
+    Works on dimensional and nondimensional models alike, since it
+    compares two lengths taken from the same model.
+
+    Args:
+        spec: The validated RunSpec (unused; present for registry
+            signature symmetry, and ``None`` when called from a
+            ``from_nondimensional`` factory).
+        model: The constructed model instance.
+        n_cells_min: ``delta_M/dx`` below which to FAIL.
+        n_cells_warn: ``delta_M/dx`` below which to WARN.
+
+    Raises:
+        AssertionFailedError: If the model lacks beta / viscosity, if
+            viscosity is zero, or if the layer is unresolved.
+    """
+    del spec
+    params, beta, dx_min = _boundary_layer_inputs(model, "munk_width")
+    nu = getattr(params, "lateral_viscosity", None)
+    if nu is None:
+        raise AssertionFailedError(
+            "munk_width: model does not expose params.lateral_viscosity; "
+            "cannot compute the Munk width."
+        )
+    nu = abs(float(jnp.asarray(nu)))
+    if nu == 0.0:
+        raise AssertionFailedError(
+            "munk_width: lateral_viscosity is zero, so there is no Munk "
+            "layer. Drop this check for an inviscid or Stommel-only run."
+        )
+    delta_m = (nu / beta) ** (1.0 / 3.0)
+    ratio = delta_m / dx_min
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"munk_width check FAILED: delta_M/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  delta_M = {delta_m:.4g} (= (nu/beta)^(1/3), nu={nu:.4g}, "
+            f"beta={beta:.4g})\n"
+            f"  dx      = {dx_min:.4g}\n"
+            f"  → the western boundary current is unresolved; refine the "
+            f"grid or raise the viscosity "
+            f"(nu >= {beta * (n_cells_min * dx_min) ** 3:.4g})."
+        )
+    if ratio < n_cells_warn:
+        logger.warning(
+            "Munk layer marginally resolved: delta_M/dx = {:.2f} "
+            "(delta_M={:.4g}, dx={:.4g})",
+            ratio,
+            delta_m,
+            dx_min,
+        )
+
+
+def check_stommel_width(
+    spec: RunSpec | None,
+    model: Any,
+    *,
+    n_cells_min: float = 1.0,
+    n_cells_warn: float = 2.0,
+) -> None:
+    """Pre-flight: the Stommel (frictional) western boundary layer is resolved.
+
+    The Stommel layer has width ``delta_S = kappa / beta``. The
+    threshold is one cell rather than two: a drag-dominated boundary
+    layer is a smoother structure than a viscous one, so a coarser
+    representation is still meaningful.
+
+    Args:
+        spec: The validated RunSpec (unused; see :func:`check_munk_width`).
+        model: The constructed model instance.
+        n_cells_min: ``delta_S/dx`` below which to FAIL.
+        n_cells_warn: ``delta_S/dx`` below which to WARN.
+
+    Raises:
+        AssertionFailedError: If the model lacks beta / drag, if drag is
+            zero, or if the layer is unresolved.
+    """
+    del spec
+    params, beta, dx_min = _boundary_layer_inputs(model, "stommel_width")
+    kappa = getattr(params, "bottom_drag", None)
+    if kappa is None:
+        raise AssertionFailedError(
+            "stommel_width: model does not expose params.bottom_drag; "
+            "cannot compute the Stommel width."
+        )
+    kappa = abs(float(jnp.asarray(kappa)))
+    if kappa == 0.0:
+        raise AssertionFailedError(
+            "stommel_width: bottom_drag is zero, so there is no Stommel "
+            "layer. Drop this check for a Munk-only run."
+        )
+    delta_s = kappa / beta
+    ratio = delta_s / dx_min
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"stommel_width check FAILED: delta_S/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  delta_S = {delta_s:.4g} (= kappa/beta, kappa={kappa:.4g}, "
+            f"beta={beta:.4g})\n"
+            f"  dx      = {dx_min:.4g}\n"
+            f"  → the frictional boundary layer is unresolved; refine the "
+            f"grid or raise the drag "
+            f"(kappa >= {beta * n_cells_min * dx_min:.4g})."
+        )
+    if ratio < n_cells_warn:
+        logger.warning(
+            "Stommel layer marginally resolved: delta_S/dx = {:.2f} "
+            "(delta_S={:.4g}, dx={:.4g})",
+            ratio,
+            delta_s,
+            dx_min,
+        )
+
+
 PREFLIGHT_ASSERTIONS: dict[str, Callable[..., None]] = {
     "cfl": check_cfl,
     "deformation_radius": check_deformation_radius,
+    "munk_width": check_munk_width,
     "pv_inversion": check_pv_inversion,
+    "stommel_width": check_stommel_width,
     "static_stability": check_static_stability,
 }
 

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -39,8 +39,13 @@ from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
 import numpy as np
-import paramax
 from loguru import logger
+
+from somax._src.core.resolution import (
+    AssertionFailedError,
+    check_munk_width,
+    check_stommel_width,
+)
 
 
 if TYPE_CHECKING:
@@ -50,10 +55,6 @@ if TYPE_CHECKING:
 # ----------------------------------------------------------------------
 # Exception
 # ----------------------------------------------------------------------
-
-
-class AssertionFailedError(RuntimeError):
-    """Raised when an opt-in preflight or postflight assertion fails."""
 
 
 # ----------------------------------------------------------------------
@@ -333,165 +334,6 @@ def check_static_stability(spec: RunSpec, model: Any) -> None:
             f"interface(s) {bad.tolist()} (g' = {internal.tolist()}).\n"
             f"  N^2 <= 0 implies a convectively unstable / mis-ordered density "
             f"profile. Order layers light-to-dense (top-to-bottom)."
-        )
-
-
-def _boundary_layer_inputs(model: Any, check: str) -> tuple[Any, float, float]:
-    """Shared lookup for the western-boundary-layer guards.
-
-    Returns ``(params, beta, dx_min)`` with constrained parameters
-    already reconstituted, so a model carrying ``somax.positive``
-    wrappers is checked on its actual coefficient values.
-    """
-    model = paramax.unwrap(model)
-    consts = getattr(model, "consts", None)
-    grid = getattr(model, "grid", None)
-    params = getattr(model, "params", None)
-    if consts is None or grid is None or params is None:
-        raise AssertionFailedError(
-            f"{check}: model {type(model).__name__!r} lacks params/consts/grid; "
-            f"this check applies to beta-plane QG models."
-        )
-    beta = getattr(consts, "beta", None)
-    if beta is None:
-        raise AssertionFailedError(
-            f"{check}: model {type(model).__name__!r} does not expose "
-            f"consts.beta; the boundary-layer width is undefined without it."
-        )
-    beta = abs(float(beta))
-    if beta == 0.0:
-        raise AssertionFailedError(
-            f"{check}: consts.beta is zero. There is no western boundary "
-            f"layer on an f-plane, so this check does not apply."
-        )
-    return params, beta, float(min(grid.dx, grid.dy))
-
-
-def check_munk_width(
-    spec: RunSpec | None,
-    model: Any,
-    *,
-    n_cells_min: float = 2.0,
-    n_cells_warn: float = 4.0,
-) -> None:
-    """Pre-flight: the Munk (viscous) western boundary layer is resolved.
-
-    The Munk layer has width ``delta_M = (nu / beta)**(1/3)``. It is the
-    thinnest feature a viscous wind-driven gyre contains, so if the grid
-    cannot span it the western boundary current is wrong no matter what
-    the interior looks like. FAIL when ``delta_M/dx < n_cells_min``;
-    WARN below ``n_cells_warn``.
-
-    Works on dimensional and nondimensional models alike, since it
-    compares two lengths taken from the same model.
-
-    Args:
-        spec: The validated RunSpec (unused; present for registry
-            signature symmetry, and ``None`` when called from a
-            ``from_nondimensional`` factory).
-        model: The constructed model instance.
-        n_cells_min: ``delta_M/dx`` below which to FAIL.
-        n_cells_warn: ``delta_M/dx`` below which to WARN.
-
-    Raises:
-        AssertionFailedError: If the model lacks beta / viscosity, if
-            viscosity is zero, or if the layer is unresolved.
-    """
-    del spec
-    params, beta, dx_min = _boundary_layer_inputs(model, "munk_width")
-    nu = getattr(params, "lateral_viscosity", None)
-    if nu is None:
-        raise AssertionFailedError(
-            "munk_width: model does not expose params.lateral_viscosity; "
-            "cannot compute the Munk width."
-        )
-    nu = abs(float(jnp.asarray(nu)))
-    if nu == 0.0:
-        raise AssertionFailedError(
-            "munk_width: lateral_viscosity is zero, so there is no Munk "
-            "layer. Drop this check for an inviscid or Stommel-only run."
-        )
-    delta_m = (nu / beta) ** (1.0 / 3.0)
-    ratio = delta_m / dx_min
-    if ratio < n_cells_min:
-        raise AssertionFailedError(
-            f"munk_width check FAILED: delta_M/dx = {ratio:.2f} < "
-            f"{n_cells_min}\n"
-            f"  delta_M = {delta_m:.4g} (= (nu/beta)^(1/3), nu={nu:.4g}, "
-            f"beta={beta:.4g})\n"
-            f"  dx      = {dx_min:.4g}\n"
-            f"  → the western boundary current is unresolved; refine the "
-            f"grid or raise the viscosity "
-            f"(nu >= {beta * (n_cells_min * dx_min) ** 3:.4g})."
-        )
-    if ratio < n_cells_warn:
-        logger.warning(
-            "Munk layer marginally resolved: delta_M/dx = {:.2f} "
-            "(delta_M={:.4g}, dx={:.4g})",
-            ratio,
-            delta_m,
-            dx_min,
-        )
-
-
-def check_stommel_width(
-    spec: RunSpec | None,
-    model: Any,
-    *,
-    n_cells_min: float = 1.0,
-    n_cells_warn: float = 2.0,
-) -> None:
-    """Pre-flight: the Stommel (frictional) western boundary layer is resolved.
-
-    The Stommel layer has width ``delta_S = kappa / beta``. The
-    threshold is one cell rather than two: a drag-dominated boundary
-    layer is a smoother structure than a viscous one, so a coarser
-    representation is still meaningful.
-
-    Args:
-        spec: The validated RunSpec (unused; see :func:`check_munk_width`).
-        model: The constructed model instance.
-        n_cells_min: ``delta_S/dx`` below which to FAIL.
-        n_cells_warn: ``delta_S/dx`` below which to WARN.
-
-    Raises:
-        AssertionFailedError: If the model lacks beta / drag, if drag is
-            zero, or if the layer is unresolved.
-    """
-    del spec
-    params, beta, dx_min = _boundary_layer_inputs(model, "stommel_width")
-    kappa = getattr(params, "bottom_drag", None)
-    if kappa is None:
-        raise AssertionFailedError(
-            "stommel_width: model does not expose params.bottom_drag; "
-            "cannot compute the Stommel width."
-        )
-    kappa = abs(float(jnp.asarray(kappa)))
-    if kappa == 0.0:
-        raise AssertionFailedError(
-            "stommel_width: bottom_drag is zero, so there is no Stommel "
-            "layer. Drop this check for a Munk-only run."
-        )
-    delta_s = kappa / beta
-    ratio = delta_s / dx_min
-    if ratio < n_cells_min:
-        raise AssertionFailedError(
-            f"stommel_width check FAILED: delta_S/dx = {ratio:.2f} < "
-            f"{n_cells_min}\n"
-            f"  delta_S = {delta_s:.4g} (= kappa/beta, kappa={kappa:.4g}, "
-            f"beta={beta:.4g})\n"
-            f"  dx      = {dx_min:.4g}\n"
-            f"  → the frictional boundary layer is unresolved; refine the "
-            f"grid or raise the drag "
-            f"(kappa >= {beta * n_cells_min * dx_min:.4g})."
-        )
-    if ratio < n_cells_warn:
-        logger.warning(
-            "Stommel layer marginally resolved: delta_S/dx = {:.2f} "
-            "(delta_S={:.4g}, dx={:.4g})",
-            ratio,
-            delta_s,
-            dx_min,
         )
 
 

--- a/somax/_src/core/resolution.py
+++ b/somax/_src/core/resolution.py
@@ -71,7 +71,7 @@ def _require_finite_positive(check: str, name: str, value: float) -> float:
 
 
 def _require_finite_thresholds(check: str, **thresholds: float) -> None:
-    """Reject a non-finite resolution threshold.
+    """Reject a resolution threshold that would disable its guard.
 
     These come straight from a config: ``munk_width: {n_cells_min:
     .nan}`` is valid YAML, ``yaml.safe_load`` produces a NaN, and
@@ -79,19 +79,32 @@ def _require_finite_thresholds(check: str, **thresholds: float) -> None:
     NaN is false, so the guard would pass a layer resolved by no cells
     at all.
 
+    A negative threshold has the same effect by a different route: a
+    width ratio is never negative, so ``ratio < n_cells_min`` is
+    always false and an explicitly configured assertion silently stops
+    asserting anything. Zero is allowed — it is the warn-only setting.
+
     Args:
         check: Caller name, for the error message.
         **thresholds: Named threshold values.
 
     Raises:
-        AssertionFailedError: If any threshold is not finite.
+        AssertionFailedError: If any threshold is not finite, or is
+            negative.
     """
     for name, value in thresholds.items():
-        if not math.isfinite(float(value)):
+        number = float(value)
+        if not math.isfinite(number):
             raise AssertionFailedError(
-                f"{check}: {name} is {float(value)}. A non-finite threshold "
+                f"{check}: {name} is {number}. A non-finite threshold "
                 f"compares false against every ratio, so the check would "
                 f"always pass."
+            )
+        if number < 0.0:
+            raise AssertionFailedError(
+                f"{check}: {name} is {number}. A width ratio is never "
+                f"negative, so a negative threshold would disable the "
+                f"check entirely; use 0 to warn only."
             )
 
 

--- a/somax/_src/core/resolution.py
+++ b/somax/_src/core/resolution.py
@@ -1,0 +1,237 @@
+"""Resolution guards shared by the model factories and the CLI.
+
+These live outside the CLI package on purpose. A
+``from_nondimensional`` factory runs them by default, and the factories
+are ordinary library API — a base ``pip install somax`` must be able to
+call them without pulling in the optional ``sim`` dependency group that
+the command-line interface needs.
+
+They take ``(spec, model)`` so the CLI can register them directly as
+preflight assertions; ``spec`` is unused and may be ``None``.
+"""
+
+from __future__ import annotations
+
+import math
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import jax.numpy as jnp
+import paramax
+
+
+if TYPE_CHECKING:
+    from somax._src.cli.spec import RunSpec
+
+try:  # pragma: no cover - exercised by whichever install is in use
+    from loguru import logger as _logger
+except ModuleNotFoundError:  # pragma: no cover
+    _logger = None
+
+
+class AssertionFailedError(RuntimeError):
+    """Raised when an opt-in preflight or postflight assertion fails."""
+
+
+def _warn(template: str, *args: Any) -> None:
+    """Emit a non-fatal guard warning.
+
+    Routed through loguru when it is installed, so a CLI run keeps its
+    single log stream; through :mod:`warnings` otherwise, so a base
+    install still hears about a marginally resolved boundary layer.
+    """
+    if _logger is not None:
+        _logger.warning(template, *args)
+    else:
+        warnings.warn(template.format(*args), UserWarning, stacklevel=3)
+
+
+def _require_finite_positive(check: str, name: str, value: float) -> float:
+    """Return ``value``, or fail the check if it is not usable.
+
+    Taking ``abs`` would invent a boundary layer for a model that has
+    none: a negative viscosity is anti-diffusive and a negative drag is
+    anti-damping, and reporting either as "resolved" is worse than
+    saying the check does not apply. Plain parameters can be passed
+    straight to ``create``, so this is reachable.
+    """
+    value = float(value)
+    if not math.isfinite(value):
+        raise AssertionFailedError(
+            f"{check}: {name} is {value}; the boundary-layer width is "
+            f"undefined for a non-finite coefficient."
+        )
+    if value < 0.0:
+        raise AssertionFailedError(
+            f"{check}: {name} is {value:.4g}. A negative coefficient is "
+            f"anti-diffusive rather than dissipative, so there is no "
+            f"boundary layer to resolve — fix the model rather than the grid."
+        )
+    return value
+
+
+def _boundary_layer_inputs(model: Any, check: str) -> tuple[Any, float, float]:
+    """Shared lookup for the western-boundary-layer guards.
+
+    Returns ``(params, beta, dx)`` with constrained parameters already
+    reconstituted, so a model carrying ``somax.positive`` wrappers is
+    checked on its actual coefficient values.
+    """
+    model = paramax.unwrap(model)
+    consts = getattr(model, "consts", None)
+    grid = getattr(model, "grid", None)
+    params = getattr(model, "params", None)
+    if consts is None or grid is None or params is None:
+        raise AssertionFailedError(
+            f"{check}: model {type(model).__name__!r} lacks params/consts/grid; "
+            f"this check applies to beta-plane QG models."
+        )
+    beta = getattr(consts, "beta", None)
+    if beta is None:
+        raise AssertionFailedError(
+            f"{check}: model {type(model).__name__!r} does not expose "
+            f"consts.beta; the boundary-layer width is undefined without it."
+        )
+    # ``abs`` is right for beta, unlike for the dissipative
+    # coefficients: its sign is a hemisphere convention, and the layer
+    # width depends only on its magnitude.
+    beta = abs(float(beta))
+    if beta == 0.0:
+        raise AssertionFailedError(
+            f"{check}: consts.beta is zero. There is no western boundary "
+            f"layer on an f-plane, so this check does not apply."
+        )
+    # The zonal spacing, not the finer of the two. Both layers are
+    # normal to the western and eastern walls, so it is ``dx`` that has
+    # to span them; on a grid with ``dy < dx`` — ``ny`` much larger
+    # than ``nx`` — taking the minimum inflates both ratios and can
+    # pass a western boundary current that is unresolved.
+    return params, beta, float(grid.dx)
+
+
+def check_munk_width(
+    spec: RunSpec | None,
+    model: Any,
+    *,
+    n_cells_min: float = 2.0,
+    n_cells_warn: float = 4.0,
+) -> None:
+    """Pre-flight: the Munk (viscous) western boundary layer is resolved.
+
+    The Munk layer has width ``delta_M = (nu / beta)**(1/3)``. It is the
+    thinnest feature a viscous wind-driven gyre contains, so if the grid
+    cannot span it the western boundary current is wrong no matter what
+    the interior looks like. FAIL when ``delta_M/dx < n_cells_min``;
+    WARN below ``n_cells_warn``.
+
+    Works on dimensional and nondimensional models alike, since it
+    compares two lengths taken from the same model.
+
+    Args:
+        spec: The validated RunSpec (unused; present for registry
+            signature symmetry, and ``None`` when called from a
+            ``from_nondimensional`` factory).
+        model: The constructed model instance.
+        n_cells_min: ``delta_M/dx`` below which to FAIL.
+        n_cells_warn: ``delta_M/dx`` below which to WARN.
+
+    Raises:
+        AssertionFailedError: If the model lacks beta / viscosity, if
+            viscosity is zero, or if the layer is unresolved.
+    """
+    del spec
+    params, beta, dx = _boundary_layer_inputs(model, "munk_width")
+    nu = getattr(params, "lateral_viscosity", None)
+    if nu is None:
+        raise AssertionFailedError(
+            "munk_width: model does not expose params.lateral_viscosity; "
+            "cannot compute the Munk width."
+        )
+    nu = _require_finite_positive("munk_width", "lateral_viscosity", jnp.asarray(nu))
+    if nu == 0.0:
+        raise AssertionFailedError(
+            "munk_width: lateral_viscosity is zero, so there is no Munk "
+            "layer. Drop this check for an inviscid or Stommel-only run."
+        )
+    delta_m = (nu / beta) ** (1.0 / 3.0)
+    ratio = delta_m / dx
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"munk_width check FAILED: delta_M/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  delta_M = {delta_m:.4g} (= (nu/beta)^(1/3), nu={nu:.4g}, "
+            f"beta={beta:.4g})\n"
+            f"  dx      = {dx:.4g}\n"
+            f"  → the western boundary current is unresolved; refine the "
+            f"grid or raise the viscosity "
+            f"(nu >= {beta * (n_cells_min * dx) ** 3:.4g})."
+        )
+    if ratio < n_cells_warn:
+        _warn(
+            "Munk layer marginally resolved: delta_M/dx = {:.2f} "
+            "(delta_M={:.4g}, dx={:.4g})",
+            ratio,
+            delta_m,
+            dx,
+        )
+
+
+def check_stommel_width(
+    spec: RunSpec | None,
+    model: Any,
+    *,
+    n_cells_min: float = 1.0,
+    n_cells_warn: float = 2.0,
+) -> None:
+    """Pre-flight: the Stommel (frictional) western boundary layer is resolved.
+
+    The Stommel layer has width ``delta_S = kappa / beta``. The
+    threshold is one cell rather than two: a drag-dominated boundary
+    layer is a smoother structure than a viscous one, so a coarser
+    representation is still meaningful.
+
+    Args:
+        spec: The validated RunSpec (unused; see :func:`check_munk_width`).
+        model: The constructed model instance.
+        n_cells_min: ``delta_S/dx`` below which to FAIL.
+        n_cells_warn: ``delta_S/dx`` below which to WARN.
+
+    Raises:
+        AssertionFailedError: If the model lacks beta / drag, if drag is
+            zero, or if the layer is unresolved.
+    """
+    del spec
+    params, beta, dx = _boundary_layer_inputs(model, "stommel_width")
+    kappa = getattr(params, "bottom_drag", None)
+    if kappa is None:
+        raise AssertionFailedError(
+            "stommel_width: model does not expose params.bottom_drag; "
+            "cannot compute the Stommel width."
+        )
+    kappa = _require_finite_positive("stommel_width", "bottom_drag", jnp.asarray(kappa))
+    if kappa == 0.0:
+        raise AssertionFailedError(
+            "stommel_width: bottom_drag is zero, so there is no Stommel "
+            "layer. Drop this check for a Munk-only run."
+        )
+    delta_s = kappa / beta
+    ratio = delta_s / dx
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"stommel_width check FAILED: delta_S/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  delta_S = {delta_s:.4g} (= kappa/beta, kappa={kappa:.4g}, "
+            f"beta={beta:.4g})\n"
+            f"  dx      = {dx:.4g}\n"
+            f"  → the frictional boundary layer is unresolved; refine the "
+            f"grid or raise the drag "
+            f"(kappa >= {beta * n_cells_min * dx:.4g})."
+        )
+    if ratio < n_cells_warn:
+        _warn(
+            "Stommel layer marginally resolved: delta_S/dx = {:.2f} "
+            "(delta_S={:.4g}, dx={:.4g})",
+            ratio,
+            delta_s,
+            dx,
+        )

--- a/somax/_src/core/resolution.py
+++ b/somax/_src/core/resolution.py
@@ -70,6 +70,31 @@ def _require_finite_positive(check: str, name: str, value: float) -> float:
     return value
 
 
+def _require_finite_thresholds(check: str, **thresholds: float) -> None:
+    """Reject a non-finite resolution threshold.
+
+    These come straight from a config: ``munk_width: {n_cells_min:
+    .nan}`` is valid YAML, ``yaml.safe_load`` produces a NaN, and
+    ``run_preflight`` forwards it unchanged. Every comparison against
+    NaN is false, so the guard would pass a layer resolved by no cells
+    at all.
+
+    Args:
+        check: Caller name, for the error message.
+        **thresholds: Named threshold values.
+
+    Raises:
+        AssertionFailedError: If any threshold is not finite.
+    """
+    for name, value in thresholds.items():
+        if not math.isfinite(float(value)):
+            raise AssertionFailedError(
+                f"{check}: {name} is {float(value)}. A non-finite threshold "
+                f"compares false against every ratio, so the check would "
+                f"always pass."
+            )
+
+
 def _boundary_layer_inputs(model: Any, check: str) -> tuple[Any, float, float]:
     """Shared lookup for the western-boundary-layer guards.
 
@@ -94,7 +119,15 @@ def _boundary_layer_inputs(model: Any, check: str) -> tuple[Any, float, float]:
         )
     # ``abs`` is right for beta, unlike for the dissipative
     # coefficients: its sign is a hemisphere convention, and the layer
-    # width depends only on its magnitude.
+    # width depends only on its magnitude. Finiteness still has to be
+    # tested separately — ``abs(nan)`` is NaN, the zero test below does
+    # not catch it, and both width ratios then compare false against
+    # their thresholds, so every guard would silently pass.
+    if not math.isfinite(float(beta)):
+        raise AssertionFailedError(
+            f"{check}: consts.beta is {float(beta)}; the boundary-layer "
+            f"width is undefined for a non-finite planetary gradient."
+        )
     beta = abs(float(beta))
     if beta == 0.0:
         raise AssertionFailedError(
@@ -140,6 +173,9 @@ def check_munk_width(
             viscosity is zero, or if the layer is unresolved.
     """
     del spec
+    _require_finite_thresholds(
+        "munk_width", n_cells_min=n_cells_min, n_cells_warn=n_cells_warn
+    )
     params, beta, dx = _boundary_layer_inputs(model, "munk_width")
     nu = getattr(params, "lateral_viscosity", None)
     if nu is None:
@@ -201,6 +237,9 @@ def check_stommel_width(
             zero, or if the layer is unresolved.
     """
     del spec
+    _require_finite_thresholds(
+        "stommel_width", n_cells_min=n_cells_min, n_cells_warn=n_cells_warn
+    )
     params, beta, dx = _boundary_layer_inputs(model, "stommel_width")
     kappa = getattr(params, "bottom_drag", None)
     if kappa is None:

--- a/somax/_src/models/_nondim.py
+++ b/somax/_src/models/_nondim.py
@@ -1,0 +1,31 @@
+"""Shared helpers for the ``from_nondimensional`` model factories.
+
+Every factory does the same three things: validate its dimensionless
+inputs, turn them into the SI-shaped kwargs ``create()`` already
+accepts, and hand back the unit :class:`~somax._src.core.scales.Scales`
+the resulting model runs in. The pieces that are common to more than
+one model live here so the mappings stay stated once.
+"""
+
+from __future__ import annotations
+
+import math
+
+
+def require_positive(context: str, **values: float) -> None:
+    """Raise if any named value is not finite and strictly positive."""
+    for name, value in values.items():
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(
+                f"{context}: {name} must be a finite positive number; got {value!r}."
+            )
+
+
+def require_non_negative(context: str, **values: float) -> None:
+    """Raise if any named value is negative or not finite."""
+    for name, value in values.items():
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError(
+                f"{context}: {name} must be a finite non-negative number; "
+                f"got {value!r}."
+            )

--- a/somax/_src/models/qg/barotropic.py
+++ b/somax/_src/models/qg/barotropic.py
@@ -16,6 +16,7 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
 
 
@@ -197,6 +198,147 @@ class BarotropicQG(SomaxModel):
             enstrophy=enstrophy,
             relative_vorticity=zeta,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        rossby: float,
+        beta_hat: float,
+        delta_M: float,
+        delta_S: float = 0.0,
+        delta_I: float | None = None,
+        aspect: float = 1.0,
+        wind_profile: str = "doublegyre",
+        mask: Mask2D | None = None,
+        check_resolution: bool = True,
+    ) -> tuple[BarotropicQG, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **advective** (:meth:`somax.Scales.advective`), with
+        ``L = U = H = 1`` so that ``T = L/U = 1`` and ``f0 = 1/Ro``.
+        In these units the barotropic QG equation reads
+
+        .. math::
+
+            \partial_t q + J(\psi,\, q + \hat\beta y)
+                = \delta_M^3 \hat\beta\, \nabla^2 q
+                - \delta_S \hat\beta\, \nabla^2 \psi
+                + \hat\tau\, \mathrm{curl}\,\tau .
+
+        The dimensionless numbers and what each sets:
+
+        ==============  ==========================  =========================
+        Input           Definition                  ``create()`` kwarg
+        ==============  ==========================  =========================
+        ``rossby``      :math:`Ro = U/(f_0 L)`      ``f0 = 1/Ro``
+        ``beta_hat``    :math:`\hat\beta = \beta L^2/U`  ``beta``
+        ``delta_M``     :math:`(\nu/\beta)^{1/3}/L`   ``lateral_viscosity``
+        ``delta_S``     :math:`\kappa/(\beta L)`      ``bottom_drag``
+        ``delta_I``     :math:`(U/\beta)^{1/2}/L`     ``wind_amplitude``
+        ==============  ==========================  =========================
+
+        Choosing ``delta_M`` and ``delta_S`` rather than ``nu`` and
+        ``kappa`` is the point of this factory: the western-boundary-layer
+        widths are what has to be resolved, and picking them directly
+        replaces tuning two coefficients until a run is both stable and
+        resolved.
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            rossby: Rossby number ``Ro = U / (f0 L)``. Sets ``f0 = 1/Ro``.
+            beta_hat: Planetary vorticity gradient ``beta L^2 / U``.
+            delta_M: Munk-layer width as a fraction of ``L``.
+            delta_S: Stommel-layer width as a fraction of ``L``. Zero
+                (the default) means no bottom drag.
+            delta_I: Inertial-layer width as a fraction of ``L``. This
+                fixes the wind amplitude through the Sverdrup balance
+                ``tau0 = delta_I**2 * beta_hat**2``. Left at ``None``,
+                the wind is set to ``beta_hat``, the amplitude whose
+                Sverdrup interior velocity is exactly the velocity scale
+                ``U`` — equivalent to ``delta_I = beta_hat**-0.5``.
+            aspect: ``Ly / Lx``. The domain is ``Lx = 1`` by construction.
+            wind_profile: Passed through to :meth:`create`.
+            mask: Passed through to :meth:`create`.
+            check_resolution: Run the Munk and Stommel resolution guards
+                and raise if the boundary layers are unresolved. Set
+                ``False`` only to build a deliberately coarse model (a
+                unit test, say).
+
+        Returns:
+            ``(model, scales)``. The ``Scales`` records the unit scale
+            set the model runs in, and is what
+            :meth:`somax.StateAffine.from_scales` needs to map a
+            dimensional state into these coordinates.
+
+        Raises:
+            ValueError: If a dimensionless input is out of range.
+            AssertionFailedError: If ``check_resolution`` is set and a
+                boundary layer is unresolved on this grid.
+
+        Example:
+            >>> model, scales = BarotropicQG.from_nondimensional(
+            ...     nx=128, ny=128, rossby=0.02, beta_hat=50.0,
+            ...     delta_M=0.03, delta_S=0.01,
+            ... )
+            >>> scales.kind
+            'advective'
+        """
+        if rossby <= 0.0:
+            raise ValueError(
+                f"from_nondimensional: rossby must be > 0; got {rossby!r}."
+            )
+        if beta_hat <= 0.0:
+            raise ValueError(
+                f"from_nondimensional: beta_hat must be > 0; got {beta_hat!r}."
+            )
+        if delta_M < 0.0 or delta_S < 0.0:
+            raise ValueError(
+                "from_nondimensional: delta_M and delta_S must be >= 0; got "
+                f"delta_M={delta_M!r}, delta_S={delta_S!r}."
+            )
+        if delta_I is not None and delta_I <= 0.0:
+            raise ValueError(
+                f"from_nondimensional: delta_I must be > 0; got {delta_I!r}."
+            )
+        if aspect <= 0.0:
+            raise ValueError(
+                f"from_nondimensional: aspect must be > 0; got {aspect!r}."
+            )
+
+        # Unit scales: L = U = H = 1, so f0 = 1/Ro and every coefficient
+        # below is already the nondimensional group itself.
+        wind_amplitude = beta_hat if delta_I is None else delta_I**2 * beta_hat**2
+        model = BarotropicQG.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            f0=1.0 / rossby,
+            beta=beta_hat,
+            lateral_viscosity=delta_M**3 * beta_hat,
+            bottom_drag=delta_S * beta_hat,
+            wind_amplitude=wind_amplitude,
+            wind_profile=wind_profile,
+            mask=mask,
+        )
+        scales = Scales.advective(L=1.0, U=1.0, f0=1.0 / rossby, H=1.0)
+
+        if check_resolution:
+            from somax._src.cli._assertions import (
+                check_munk_width,
+                check_stommel_width,
+            )
+
+            check_munk_width(None, model)
+            if delta_S > 0.0:
+                check_stommel_width(None, model)
+
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/qg/barotropic.py
+++ b/somax/_src/models/qg/barotropic.py
@@ -26,6 +26,10 @@ from somax._src.core.types import (
     State,
     as_parameter,
 )
+from somax._src.models._nondim import (
+    require_non_negative,
+    require_positive,
+)
 
 
 class BarotropicQGState(State):
@@ -282,9 +286,23 @@ class BarotropicQG(SomaxModel):
 
         Returns:
             ``(model, scales)``. The ``Scales`` records the unit scale
-            set the model runs in, and is what
-            :meth:`somax.StateAffine.from_scales` needs to map a
-            dimensional state into these coordinates.
+            set the model *runs in* — ``L = U = H = 1``.
+
+            It is therefore not enough on its own to convert a
+            dimensional state: with ``L = U = 1`` the vorticity scale
+            is 1 and the time scale is 1, so
+            :meth:`somax.StateAffine.from_scales` built from it leaves
+            a dimensional ``q`` unchanged. Converting needs the
+            *physical* scale set as well — the
+            ``Scales.advective(L=..., U=...)`` describing the run being
+            reproduced — with this one as the target:
+
+            >>> physical = Scales.advective(L=1.0e6, U=0.05, f0=1.0e-4)
+            >>> to_units = StateAffine.from_scales(  # doctest: +SKIP
+            ...     BarotropicQGState, physical
+            ... )
+
+            Keep both; this return value is the second of the pair.
 
         Raises:
             ValueError: If a dimensionless input is out of range.
@@ -299,27 +317,18 @@ class BarotropicQG(SomaxModel):
             >>> scales.kind
             'advective'
         """
-        if rossby <= 0.0:
-            raise ValueError(
-                f"from_nondimensional: rossby must be > 0; got {rossby!r}."
-            )
-        if beta_hat <= 0.0:
-            raise ValueError(
-                f"from_nondimensional: beta_hat must be > 0; got {beta_hat!r}."
-            )
-        if delta_M < 0.0 or delta_S < 0.0:
-            raise ValueError(
-                "from_nondimensional: delta_M and delta_S must be >= 0; got "
-                f"delta_M={delta_M!r}, delta_S={delta_S!r}."
-            )
-        if delta_I is not None and delta_I <= 0.0:
-            raise ValueError(
-                f"from_nondimensional: delta_I must be > 0; got {delta_I!r}."
-            )
-        if aspect <= 0.0:
-            raise ValueError(
-                f"from_nondimensional: aspect must be > 0; got {aspect!r}."
-            )
+        # Every check is stated as "must be finite and in range" rather
+        # than as a one-sided comparison: every comparison with NaN is
+        # false, and +inf passes a bare ``> 0``, so the one-sided form
+        # lets both through. A NaN delta_M then makes a NaN viscosity,
+        # and the resolution guard below falls through too because its
+        # ratio compares false against both thresholds — handing back a
+        # model that will quietly corrupt a simulation.
+        context = "from_nondimensional"
+        require_positive(context, rossby=rossby, beta_hat=beta_hat, aspect=aspect)
+        require_non_negative(context, delta_M=delta_M, delta_S=delta_S)
+        if delta_I is not None:
+            require_positive(context, delta_I=delta_I)
 
         # Unit scales: L = U = H = 1, so f0 = 1/Ro and every coefficient
         # below is already the nondimensional group itself.

--- a/tests/test_barotropic_qg_nondim.py
+++ b/tests/test_barotropic_qg_nondim.py
@@ -1,0 +1,379 @@
+"""Tests for the barotropic QG nondimensional factory and its guards."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from somax._src.cli._assertions import (
+    AssertionFailedError,
+    check_munk_width,
+    check_stommel_width,
+)
+from somax._src.core.scales import Scales
+from somax._src.core.transforms import StateAffine
+from somax._src.models.qg.barotropic import BarotropicQG, BarotropicQGState
+
+
+class TestParameterMapping:
+    """Each dimensionless input lands on the right ``create()`` kwarg."""
+
+    @pytest.fixture
+    def built(self):
+        return BarotropicQG.from_nondimensional(
+            nx=32,
+            ny=32,
+            rossby=0.02,
+            beta_hat=50.0,
+            delta_M=0.1,
+            delta_S=0.1,
+            check_resolution=False,
+        )
+
+    def test_rossby_sets_the_coriolis_parameter(self, built):
+        model, _ = built
+        assert float(model.consts.f0) == pytest.approx(1.0 / 0.02)
+
+    def test_beta_hat_is_beta_directly(self, built):
+        model, _ = built
+        assert float(model.consts.beta) == pytest.approx(50.0)
+
+    def test_delta_M_sets_the_viscosity(self, built):
+        model, _ = built
+        assert float(model.params.lateral_viscosity) == pytest.approx(
+            0.1**3 * 50.0, rel=1e-6
+        )
+
+    def test_delta_S_sets_the_bottom_drag(self, built):
+        model, _ = built
+        assert float(model.params.bottom_drag) == pytest.approx(0.1 * 50.0, rel=1e-6)
+
+    def test_domain_is_unit_length(self, built):
+        model, _ = built
+        assert model.grid.Lx == pytest.approx(1.0)
+        assert model.grid.Ly == pytest.approx(1.0)
+
+    def test_aspect_stretches_only_y(self):
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=32,
+            ny=16,
+            rossby=0.02,
+            beta_hat=50.0,
+            delta_M=0.1,
+            aspect=0.5,
+            check_resolution=False,
+        )
+        assert model.grid.Lx == pytest.approx(1.0)
+        assert model.grid.Ly == pytest.approx(0.5)
+
+    def test_returns_the_advective_unit_scale_set(self, built):
+        _, scales = built
+        assert scales.kind == "advective"
+        assert scales.L == 1.0
+        assert scales.U == 1.0
+        assert scales.T == 1.0
+        assert scales.rossby == pytest.approx(0.02)
+
+    def test_recovers_delta_M_from_the_built_model(self, built):
+        """The round trip a resolution guard relies on."""
+        model, _ = built
+        nu = float(model.params.lateral_viscosity)
+        beta = float(model.consts.beta)
+        assert (nu / beta) ** (1 / 3) == pytest.approx(0.1, rel=1e-5)
+
+
+class TestWindAmplitude:
+    def test_defaults_to_the_sverdrup_consistent_amplitude(self):
+        """tau_hat = beta_hat makes the Sverdrup interior velocity exactly U."""
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=32,
+            ny=32,
+            rossby=0.02,
+            beta_hat=50.0,
+            delta_M=0.1,
+            check_resolution=False,
+        )
+        assert float(model.params.wind_amplitude) == pytest.approx(50.0)
+
+    def test_delta_I_sets_the_amplitude(self):
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=32,
+            ny=32,
+            rossby=0.02,
+            beta_hat=50.0,
+            delta_M=0.1,
+            delta_I=0.2,
+            check_resolution=False,
+        )
+        assert float(model.params.wind_amplitude) == pytest.approx(
+            0.2**2 * 50.0**2, rel=1e-5
+        )
+
+    def test_the_default_matches_the_consistent_delta_I(self):
+        """delta_I = beta_hat**-0.5 is the value the default corresponds to."""
+        beta_hat = 50.0
+        kw = {
+            "nx": 32,
+            "ny": 32,
+            "rossby": 0.02,
+            "beta_hat": beta_hat,
+            "delta_M": 0.1,
+            "check_resolution": False,
+        }
+        default, _ = BarotropicQG.from_nondimensional(**kw)
+        explicit, _ = BarotropicQG.from_nondimensional(**kw, delta_I=beta_hat**-0.5)
+        assert float(explicit.params.wind_amplitude) == pytest.approx(
+            float(default.params.wind_amplitude), rel=1e-5
+        )
+
+
+class TestValidation:
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"rossby": 0.0}, "rossby"),
+            ({"rossby": -1.0}, "rossby"),
+            ({"beta_hat": 0.0}, "beta_hat"),
+            ({"delta_M": -0.1}, "delta_M"),
+            ({"delta_S": -0.1}, "delta_S"),
+            ({"delta_I": 0.0}, "delta_I"),
+            ({"aspect": 0.0}, "aspect"),
+        ],
+    )
+    def test_rejects_out_of_range_inputs(self, kwargs, message):
+        base = {
+            "nx": 16,
+            "ny": 16,
+            "rossby": 0.02,
+            "beta_hat": 50.0,
+            "delta_M": 0.1,
+            "check_resolution": False,
+        }
+        with pytest.raises(ValueError, match=message):
+            BarotropicQG.from_nondimensional(**{**base, **kwargs})
+
+
+class TestResolutionGuards:
+    def test_unresolved_munk_layer_is_rejected(self):
+        """delta_M * nx < 2 means the boundary current has nowhere to live."""
+        with pytest.raises(AssertionFailedError, match="munk_width check FAILED"):
+            BarotropicQG.from_nondimensional(
+                nx=16,
+                ny=16,
+                rossby=0.02,
+                beta_hat=50.0,
+                delta_M=0.01,  # 0.16 cells wide
+            )
+
+    def test_resolved_munk_layer_passes(self):
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=64, ny=64, rossby=0.02, beta_hat=50.0, delta_M=0.1
+        )
+        assert model is not None
+
+    def test_unresolved_stommel_layer_is_rejected(self):
+        with pytest.raises(AssertionFailedError, match="stommel_width check FAILED"):
+            BarotropicQG.from_nondimensional(
+                nx=32,
+                ny=32,
+                rossby=0.02,
+                beta_hat=50.0,
+                delta_M=0.15,
+                delta_S=0.001,  # 0.03 cells wide
+            )
+
+    def test_stommel_guard_is_skipped_when_there_is_no_drag(self):
+        """delta_S = 0 is a legitimate Munk-only run, not a failure."""
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=64, ny=64, rossby=0.02, beta_hat=50.0, delta_M=0.1, delta_S=0.0
+        )
+        assert float(model.params.bottom_drag) == 0.0
+
+    def test_check_resolution_false_allows_a_coarse_model(self):
+        model, _ = BarotropicQG.from_nondimensional(
+            nx=16,
+            ny=16,
+            rossby=0.02,
+            beta_hat=50.0,
+            delta_M=0.001,
+            check_resolution=False,
+        )
+        assert model is not None
+
+    def test_guard_message_names_a_usable_remedy(self):
+        with pytest.raises(AssertionFailedError) as excinfo:
+            BarotropicQG.from_nondimensional(
+                nx=16, ny=16, rossby=0.02, beta_hat=50.0, delta_M=0.01
+            )
+        message = str(excinfo.value)
+        assert "delta_M/dx" in message
+        assert "nu >=" in message
+
+
+class TestGuardsOnDimensionalModels:
+    """The guards compare two lengths, so they work in SI units too."""
+
+    def test_munk_guard_on_a_dimensional_model(self):
+        # delta_M = (nu/beta)^(1/3) = (1e3/1.6e-11)^(1/3) ~ 3.97e4 m,
+        # dx = 1e6/16 = 6.25e4 m -> 0.63 cells: unresolved.
+        model = BarotropicQG.create(
+            nx=16, ny=16, Lx=1e6, Ly=1e6, beta=1.6e-11, lateral_viscosity=1e3
+        )
+        with pytest.raises(AssertionFailedError, match="munk_width check FAILED"):
+            check_munk_width(None, model)
+
+    def test_munk_guard_passes_on_a_fine_dimensional_grid(self):
+        model = BarotropicQG.create(
+            nx=256, ny=256, Lx=1e6, Ly=1e6, beta=1.6e-11, lateral_viscosity=1e3
+        )
+        check_munk_width(None, model)
+
+    def test_zero_viscosity_is_reported_not_silently_skipped(self):
+        model = BarotropicQG.create(nx=64, ny=64, lateral_viscosity=0.0)
+        with pytest.raises(AssertionFailedError, match="lateral_viscosity is zero"):
+            check_munk_width(None, model)
+
+    def test_zero_drag_is_reported_not_silently_skipped(self):
+        model = BarotropicQG.create(nx=64, ny=64, bottom_drag=0.0)
+        with pytest.raises(AssertionFailedError, match="bottom_drag is zero"):
+            check_stommel_width(None, model)
+
+    def test_f_plane_has_no_boundary_layer(self):
+        model = BarotropicQG.create(nx=64, ny=64, beta=0.0, lateral_viscosity=1e3)
+        with pytest.raises(AssertionFailedError, match=r"consts\.beta is zero"):
+            check_munk_width(None, model)
+
+    def test_guards_reject_a_model_without_the_needed_structure(self):
+        class Bare:
+            pass
+
+        with pytest.raises(AssertionFailedError, match="lacks params/consts/grid"):
+            check_munk_width(None, Bare())
+
+    def test_guards_see_through_constrained_parameters(self):
+        """A positive()-wrapped viscosity must still be checked."""
+        import equinox as eqx
+
+        from somax._src.core.types import positive
+
+        model = BarotropicQG.create(
+            nx=16, ny=16, Lx=1e6, Ly=1e6, beta=1.6e-11, lateral_viscosity=1e3
+        )
+        wrapped = eqx.tree_at(
+            lambda m: m.params.lateral_viscosity, model, positive(1e3)
+        )
+        with pytest.raises(AssertionFailedError, match="munk_width check FAILED"):
+            check_munk_width(None, wrapped)
+
+
+class TestDimensionalEquivalence:
+    """A nondimensional run reproduces its dimensional counterpart.
+
+    This is the property the whole factory rests on: the RHS reads only
+    ``grid.dx/dy``, ``consts`` and ``params``, so rebuilding at unit
+    scales must integrate the same equation.
+
+    With ``L``, ``U`` chosen and ``H = 1``:
+
+        f0    = U / (Ro L)          beta = beta_hat U / L**2
+        nu    = delta_M**3 L**3 beta kappa = delta_S beta L
+        tau0  = tau_hat U**2 / L**2
+
+    and the states map as ``q_dim = (U/L) q_nd`` with ``t_dim = (L/U) t_nd``.
+    """
+
+    L = 1.0e6
+    U = 0.05
+    ROSSBY = 0.02
+    BETA_HAT = 20.0
+    DELTA_M = 0.08
+    DELTA_S = 0.05
+    NX = NY = 48
+
+    def dimensional_model(self):
+        beta = self.BETA_HAT * self.U / self.L**2
+        return BarotropicQG.create(
+            nx=self.NX,
+            ny=self.NY,
+            Lx=self.L,
+            Ly=self.L,
+            f0=self.U / (self.ROSSBY * self.L),
+            beta=beta,
+            lateral_viscosity=self.DELTA_M**3 * self.L**3 * beta,
+            bottom_drag=self.DELTA_S * beta * self.L,
+            wind_amplitude=self.BETA_HAT * self.U**2 / self.L**2,
+        )
+
+    def nondimensional_model(self):
+        return BarotropicQG.from_nondimensional(
+            nx=self.NX,
+            ny=self.NY,
+            rossby=self.ROSSBY,
+            beta_hat=self.BETA_HAT,
+            delta_M=self.DELTA_M,
+            delta_S=self.DELTA_S,
+        )
+
+    def initial_state(self, grid, amplitude):
+        rng = np.random.RandomState(0)
+        field = rng.randn(grid.Ny, grid.Nx)
+        field -= field.mean()
+        return BarotropicQGState(q=jnp.asarray(amplitude * field))
+
+    def test_coefficients_round_trip(self):
+        """The dimensional coefficients recover the dimensionless numbers."""
+        dim = self.dimensional_model()
+        beta = float(dim.consts.beta)
+        nu = float(dim.params.lateral_viscosity)
+        kappa = float(dim.params.bottom_drag)
+        assert (nu / beta) ** (1 / 3) / self.L == pytest.approx(self.DELTA_M, rel=1e-4)
+        assert kappa / (beta * self.L) == pytest.approx(self.DELTA_S, rel=1e-4)
+        assert self.U / (float(dim.consts.f0) * self.L) == pytest.approx(
+            self.ROSSBY, rel=1e-6
+        )
+
+    def test_trajectories_agree_under_the_scales_mapping(self):
+        dim = self.dimensional_model()
+        nd, _ = self.nondimensional_model()
+        scales = Scales.advective(L=self.L, U=self.U, f0=float(dim.consts.f0))
+        transform = StateAffine.from_scales(BarotropicQGState, scales)
+
+        q_scale = scales.vorticity
+        state_dim = self.initial_state(dim.grid, 0.05 * q_scale)
+        state_nd = transform.forward(state_dim)
+
+        t_nd = 0.4
+        n_steps = 40
+        sol_nd = nd.integrate(state_nd, t0=0.0, t1=t_nd, dt=t_nd / n_steps)
+        sol_dim = dim.integrate(
+            state_dim,
+            t0=0.0,
+            t1=t_nd * scales.T,
+            dt=t_nd * scales.T / n_steps,
+        )
+
+        got = np.asarray(transform.inverse(sol_nd.ys).q)
+        expected = np.asarray(sol_dim.ys.q)
+        assert np.isfinite(got).all()
+        rel = np.abs(got - expected).max() / np.abs(expected).max()
+        assert rel < 2e-3, f"nondim and dimensional runs diverged: rel={rel:.3e}"
+
+    def test_the_two_runs_are_not_trivially_equal(self):
+        """Guard against the comparison passing because nothing happened."""
+        dim = self.dimensional_model()
+        scales = Scales.advective(L=self.L, U=self.U, f0=float(dim.consts.f0))
+        state = self.initial_state(dim.grid, 0.05 * scales.vorticity)
+        evolved = dim.integrate(
+            state, t0=0.0, t1=0.4 * scales.T, dt=0.4 * scales.T / 40
+        ).ys.q
+        change = np.abs(np.asarray(evolved) - np.asarray(state.q)).max()
+        assert change > 0.05 * np.abs(np.asarray(state.q)).max()
+
+
+class TestAssertionRegistry:
+    def test_new_guards_are_registered(self):
+        from somax._src.cli._assertions import PREFLIGHT_ASSERTIONS
+
+        assert PREFLIGHT_ASSERTIONS["munk_width"] is check_munk_width
+        assert PREFLIGHT_ASSERTIONS["stommel_width"] is check_stommel_width

--- a/tests/test_barotropic_qg_nondim.py
+++ b/tests/test_barotropic_qg_nondim.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 from somax._src.cli._assertions import (
+    PREFLIGHT_ASSERTIONS,
     AssertionFailedError,
     check_munk_width,
     check_stommel_width,
@@ -377,3 +378,201 @@ class TestAssertionRegistry:
 
         assert PREFLIGHT_ASSERTIONS["munk_width"] is check_munk_width
         assert PREFLIGHT_ASSERTIONS["stommel_width"] is check_stommel_width
+
+
+class TestGuardsUseTheZonalSpacing:
+    """Both layers are normal to the western wall, so ``dx`` spans them.
+
+    On an anisotropic grid the finer direction is irrelevant: taking
+    ``min(dx, dy)`` inflates the ratio and can pass a western boundary
+    current that is not resolved zonally at all.
+    """
+
+    def model(self, nx, ny, aspect=1.0):
+        return BarotropicQG.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            beta=50.0,
+            lateral_viscosity=0.05**3 * 50.0,
+            bottom_drag=0.02 * 50.0,
+        )
+
+    def test_a_tall_thin_grid_no_longer_passes(self):
+        """dy << dx: resolved meridionally, unresolved zonally."""
+        model = self.model(nx=8, ny=256)
+        with pytest.raises(AssertionFailedError, match="delta_M/dx"):
+            check_munk_width(None, model)
+
+    def test_the_same_zonal_spacing_passes_when_square(self):
+        """So the failure above is about dx, not about nx being small."""
+        check_munk_width(None, self.model(nx=128, ny=128))
+
+    def test_refining_only_y_does_not_help(self):
+        coarse = self.model(nx=8, ny=8)
+        refined = self.model(nx=8, ny=512)
+        for model in (coarse, refined):
+            with pytest.raises(AssertionFailedError):
+                check_munk_width(None, model)
+
+    def test_the_reported_dx_is_the_zonal_one(self):
+        model = self.model(nx=8, ny=256)
+        with pytest.raises(AssertionFailedError) as excinfo:
+            check_munk_width(None, model)
+        assert f"{model.grid.dx:.4g}" in str(excinfo.value)
+
+    def test_stommel_uses_it_too(self):
+        model = self.model(nx=8, ny=256)
+        with pytest.raises(AssertionFailedError, match="delta_S/dx"):
+            check_stommel_width(None, model)
+
+
+class TestGuardsRejectAntiDissipativeCoefficients:
+    """A negative coefficient has no boundary layer to resolve.
+
+    Taking ``abs`` invented one and could report an anti-diffusive
+    model as resolved. Plain values reach ``create`` directly, so this
+    is reachable.
+    """
+
+    def model(self, **params):
+        return BarotropicQG.create(nx=64, ny=64, Lx=1.0, Ly=1.0, beta=50.0, **params)
+
+    def test_negative_viscosity_is_rejected(self):
+        model = self.model(lateral_viscosity=-(0.05**3) * 50.0)
+        with pytest.raises(AssertionFailedError, match="anti-diffusive"):
+            check_munk_width(None, model)
+
+    def test_negative_drag_is_rejected(self):
+        model = self.model(bottom_drag=-1.0)
+        with pytest.raises(AssertionFailedError, match="anti-diffusive"):
+            check_stommel_width(None, model)
+
+    def test_a_non_finite_viscosity_is_rejected(self):
+        model = self.model(lateral_viscosity=float("nan"))
+        with pytest.raises(AssertionFailedError, match="non-finite"):
+            check_munk_width(None, model)
+
+    def test_a_positive_coefficient_is_unaffected(self):
+        check_munk_width(None, self.model(lateral_viscosity=0.05**3 * 50.0))
+
+    def test_beta_keeps_its_sign_tolerance(self):
+        """Southern-hemisphere beta is negative by convention, not by error."""
+        model = BarotropicQG.create(
+            nx=64,
+            ny=64,
+            Lx=1.0,
+            Ly=1.0,
+            beta=-50.0,
+            lateral_viscosity=0.05**3 * 50.0,
+        )
+        check_munk_width(None, model)
+
+
+class TestNonFiniteDimensionlessInputs:
+    """NaN and +inf must not reach the model.
+
+    NaN compares false against every threshold, so a one-sided range
+    check lets it through *and* so does the resolution guard's ratio —
+    the factory would hand back a model that silently produces NaN.
+    """
+
+    def base(self):
+        return dict(
+            nx=64, ny=64, rossby=0.02, beta_hat=50.0, delta_M=0.05, delta_S=0.02
+        )
+
+    @pytest.mark.parametrize("name", ["rossby", "beta_hat", "aspect"])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_positive_inputs_must_be_finite(self, name, bad):
+        with pytest.raises(ValueError, match="finite positive"):
+            BarotropicQG.from_nondimensional(**{**self.base(), name: bad})
+
+    @pytest.mark.parametrize("name", ["delta_M", "delta_S"])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_non_negative_inputs_must_be_finite(self, name, bad):
+        with pytest.raises(ValueError, match="finite non-negative"):
+            BarotropicQG.from_nondimensional(**{**self.base(), name: bad})
+
+    def test_delta_i_must_be_finite(self):
+        with pytest.raises(ValueError, match="finite positive"):
+            BarotropicQG.from_nondimensional(**self.base(), delta_I=float("nan"))
+
+    def test_a_nan_no_longer_slips_past_the_resolution_guard(self):
+        """The second half of the failure: the guard's ratio is NaN too."""
+        with pytest.raises(ValueError):
+            BarotropicQG.from_nondimensional(**{**self.base(), "delta_M": float("nan")})
+
+    def test_valid_inputs_still_build(self):
+        model, scales = BarotropicQG.from_nondimensional(**self.base())
+        assert scales.kind == "advective"
+        assert model.grid.Nx == 66
+
+
+class TestGuardsAreImportableWithoutTheCliExtras:
+    """A base install must be able to call ``from_nondimensional``.
+
+    The factory runs the guards by default, so if they live behind an
+    optional CLI dependency an ordinary library user cannot use the
+    public API without installing unrelated packages.
+    """
+
+    def test_the_guards_live_outside_the_cli_package(self):
+        from somax._src.core import resolution
+
+        assert resolution.check_munk_width.__module__ == "somax._src.core.resolution"
+
+    def test_the_cli_registry_uses_the_same_objects(self):
+        from somax._src.core import resolution
+
+        assert PREFLIGHT_ASSERTIONS["munk_width"] is resolution.check_munk_width
+        assert PREFLIGHT_ASSERTIONS["stommel_width"] is resolution.check_stommel_width
+
+    def test_the_module_imports_with_loguru_hidden(self):
+        """The one non-base import the guards used to require."""
+        import subprocess
+        import sys
+        import textwrap
+
+        script = textwrap.dedent("""
+            import sys
+            sys.modules["loguru"] = None  # make `from loguru import ...` fail
+            import importlib
+            for name in list(sys.modules):
+                if name.startswith("somax"):
+                    del sys.modules[name]
+            import builtins
+            real_import = builtins.__import__
+            def guarded(name, *args, **kw):
+                if name == "loguru":
+                    raise ModuleNotFoundError("No module named 'loguru'")
+                return real_import(name, *args, **kw)
+            builtins.__import__ = guarded
+            from somax._src.core.resolution import check_munk_width
+            print("ok")
+        """)
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        assert out.stdout.strip() == "ok", out.stderr
+
+    def test_a_marginal_layer_still_warns_without_loguru(self):
+        """The warning must not simply vanish on a base install."""
+        from somax._src.core import resolution
+
+        model = BarotropicQG.create(
+            nx=64,
+            ny=64,
+            Lx=1.0,
+            Ly=1.0,
+            beta=50.0,
+            lateral_viscosity=0.05**3 * 50.0,
+        )
+        saved = resolution._logger
+        try:
+            resolution._logger = None
+            with pytest.warns(UserWarning, match="marginally resolved"):
+                resolution.check_munk_width(None, model, n_cells_warn=1e9)
+        finally:
+            resolution._logger = saved

--- a/tests/test_barotropic_qg_nondim.py
+++ b/tests/test_barotropic_qg_nondim.py
@@ -632,3 +632,39 @@ class TestGuardsRejectNonFiniteInputs:
     def test_a_finite_negative_beta_is_still_fine(self):
         """Southern-hemisphere convention, not an error."""
         check_munk_width(None, self.model(beta=-50.0))
+
+
+class TestNegativeThresholdsAreRejectedToo:
+    """A negative threshold disables its guard as surely as a NaN.
+
+    A width ratio is never negative, so ``ratio < n_cells_min`` is
+    always false and an assertion the config explicitly asked for
+    silently stops asserting anything. Zero is the warn-only setting
+    and stays allowed.
+    """
+
+    @staticmethod
+    def model(**kw):
+        return BarotropicQG.create(
+            nx=64, ny=64, Lx=1.0, Ly=1.0, beta=50.0, lateral_viscosity=1e-4, **kw
+        )
+
+    @pytest.mark.parametrize("name", ["n_cells_min", "n_cells_warn"])
+    def test_the_munk_guard_rejects_it(self, name):
+        with pytest.raises(AssertionFailedError, match=rf"{name} is -1\.0"):
+            check_munk_width(None, self.model(), **{name: -1.0})
+
+    def test_the_stommel_guard_rejects_it(self):
+        with pytest.raises(AssertionFailedError, match=r"n_cells_min is -1\.0"):
+            check_stommel_width(None, self.model(), n_cells_min=-1.0)
+
+    def test_an_unresolved_layer_with_a_negative_threshold_no_longer_passes(self):
+        coarse = BarotropicQG.create(
+            nx=8, ny=8, Lx=1.0, Ly=1.0, beta=50.0, lateral_viscosity=1.0e-9
+        )
+        with pytest.raises(AssertionFailedError):
+            check_munk_width(None, coarse, n_cells_min=-1.0)
+
+    def test_zero_is_still_allowed(self):
+        """Warn-only: nothing fails, but the warning threshold applies."""
+        check_munk_width(None, self.model(), n_cells_min=0.0, n_cells_warn=0.0)

--- a/tests/test_barotropic_qg_nondim.py
+++ b/tests/test_barotropic_qg_nondim.py
@@ -576,3 +576,59 @@ class TestGuardsAreImportableWithoutTheCliExtras:
                 resolution.check_munk_width(None, model, n_cells_warn=1e9)
         finally:
             resolution._logger = saved
+
+
+class TestGuardsRejectNonFiniteInputs:
+    """A NaN makes every comparison false, so a guard silently passes.
+
+    Both routes reach the guards without the nondimensional factory's
+    validation: ``beta`` through ``create`` or a CLI adapter, and the
+    thresholds straight from YAML — ``n_cells_min: .nan`` is valid and
+    ``run_preflight`` forwards it unchanged.
+    """
+
+    def model(self, **kw):
+        params = {
+            "beta": 50.0,
+            "lateral_viscosity": 0.05**3 * 50.0,
+            "bottom_drag": 0.02 * 50.0,
+        }
+        params.update(kw)
+        return BarotropicQG.create(nx=64, ny=64, Lx=1.0, Ly=1.0, **params)
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_a_non_finite_beta_is_rejected(self, bad):
+        with pytest.raises(AssertionFailedError, match="non-finite planetary"):
+            check_munk_width(None, self.model(beta=bad))
+
+    def test_the_stommel_guard_rejects_it_too(self):
+        with pytest.raises(AssertionFailedError, match="non-finite planetary"):
+            check_stommel_width(None, self.model(beta=float("nan")))
+
+    def test_a_nan_beta_would_otherwise_pass(self):
+        """The ratio is NaN, so both threshold comparisons are false."""
+        assert not (float("nan") < 2.0)
+
+    @pytest.mark.parametrize("name", ["n_cells_min", "n_cells_warn"])
+    def test_a_non_finite_threshold_is_rejected(self, name):
+        with pytest.raises(AssertionFailedError, match=f"{name} is nan"):
+            check_munk_width(None, self.model(), **{name: float("nan")})
+
+    def test_the_stommel_guard_checks_its_thresholds_too(self):
+        with pytest.raises(AssertionFailedError, match="n_cells_min is nan"):
+            check_stommel_width(None, self.model(), n_cells_min=float("nan"))
+
+    def test_an_unresolved_layer_with_a_nan_threshold_no_longer_passes(self):
+        """The failure this prevents, on a grid that really is too coarse."""
+        coarse = BarotropicQG.create(
+            nx=8, ny=8, Lx=1.0, Ly=1.0, beta=50.0, lateral_viscosity=1.0e-9
+        )
+        with pytest.raises(AssertionFailedError):
+            check_munk_width(None, coarse, n_cells_min=float("nan"))
+
+    def test_finite_thresholds_still_work(self):
+        check_munk_width(None, self.model(), n_cells_min=2.0, n_cells_warn=4.0)
+
+    def test_a_finite_negative_beta_is_still_fine(self):
+        """Southern-hemisphere convention, not an error."""
+        check_munk_width(None, self.model(beta=-50.0))


### PR DESCRIPTION
Closes #173. Stacked on #181 (epic #170). **This is where the user-facing payoff lands.**

## What this adds

Build the barotropic QG model from dimensionless numbers instead of SI coefficients, on the advective scale set with `L = U = H = 1` (so `T = 1` and `f0 = 1/Ro`):

| Input | Sets |
|---|---|
| `rossby` | `f0 = 1/Ro` |
| `beta_hat` | `beta` |
| `delta_M` | `lateral_viscosity = delta_M**3 * beta_hat` |
| `delta_S` | `bottom_drag = delta_S * beta_hat` |
| `delta_I` | `wind_amplitude = delta_I**2 * beta_hat**2` |

`create()` is untouched; the factory composes it and returns `(model, Scales)`.

Picking `delta_M` and `delta_S` rather than `nu` and `kappa` is the point: the western-boundary-layer widths are what has to be resolved, so choosing them directly replaces tuning two coefficients until a run is both stable and resolved.

## Decisions worth review

**The wind default is `beta_hat`,** the Sverdrup-balanced value whose interior velocity is exactly the velocity scale `U`. That is equivalent to `delta_I = beta_hat**-0.5`, which is asserted rather than just claimed. Passing both would be over-determined at unit scales, so `delta_I` overrides rather than adding a degree of freedom.

**A zero coefficient is reported, not silently skipped.** `munk_width` on a model with `nu = 0` raises, matching `check_deformation_radius`: a user who opted into the check expects the layer to exist.

**The guards work on dimensional models too,** since they compare two lengths read off the same model. They also unwrap constrained parameters, so a `positive()`-wrapped viscosity is still checked.

## Testing

The regression test is the one that matters: a nondimensional run and its dimensional counterpart agree to `2e-3` relative after 40 steps under the `Scales` mapping. A companion test asserts the state actually evolved, so the comparison cannot pass vacuously.

35 new tests total. Full suite 905 → 940 passing; lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg)_