### PR TITLE
feat(models): from_nondimensional for the layered models

### DIFF
--- a/content/notes/quasigeostrophic.md
+++ b/content/notes/quasigeostrophic.md
@@ -78,3 +78,44 @@ The returned `Scales` is the unit scale set the model runs in. Pair it
 with `StateAffine.from_scales` to move a dimensional state into these
 coordinates, and remember that times passed to the nondimensional model
 are in units of $T = L/U$.
+
+### Layered QG
+
+`BaroclinicQG.from_nondimensional` and
+`ReparameterizedQG.from_nondimensional` use the same advective set and
+add stratification, given as one Burger number **per interface**:
+
+$$
+Bu_k = \frac{g'_k H_k}{(f_0 L)^2}
+\quad\Longrightarrow\quad
+g'_k = \frac{Bu_k (f_0 L)^2}{H_k}.
+$$
+
+```python
+model, scales = BaroclinicQG.from_nondimensional(
+    nx=128,
+    ny=128,
+    rossby=0.02,
+    beta_hat=20.0,
+    burger=[1.0, 0.02],
+    thickness_ratio=[1.0, 4.0],
+    delta_M=0.06,
+)
+```
+
+The interface convention is not the per-mode one. The deformation
+radius of vertical mode $m$ comes from the eigenproblem and combines
+the interface values: for two layers the rigid-lid result is
+$L_d^2 = g' H_1 H_2 / (f_0^2 (H_1+H_2))$, and the free surface shifts it
+a few percent below that. Prescribing modal radii directly would mean
+inverting the eigenproblem, so the factory takes the interface numbers
+and the built model reports the resulting radii as
+`model.modal.rossby_radii` — already in units of $L$, so directly
+comparable with $\Delta x$. That is exactly what the `deformation_radius`
+guard reads, and `from_nondimensional` runs it alongside the Munk and
+Stommel guards.
+
+The wind default is again Sverdrup-balanced, $\hat\tau = \hat\beta$. The
+right-hand side applies the wind as $\tau_0 F / H_1$, so the
+dimensionless group is $\hat\tau = \tau_0 L^2 / (U^2 H_1)$ and the
+factory multiplies by the top-layer thickness on the way in.

--- a/content/notes/shallow_water.md
+++ b/content/notes/shallow_water.md
@@ -21,3 +21,58 @@ $$
 ## Implementation in somax
 
 somax provides both linear and nonlinear shallow water model implementations using the Arakawa C-grid discretization and WENO reconstruction for advection terms.
+
+## Non-dimensional form
+
+`NonlinearShallowWater2D.from_nondimensional` and
+`MultilayerShallowWater2D.from_nondimensional` use the **inertial**
+scale set: $L = f_0 = H = 1$, so $T = 1/f_0 = 1$ and the velocity scale
+is $U = f_0 L\,Ro = Ro$.
+
+| Input | Definition | Sets |
+|---|---|---|
+| `rossby` | $Ro = U/(f_0 L)$ | the velocity scale |
+| `burger` | $Bu = gH/(f_0 L)^2$ | `g` (single layer), `g_prime` (multilayer) |
+| `froude` | $Fr = U/\sqrt{gH}$ | `g`, through $Bu = (Ro/Fr)^2$ |
+| `beta_hat` | $\beta L/f_0$ | `beta` |
+| `ekman` | $\kappa/f_0$ | `bottom_drag` |
+| `ekman_lateral` | $\nu/(f_0 L^2)$ | `lateral_viscosity` |
+| `wind_hat` | $\tau_0/(f_0 U)$ | `wind_amplitude` |
+
+```python
+model, scales = NonlinearShallowWater2D.from_nondimensional(
+    nx=128,
+    ny=128,
+    rossby=0.05,
+    burger=1.0,
+    ekman=1e-3,
+)
+
+layered, scales = MultilayerShallowWater2D.from_nondimensional(
+    nx=128,
+    ny=128,
+    rossby=0.05,
+    burger=[1.0, 0.1],
+    thickness_ratio=[1.0, 9.0],
+)
+```
+
+`burger` and `froude` are not independent once $Ro$ is fixed, so exactly
+one may be given; supplying both would let you state an inconsistent
+pair, and the factory rejects it.
+
+Note that the model's own velocity fields are $O(Ro)$, not $O(1)$: the
+inertial set puts $L$, $f_0$ and $H$ at unity, which leaves velocity at
+$Ro$. Wrap the model in a `ScaledModel` built from the returned `Scales`
+to work in $O(1)$ state.
+
+## Comparing against a dimensional run
+
+A nondimensional run reproduces its dimensional counterpart exactly in
+arithmetic, and to a few times $10^{-5}$ in float32 — with one caveat
+worth knowing. The Bernoulli term carries $g h$ including the mean
+thickness, so at small Rossby number the mean swamps the anomaly and
+float32 cancellation alone separates two algebraically identical runs by
+a few times $10^{-4}$. Compare thickness against its anomaly rather than
+its absolute value, and prefer a moderate Rossby number when checking
+equivalence.

--- a/content/notes/shallow_water.md
+++ b/content/notes/shallow_water.md
@@ -66,6 +66,24 @@ inertial set puts $L$, $f_0$ and $H$ at unity, which leaves velocity at
 $Ro$. Wrap the model in a `ScaledModel` built from the returned `Scales`
 to work in $O(1)$ state.
 
+With unequal layer depths, give the thickness its own per-layer
+override rather than relying on the returned `Scales` alone. The
+default `h` rule is the single pair `(scales.H, scales.eta)`, which is
+the *top* layer's depth — so a zero normalized thickness would map
+every layer to $H_1$ instead of to its own $H_k$:
+
+```python
+transform = StateAffine.from_scales(
+    MultilayerSW2DState,
+    scales,
+    h={"loc": model.strat.H[:, None, None], "scale": dH},
+)
+scaled = ScaledModel(inner=model, transform=transform, time_scale=scales.T)
+```
+
+`dH` is the interface anomaly scale, per interface where they differ;
+a scalar is fine when one anomaly scale covers the column.
+
 ## Comparing against a dimensional run
 
 A nondimensional run reproduces its dimensional counterpart exactly in

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -203,16 +203,16 @@ def check_deformation_radius(
         raise AssertionFailedError(
             f"deformation_radius check FAILED: L_d/dx = {ratio:.2f} < "
             f"{n_cells_min}\n"
-            f"  L_d   = {Ld:.0f} m (smallest internal deformation radius, "
+            f"  L_d   = {Ld:.4g} (smallest internal deformation radius, "
             f"from {source})\n"
-            f"  dx    = {dx_min:.0f} m\n"
+            f"  dx    = {dx_min:.4g}\n"
             f"  → eddies will be suppressed; refine the grid or pick an "
             f"eddy-permitting configuration."
         )
     if ratio < n_cells_warn:
         logger.warning(
             "deformation radius marginally resolved: L_d/dx = {:.2f} "
-            "(L_d={:.0f} m, dx={:.0f} m)",
+            "(L_d={:.4g}, dx={:.4g})",
             ratio,
             Ld,
             dx_min,

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -39,10 +39,10 @@ from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
 import numpy as np
-from loguru import logger
 
 from somax._src.core.resolution import (
     AssertionFailedError,
+    check_deformation_radius,
     check_munk_width,
     check_stommel_width,
 )
@@ -116,115 +116,6 @@ def check_cfl(
             f"  dt         = {dt:.4f} s\n"
             f"  dx_min     = {dx_min:.2f} m\n"
             f"  → maximum stable dt at this CFL: {dt_safe:.4f} s"
-        )
-
-
-def check_deformation_radius(
-    spec: RunSpec,
-    model: Any,
-    *,
-    n_cells_min: float = 2.0,
-    n_cells_warn: float = 4.0,
-) -> None:
-    """Pre-flight: the first baroclinic deformation radius is resolved.
-
-    Resolving the first internal deformation radius ``L_d = sqrt(g'H)/f0``
-    with at least ``n_cells_min`` grid cells is necessary for baroclinic
-    instability and mesoscale eddies (Hallberg 2013). FAIL when
-    ``L_d/dx < n_cells_min``; WARN when ``n_cells_min <= L_d/dx <
-    n_cells_warn``.
-
-    ``dx`` here is the coarser of the two spacings, since a deformation
-    radius is isotropic and must be spanned in both directions.
-
-    Requires a stratified model exposing ``model.strat.g_prime`` /
-    ``model.strat.H`` and ``model.consts.f0`` (multilayer SWM, baroclinic /
-    reparameterized QG). Raises for models without that structure so a typo'd
-    config doesn't silently skip the check.
-
-    Args:
-        spec: The validated RunSpec (unused; present for signature symmetry).
-        model: The constructed model instance.
-        n_cells_min: Minimum ``L_d/dx`` below which to FAIL. Defaults to 2.0.
-        n_cells_warn: ``L_d/dx`` below which to WARN. Defaults to 4.0.
-
-    Raises:
-        AssertionFailedError: If the model lacks stratification/Coriolis, or
-            if ``L_d/dx < n_cells_min``.
-    """
-    strat = getattr(model, "strat", None)
-    consts = getattr(model, "consts", None)
-    grid = getattr(model, "grid", None)
-    if strat is None or grid is None or consts is None:
-        raise AssertionFailedError(
-            f"deformation_radius: model {type(model).__name__!r} lacks "
-            f"strat/consts/grid; this check applies to stratified models "
-            f"(multilayer SWM, baroclinic/reparameterized QG)."
-        )
-    g_prime = getattr(strat, "g_prime", None)
-    H = getattr(strat, "H", None)
-    f0 = getattr(consts, "f0", None)
-    if g_prime is None or H is None or f0 is None:
-        raise AssertionFailedError(
-            f"deformation_radius: model {type(model).__name__!r} does not "
-            f"expose strat.g_prime / strat.H / consts.f0; cannot compute L_d."
-        )
-    f0_abs = abs(float(f0))
-    if f0_abs == 0.0:
-        raise AssertionFailedError(
-            "deformation_radius: consts.f0 is zero; L_d is undefined on an "
-            "f-plane with no rotation."
-        )
-    # Prefer the model's vertical-mode deformation radii when available: the
-    # first internal radius comes from the vertical-mode eigenproblem, not
-    # just one interface's sqrt(g'_k H_k)/f0 (which can substantially
-    # overestimate the baroclinic radius for a thin upper layer). Fall back to
-    # the per-interface estimate only when the modal transform is absent.
-    modal = getattr(model, "modal", None)
-    modal_radii = getattr(modal, "rossby_radii", None) if modal is not None else None
-    if modal_radii is not None:
-        radii = np.asarray(jnp.asarray(modal_radii))
-        # The barotropic mode is infinite; keep only the finite internal modes.
-        finite = radii[np.isfinite(radii)]
-        if finite.size == 0:
-            raise AssertionFailedError(
-                "deformation_radius: model exposes no finite internal "
-                "deformation radius (modal.rossby_radii are all non-finite)."
-            )
-        Ld = float(np.min(finite))
-        source = "modal.rossby_radii"
-    else:
-        # Per-interface estimate sqrt(g'_k H_k)/f0; smallest internal mode.
-        g_prime_arr = np.asarray(jnp.asarray(g_prime))
-        H_arr = np.asarray(jnp.asarray(H))
-        radii = np.sqrt(g_prime_arr * H_arr) / f0_abs
-        internal = radii[1:] if radii.shape[0] > 1 else radii
-        Ld = float(np.min(internal))
-        source = "sqrt(g'H)/f0 estimate"
-    # The *coarser* spacing: a deformation radius is an isotropic
-    # length, so it has to be resolved in both directions, and taking
-    # the finer one would pass an anisotropic grid that resolves it
-    # along only one axis. (The Munk and Stommel guards take dx
-    # instead — those layers are normal to the western wall.)
-    dx_min = float(max(grid.dx, grid.dy))
-    ratio = Ld / dx_min
-    if ratio < n_cells_min:
-        raise AssertionFailedError(
-            f"deformation_radius check FAILED: L_d/dx = {ratio:.2f} < "
-            f"{n_cells_min}\n"
-            f"  L_d   = {Ld:.4g} (smallest internal deformation radius, "
-            f"from {source})\n"
-            f"  dx    = {dx_min:.4g}\n"
-            f"  → eddies will be suppressed; refine the grid or pick an "
-            f"eddy-permitting configuration."
-        )
-    if ratio < n_cells_warn:
-        logger.warning(
-            "deformation radius marginally resolved: L_d/dx = {:.2f} "
-            "(L_d={:.4g}, dx={:.4g})",
-            ratio,
-            Ld,
-            dx_min,
         )
 
 

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -134,6 +134,9 @@ def check_deformation_radius(
     ``L_d/dx < n_cells_min``; WARN when ``n_cells_min <= L_d/dx <
     n_cells_warn``.
 
+    ``dx`` here is the coarser of the two spacings, since a deformation
+    radius is isotropic and must be spanned in both directions.
+
     Requires a stratified model exposing ``model.strat.g_prime`` /
     ``model.strat.H`` and ``model.consts.f0`` (multilayer SWM, baroclinic /
     reparameterized QG). Raises for models without that structure so a typo'd
@@ -198,7 +201,12 @@ def check_deformation_radius(
         internal = radii[1:] if radii.shape[0] > 1 else radii
         Ld = float(np.min(internal))
         source = "sqrt(g'H)/f0 estimate"
-    dx_min = float(min(grid.dx, grid.dy))
+    # The *coarser* spacing: a deformation radius is an isotropic
+    # length, so it has to be resolved in both directions, and taking
+    # the finer one would pass an anisotropic grid that resolves it
+    # along only one axis. (The Munk and Stommel guards take dx
+    # instead — those layers are normal to the western wall.)
+    dx_min = float(max(grid.dx, grid.dy))
     ratio = Ld / dx_min
     if ratio < n_cells_min:
         raise AssertionFailedError(

--- a/somax/_src/core/resolution.py
+++ b/somax/_src/core/resolution.py
@@ -17,6 +17,7 @@ import warnings
 from typing import TYPE_CHECKING, Any
 
 import jax.numpy as jnp
+import numpy as np
 import paramax
 
 
@@ -273,4 +274,113 @@ def check_stommel_width(
             ratio,
             delta_s,
             dx,
+        )
+
+
+def check_deformation_radius(
+    spec: RunSpec,
+    model: Any,
+    *,
+    n_cells_min: float = 2.0,
+    n_cells_warn: float = 4.0,
+) -> None:
+    """Pre-flight: the first baroclinic deformation radius is resolved.
+
+    Resolving the first internal deformation radius ``L_d = sqrt(g'H)/f0``
+    with at least ``n_cells_min`` grid cells is necessary for baroclinic
+    instability and mesoscale eddies (Hallberg 2013). FAIL when
+    ``L_d/dx < n_cells_min``; WARN when ``n_cells_min <= L_d/dx <
+    n_cells_warn``.
+
+    ``dx`` here is the coarser of the two spacings, since a deformation
+    radius is isotropic and must be spanned in both directions.
+
+    Requires a stratified model exposing ``model.strat.g_prime`` /
+    ``model.strat.H`` and ``model.consts.f0`` (multilayer SWM, baroclinic /
+    reparameterized QG). Raises for models without that structure so a typo'd
+    config doesn't silently skip the check.
+
+    Args:
+        spec: The validated RunSpec (unused; present for signature symmetry).
+        model: The constructed model instance.
+        n_cells_min: Minimum ``L_d/dx`` below which to FAIL. Defaults to 2.0.
+        n_cells_warn: ``L_d/dx`` below which to WARN. Defaults to 4.0.
+
+    Raises:
+        AssertionFailedError: If the model lacks stratification/Coriolis, or
+            if ``L_d/dx < n_cells_min``.
+    """
+    strat = getattr(model, "strat", None)
+    consts = getattr(model, "consts", None)
+    grid = getattr(model, "grid", None)
+    if strat is None or grid is None or consts is None:
+        raise AssertionFailedError(
+            f"deformation_radius: model {type(model).__name__!r} lacks "
+            f"strat/consts/grid; this check applies to stratified models "
+            f"(multilayer SWM, baroclinic/reparameterized QG)."
+        )
+    g_prime = getattr(strat, "g_prime", None)
+    H = getattr(strat, "H", None)
+    f0 = getattr(consts, "f0", None)
+    if g_prime is None or H is None or f0 is None:
+        raise AssertionFailedError(
+            f"deformation_radius: model {type(model).__name__!r} does not "
+            f"expose strat.g_prime / strat.H / consts.f0; cannot compute L_d."
+        )
+    f0_abs = abs(float(f0))
+    if f0_abs == 0.0:
+        raise AssertionFailedError(
+            "deformation_radius: consts.f0 is zero; L_d is undefined on an "
+            "f-plane with no rotation."
+        )
+    # Prefer the model's vertical-mode deformation radii when available: the
+    # first internal radius comes from the vertical-mode eigenproblem, not
+    # just one interface's sqrt(g'_k H_k)/f0 (which can substantially
+    # overestimate the baroclinic radius for a thin upper layer). Fall back to
+    # the per-interface estimate only when the modal transform is absent.
+    modal = getattr(model, "modal", None)
+    modal_radii = getattr(modal, "rossby_radii", None) if modal is not None else None
+    if modal_radii is not None:
+        radii = np.asarray(jnp.asarray(modal_radii))
+        # The barotropic mode is infinite; keep only the finite internal modes.
+        finite = radii[np.isfinite(radii)]
+        if finite.size == 0:
+            raise AssertionFailedError(
+                "deformation_radius: model exposes no finite internal "
+                "deformation radius (modal.rossby_radii are all non-finite)."
+            )
+        Ld = float(np.min(finite))
+        source = "modal.rossby_radii"
+    else:
+        # Per-interface estimate sqrt(g'_k H_k)/f0; smallest internal mode.
+        g_prime_arr = np.asarray(jnp.asarray(g_prime))
+        H_arr = np.asarray(jnp.asarray(H))
+        radii = np.sqrt(g_prime_arr * H_arr) / f0_abs
+        internal = radii[1:] if radii.shape[0] > 1 else radii
+        Ld = float(np.min(internal))
+        source = "sqrt(g'H)/f0 estimate"
+    # The *coarser* spacing: a deformation radius is an isotropic
+    # length, so it has to be resolved in both directions, and taking
+    # the finer one would pass an anisotropic grid that resolves it
+    # along only one axis. (The Munk and Stommel guards take dx
+    # instead — those layers are normal to the western wall.)
+    dx_min = float(max(grid.dx, grid.dy))
+    ratio = Ld / dx_min
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"deformation_radius check FAILED: L_d/dx = {ratio:.2f} < "
+            f"{n_cells_min}\n"
+            f"  L_d   = {Ld:.4g} (smallest internal deformation radius, "
+            f"from {source})\n"
+            f"  dx    = {dx_min:.4g}\n"
+            f"  → eddies will be suppressed; refine the grid or pick an "
+            f"eddy-permitting configuration."
+        )
+    if ratio < n_cells_warn:
+        _warn(
+            "deformation radius marginally resolved: L_d/dx = {:.2f} "
+            "(L_d={:.4g}, dx={:.4g})",
+            ratio,
+            Ld,
+            dx_min,
         )

--- a/somax/_src/models/_nondim.py
+++ b/somax/_src/models/_nondim.py
@@ -1,0 +1,130 @@
+"""Shared helpers for the ``from_nondimensional`` model factories.
+
+Every factory does the same three things: validate its dimensionless
+inputs, turn them into the SI-shaped kwargs ``create()`` already
+accepts, and hand back the unit :class:`~somax._src.core.scales.Scales`
+the resulting model runs in. The pieces that are common to more than
+one model live here so the mappings stay stated once.
+
+Two Burger conventions appear in the layered models and it matters
+which is meant:
+
+* **Per interface** — ``Bu_k = g'_k H_k / (f0 L)**2``, one number per
+  layer interface. This is what :func:`burger_to_g_prime` inverts, and
+  what the factories accept, because it maps to the stratification
+  one-to-one.
+* **Per vertical mode** — ``(L_d,m / L)**2``, one number per baroclinic
+  mode, where ``L_d,m`` comes from the vertical-mode eigenproblem. For
+  two layers the internal mode has
+  ``L_d**2 = g' H_1 H_2 / (f0**2 (H_1 + H_2))``, which is a specific
+  combination of the interface values rather than any one of them.
+
+Prescribing the modal radii directly would mean solving an inverse
+eigenproblem, so the factories take the interface convention and expose
+the resulting modal radii on the built model
+(``model.modal.rossby_radii``) for the resolution guard to read.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+
+def require_positive(context: str, **values: float) -> None:
+    """Raise if any named value is not finite and strictly positive."""
+    for name, value in values.items():
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(
+                f"{context}: {name} must be a finite positive number; got {value!r}."
+            )
+
+
+def require_non_negative(context: str, **values: float) -> None:
+    """Raise if any named value is negative or not finite."""
+    for name, value in values.items():
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError(
+                f"{context}: {name} must be a finite non-negative number; "
+                f"got {value!r}."
+            )
+
+
+def resolve_burger(
+    context: str,
+    burger: float | None,
+    froude: float | None,
+    rossby: float,
+) -> float:
+    """Settle the Burger number from ``burger`` or ``froude``.
+
+    The two are not independent once the Rossby number is fixed:
+    ``Bu = (Ro / Fr)**2``. Accepting both would let a caller state an
+    inconsistent pair, so exactly one must be given.
+
+    Args:
+        context: Caller name, for error messages.
+        burger: Burger number, or ``None``.
+        froude: Froude number ``U / sqrt(gH)``, or ``None``.
+        rossby: Rossby number, already validated.
+
+    Returns:
+        The Burger number.
+
+    Raises:
+        ValueError: If both or neither is supplied, or the value is not
+            positive.
+    """
+    if (burger is None) == (froude is None):
+        raise ValueError(
+            f"{context}: give exactly one of burger or froude. They are "
+            f"related by Bu = (Ro/Fr)**2 at fixed Ro, so supplying both "
+            f"allows an inconsistent pair."
+        )
+    if froude is not None:
+        require_positive(context, froude=froude)
+        return (rossby / froude) ** 2
+    require_positive(context, burger=burger)
+    return float(burger)
+
+
+def burger_to_g_prime(
+    context: str,
+    burger: Sequence[float],
+    thickness: Sequence[float],
+    f0: float = 1.0,
+    length: float = 1.0,
+) -> tuple[float, ...]:
+    """Invert the per-interface Burger numbers into reduced gravities.
+
+    ``Bu_k = g'_k H_k / (f0 L)**2`` gives
+    ``g'_k = Bu_k * (f0 L)**2 / H_k``.
+
+    Args:
+        context: Caller name, for error messages.
+        burger: Per-interface Burger numbers, top to bottom.
+        thickness: Per-layer thicknesses in the same units the model
+            will use, same length as ``burger``.
+        f0: Reference Coriolis parameter of the target model.
+        length: Horizontal length scale of the target model.
+
+    Returns:
+        Reduced gravities, one per interface.
+
+    Raises:
+        ValueError: If the sequences differ in length, are empty, or
+            contain a non-positive entry.
+    """
+    if len(burger) != len(thickness):
+        raise ValueError(
+            f"{context}: burger and thickness_ratio must have the same "
+            f"length; got {len(burger)} and {len(thickness)}."
+        )
+    if not burger:
+        raise ValueError(f"{context}: burger must not be empty.")
+    for index, (bu, h) in enumerate(zip(burger, thickness, strict=True)):
+        require_positive(context, **{f"burger[{index}]": bu, f"thickness[{index}]": h})
+    factor = (f0 * length) ** 2
+    return tuple(
+        float(bu) * factor / float(h) for bu, h in zip(burger, thickness, strict=True)
+    )

--- a/somax/_src/models/_nondim.py
+++ b/somax/_src/models/_nondim.py
@@ -120,7 +120,10 @@ def burger_to_g_prime(
             f"{context}: burger and thickness_ratio must have the same "
             f"length; got {len(burger)} and {len(thickness)}."
         )
-    if not burger:
+    # ``len(...) == 0`` rather than ``not burger``: a multi-element
+    # NumPy or JAX array is a perfectly good sequence here, but its
+    # truth value is ambiguous and raises before the conversion below.
+    if len(burger) == 0:
         raise ValueError(f"{context}: burger must not be empty.")
     for index, (bu, h) in enumerate(zip(burger, thickness, strict=True)):
         require_positive(context, **{f"burger[{index}]": bu, f"thickness[{index}]": h})

--- a/somax/_src/models/_nondim.py
+++ b/somax/_src/models/_nondim.py
@@ -128,3 +128,34 @@ def burger_to_g_prime(
     return tuple(
         float(bu) * factor / float(h) for bu, h in zip(burger, thickness, strict=True)
     )
+
+
+def reject_derived_kwargs(
+    context: str, derived: Sequence[str], **create_kw: object
+) -> None:
+    """Refuse forwarded arguments the factory derives for itself.
+
+    ``**create_kw`` is a convenience for the knobs a dimensionless
+    description says nothing about — ``bc``, ``method``, ``mask``,
+    ``wind_profile``. Letting a stratification or a Coriolis parameter
+    through it would silently win over the values derived from the
+    dimensionless inputs, while the returned ``Scales`` still described
+    the derived ones: the model and its scales would then be different
+    systems.
+
+    Args:
+        context: Caller name, for error messages.
+        derived: Argument names the factory sets itself.
+        **create_kw: The forwarded arguments to check.
+
+    Raises:
+        ValueError: If any forwarded name is one the factory derives.
+    """
+    clash = sorted(set(create_kw) & set(derived))
+    if clash:
+        raise ValueError(
+            f"{context}: {clash} is derived from the dimensionless inputs and "
+            f"cannot be passed through to create(). Passing it would leave the "
+            f"model and the returned Scales describing different systems; drop "
+            f"it, or use create() directly for a dimensional build."
+        )

--- a/somax/_src/models/qg/baroclinic.py
+++ b/somax/_src/models/qg/baroclinic.py
@@ -387,7 +387,7 @@ class BaroclinicQG(SomaxModel):
         scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0], g=g_prime[0])
 
         if check_resolution:
-            from somax._src.cli._assertions import (
+            from somax._src.core.resolution import (
                 check_deformation_radius,
                 check_munk_width,
                 check_stommel_width,

--- a/somax/_src/models/qg/baroclinic.py
+++ b/somax/_src/models/qg/baroclinic.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -17,8 +20,14 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
+from somax._src.models._nondim import (
+    burger_to_g_prime,
+    require_non_negative,
+    require_positive,
+)
 
 
 class BaroclinicQGState(State):
@@ -241,6 +250,117 @@ class BaroclinicQG(SomaxModel):
             relative_vorticity=zeta,
             rossby_radii=self.modal.rossby_radii,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        rossby: float,
+        beta_hat: float,
+        burger: Sequence[float],
+        thickness_ratio: Sequence[float],
+        delta_M: float,
+        delta_S: float = 0.0,
+        wind_hat: float | None = None,
+        aspect: float = 1.0,
+        check_resolution: bool = True,
+        **create_kw: Any,
+    ) -> tuple[BaroclinicQG, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **advective** (:meth:`somax.Scales.advective`), with
+        ``L = U = 1`` so that ``T = L/U = 1`` and ``f0 = 1/Ro`` — the
+        same set :meth:`somax.BarotropicQG.from_nondimensional` uses,
+        plus stratification.
+
+        =================  ===============================  ======================
+        Input              Definition                       ``create()`` kwarg
+        =================  ===============================  ======================
+        ``rossby``         :math:`Ro = U/(f_0 L)`           ``f0 = 1/Ro``
+        ``beta_hat``       :math:`\beta L^2/U`               ``beta``
+        ``burger``         :math:`g'_k H_k/(f_0 L)^2`       ``g_prime``
+        ``delta_M``        :math:`(\nu/\beta)^{1/3}/L`       ``lateral_viscosity``
+        ``delta_S``        :math:`\kappa/(\beta L)`           ``bottom_drag``
+        =================  ===============================  ======================
+
+        ``burger`` is the **per-interface** Burger number, which inverts
+        to the stratification one-to-one. It is not the per-mode value:
+        the deformation radius of vertical mode ``m`` is a combination
+        of the interface numbers, and the built model reports the
+        resulting radii as ``model.modal.rossby_radii`` — already in
+        units of ``L``, so directly comparable with ``dx``.
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            rossby: Rossby number. Sets ``f0 = 1/Ro``.
+            beta_hat: Dimensionless planetary vorticity gradient.
+            burger: Per-interface Burger numbers, top to bottom.
+            thickness_ratio: Layer thicknesses relative to the depth
+                scale. Same length as ``burger``.
+            delta_M: Munk-layer width as a fraction of ``L``.
+            delta_S: Stommel-layer width as a fraction of ``L``.
+            wind_hat: Dimensionless wind amplitude
+                :math:`\\tau_0 L^2/(U^2 H_1)`. Defaults to
+                ``beta_hat``, the Sverdrup-balanced value.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            check_resolution: Run the Munk, Stommel and deformation
+                radius guards.
+            **create_kw: Forwarded to :meth:`create`.
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "advective"``.
+
+        Raises:
+            ValueError: If an input is out of range.
+            AssertionFailedError: If ``check_resolution`` is set and the
+                grid cannot resolve a boundary layer or the first
+                internal deformation radius.
+        """
+        context = "BaroclinicQG.from_nondimensional"
+        require_positive(context, rossby=rossby, beta_hat=beta_hat, aspect=aspect)
+        require_non_negative(context, delta_M=delta_M, delta_S=delta_S)
+        f0 = 1.0 / rossby
+        g_prime = burger_to_g_prime(context, burger, thickness_ratio, f0=f0, length=1.0)
+        thickness = tuple(float(h) for h in thickness_ratio)
+
+        model = BaroclinicQG.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            f0=f0,
+            beta=beta_hat,
+            n_layers=len(thickness),
+            H=thickness,
+            g_prime=g_prime,
+            lateral_viscosity=delta_M**3 * beta_hat,
+            bottom_drag=delta_S * beta_hat,
+            # The RHS applies the wind as tau0 * F / H[0], so the
+            # dimensionless group tau_hat = tau0 L**2 / (U**2 H_1)
+            # maps to a kwarg carrying the top-layer thickness.
+            wind_amplitude=(beta_hat if wind_hat is None else wind_hat) * thickness[0],
+            **create_kw,
+        )
+        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0])
+
+        if check_resolution:
+            from somax._src.cli._assertions import (
+                check_deformation_radius,
+                check_munk_width,
+                check_stommel_width,
+            )
+
+            if delta_M > 0.0:
+                check_munk_width(None, model)
+            if delta_S > 0.0:
+                check_stommel_width(None, model)
+            check_deformation_radius(None, model)
+
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/qg/baroclinic.py
+++ b/somax/_src/models/qg/baroclinic.py
@@ -31,6 +31,7 @@ from somax._src.core.types import (
 )
 from somax._src.models._nondim import (
     burger_to_g_prime,
+    reject_derived_kwargs,
     require_non_negative,
     require_positive,
 )
@@ -330,8 +331,31 @@ class BaroclinicQG(SomaxModel):
                 internal deformation radius.
         """
         context = "BaroclinicQG.from_nondimensional"
+        reject_derived_kwargs(
+            context,
+            (
+                "Lx",
+                "Ly",
+                "f0",
+                "beta",
+                "n_layers",
+                "H",
+                "g_prime",
+                "stratification",
+                "lateral_viscosity",
+                "bottom_drag",
+                "wind_amplitude",
+            ),
+            **create_kw,
+        )
         require_positive(context, rossby=rossby, beta_hat=beta_hat, aspect=aspect)
         require_non_negative(context, delta_M=delta_M, delta_S=delta_S)
+        if wind_hat is not None:
+            # Only when supplied: the default is beta_hat, already
+            # checked. Left unvalidated, a non-finite value was
+            # copied straight into wind_amplitude and produced
+            # non-finite tendencies on the first step.
+            require_non_negative(context, wind_hat=wind_hat)
         f0 = 1.0 / rossby
         g_prime = burger_to_g_prime(context, burger, thickness_ratio, f0=f0, length=1.0)
         thickness = tuple(float(h) for h in thickness_ratio)
@@ -354,7 +378,13 @@ class BaroclinicQG(SomaxModel):
             wind_amplitude=(beta_hat if wind_hat is None else wind_hat) * thickness[0],
             **create_kw,
         )
-        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0])
+        # g is the *first interface's* reduced gravity, not standard
+        # gravity: these scales describe the nondimensional model,
+        # where the surface-mode gravity is g_prime[0]. Leaving it
+        # at 9.81 would make scales.burger disagree with burger[0]
+        # and put the thickness-anomaly scale f0 U L / g out by the
+        # ratio between them.
+        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0], g=g_prime[0])
 
         if check_resolution:
             from somax._src.cli._assertions import (

--- a/somax/_src/models/qg/barotropic.py
+++ b/somax/_src/models/qg/barotropic.py
@@ -349,7 +349,7 @@ class BarotropicQG(SomaxModel):
         scales = Scales.advective(L=1.0, U=1.0, f0=1.0 / rossby, H=1.0)
 
         if check_resolution:
-            from somax._src.cli._assertions import (
+            from somax._src.core.resolution import (
                 check_munk_width,
                 check_stommel_width,
             )

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -34,6 +34,7 @@ from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics
 from somax._src.models._nondim import (
     burger_to_g_prime,
+    reject_derived_kwargs,
     require_non_negative,
     require_positive,
 )
@@ -309,8 +310,13 @@ class ReparameterizedQG(SomaxModel):
             delta_M: Munk-layer width as a fraction of ``L``.
             delta_S: Stommel-layer width as a fraction of ``L``.
             wind_hat: Dimensionless wind amplitude
-                :math:`\\tau_0 L^2/(U^2 H_1)`. Defaults to
-                ``beta_hat``, the Sverdrup-balanced value.
+                :math:`\\tau_0 L/(U^2 H_1)`. One power of ``L``, not two:
+                this model's right-hand side is
+                :class:`MultilayerShallowWater2D`'s *momentum* equation,
+                whose tendency scale is :math:`U^2/L`. The :math:`L^2`
+                group belongs to :class:`BaroclinicQG`, which advances a
+                PV tendency instead. Defaults to ``beta_hat``, the
+                Sverdrup-balanced value.
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
             check_resolution: Run the Munk, Stommel and deformation
                 radius guards.
@@ -326,8 +332,31 @@ class ReparameterizedQG(SomaxModel):
                 internal deformation radius.
         """
         context = "ReparameterizedQG.from_nondimensional"
+        reject_derived_kwargs(
+            context,
+            (
+                "Lx",
+                "Ly",
+                "f0",
+                "beta",
+                "n_layers",
+                "H",
+                "g_prime",
+                "stratification",
+                "lateral_viscosity",
+                "bottom_drag",
+                "wind_amplitude",
+            ),
+            **create_kw,
+        )
         require_positive(context, rossby=rossby, beta_hat=beta_hat, aspect=aspect)
         require_non_negative(context, delta_M=delta_M, delta_S=delta_S)
+        if wind_hat is not None:
+            # Only when supplied: the default is beta_hat, already
+            # checked. Left unvalidated, a non-finite value was
+            # copied straight into wind_amplitude and produced
+            # non-finite tendencies on the first step.
+            require_non_negative(context, wind_hat=wind_hat)
         f0 = 1.0 / rossby
         g_prime = burger_to_g_prime(context, burger, thickness_ratio, f0=f0, length=1.0)
         thickness = tuple(float(h) for h in thickness_ratio)
@@ -345,12 +374,20 @@ class ReparameterizedQG(SomaxModel):
             lateral_viscosity=delta_M**3 * beta_hat,
             bottom_drag=delta_S * beta_hat,
             # The RHS applies the wind as tau0 * F / H[0], so the
-            # dimensionless group tau_hat = tau0 L**2 / (U**2 H_1)
-            # maps to a kwarg carrying the top-layer thickness.
+            # dimensionless group tau_hat = tau0 L / (U**2 H_1) maps to
+            # a kwarg carrying the top-layer thickness. (At unit scales
+            # the two spellings of the group coincide; the power of L
+            # matters when converting a dimensional configuration.)
             wind_amplitude=(beta_hat if wind_hat is None else wind_hat) * thickness[0],
             **create_kw,
         )
-        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0])
+        # g is the *first interface's* reduced gravity, not standard
+        # gravity: these scales describe the nondimensional model,
+        # where the surface-mode gravity is g_prime[0]. Leaving it
+        # at 9.81 would make scales.burger disagree with burger[0]
+        # and put the thickness-anomaly scale f0 U L / g out by the
+        # ratio between them.
+        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0], g=g_prime[0])
 
         if check_resolution:
             from somax._src.cli._assertions import (

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -390,7 +390,7 @@ class ReparameterizedQG(SomaxModel):
         scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0], g=g_prime[0])
 
         if check_resolution:
-            from somax._src.cli._assertions import (
+            from somax._src.core.resolution import (
                 check_deformation_radius,
                 check_munk_width,
                 check_stommel_width,

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -11,6 +11,7 @@ geostrophic manifold.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Sequence
 from typing import Any
 
@@ -346,6 +347,10 @@ class ReparameterizedQG(SomaxModel):
                 "lateral_viscosity",
                 "bottom_drag",
                 "wind_amplitude",
+                # Derived from burger via g_prime[0]; a forwarded value
+                # would contradict the stratification and the returned
+                # scales.
+                "g",
             ),
             **create_kw,
         )
@@ -360,6 +365,21 @@ class ReparameterizedQG(SomaxModel):
         f0 = 1.0 / rossby
         g_prime = burger_to_g_prime(context, burger, thickness_ratio, f0=f0, length=1.0)
         thickness = tuple(float(h) for h in thickness_ratio)
+
+        # The wind group is a *stress* here, but the default is chosen
+        # for a unit Sverdrup interior velocity, which balances the
+        # stress *curl*: beta v = curl(tau) / H_1. The underlying SWM
+        # profile is tau_x = -cos(2 pi y / Ly) (or -cos(pi y / Ly)),
+        # whose curl has amplitude 2 pi / Ly (or pi / Ly), so passing
+        # beta_hat straight through overshot by that factor.
+        # ``BaroclinicQG`` needs no such division: its stored forcing
+        # is already a curl.
+        if wind_hat is None:
+            profile = create_kw.get("wind_profile", "doublegyre")
+            wavenumber = math.pi if profile == "single" else 2.0 * math.pi
+            stress_hat = beta_hat * aspect / wavenumber
+        else:
+            stress_hat = wind_hat
 
         model = ReparameterizedQG.create(
             nx=nx,
@@ -378,7 +398,14 @@ class ReparameterizedQG(SomaxModel):
             # a kwarg carrying the top-layer thickness. (At unit scales
             # the two spellings of the group coincide; the power of L
             # matters when converting a dimensional configuration.)
-            wind_amplitude=(beta_hat if wind_hat is None else wind_hat) * thickness[0],
+            wind_amplitude=stress_hat * thickness[0],
+            # g is the first interface's reduced gravity here, as in
+            # the returned scales. Left at the 9.81 default, the model
+            # constants would disagree with its own stratification and
+            # any diagnostic reading consts.gravity — the geostrophic
+            # imbalance metric among them — would use the wrong
+            # coefficient.
+            g=g_prime[0],
             **create_kw,
         )
         # g is the *first interface's* reduced gravity, not standard

--- a/somax/_src/models/qg/reparameterized.py
+++ b/somax/_src/models/qg/reparameterized.py
@@ -11,6 +11,9 @@ geostrophic manifold.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -26,8 +29,14 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics
+from somax._src.models._nondim import (
+    burger_to_g_prime,
+    require_non_negative,
+    require_positive,
+)
 from somax._src.models.swm.multilayer import (
     MultilayerShallowWater2D,
     MultilayerSW2DParams,
@@ -246,6 +255,117 @@ class ReparameterizedQG(SomaxModel):
             u_ageostrophic=u_ageo,
             v_ageostrophic=v_ageo,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        rossby: float,
+        beta_hat: float,
+        burger: Sequence[float],
+        thickness_ratio: Sequence[float],
+        delta_M: float,
+        delta_S: float = 0.0,
+        wind_hat: float | None = None,
+        aspect: float = 1.0,
+        check_resolution: bool = True,
+        **create_kw: Any,
+    ) -> tuple[ReparameterizedQG, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **advective** (:meth:`somax.Scales.advective`), with
+        ``L = U = 1`` so that ``T = L/U = 1`` and ``f0 = 1/Ro`` — the
+        same set :meth:`somax.BarotropicQG.from_nondimensional` uses,
+        plus stratification.
+
+        =================  ===============================  ======================
+        Input              Definition                       ``create()`` kwarg
+        =================  ===============================  ======================
+        ``rossby``         :math:`Ro = U/(f_0 L)`           ``f0 = 1/Ro``
+        ``beta_hat``       :math:`\beta L^2/U`               ``beta``
+        ``burger``         :math:`g'_k H_k/(f_0 L)^2`       ``g_prime``
+        ``delta_M``        :math:`(\nu/\beta)^{1/3}/L`       ``lateral_viscosity``
+        ``delta_S``        :math:`\kappa/(\beta L)`           ``bottom_drag``
+        =================  ===============================  ======================
+
+        ``burger`` is the **per-interface** Burger number, which inverts
+        to the stratification one-to-one. It is not the per-mode value:
+        the deformation radius of vertical mode ``m`` is a combination
+        of the interface numbers, and the built model reports the
+        resulting radii as ``model.modal.rossby_radii`` — already in
+        units of ``L``, so directly comparable with ``dx``.
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            rossby: Rossby number. Sets ``f0 = 1/Ro``.
+            beta_hat: Dimensionless planetary vorticity gradient.
+            burger: Per-interface Burger numbers, top to bottom.
+            thickness_ratio: Layer thicknesses relative to the depth
+                scale. Same length as ``burger``.
+            delta_M: Munk-layer width as a fraction of ``L``.
+            delta_S: Stommel-layer width as a fraction of ``L``.
+            wind_hat: Dimensionless wind amplitude
+                :math:`\\tau_0 L^2/(U^2 H_1)`. Defaults to
+                ``beta_hat``, the Sverdrup-balanced value.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            check_resolution: Run the Munk, Stommel and deformation
+                radius guards.
+            **create_kw: Forwarded to :meth:`create`.
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "advective"``.
+
+        Raises:
+            ValueError: If an input is out of range.
+            AssertionFailedError: If ``check_resolution`` is set and the
+                grid cannot resolve a boundary layer or the first
+                internal deformation radius.
+        """
+        context = "ReparameterizedQG.from_nondimensional"
+        require_positive(context, rossby=rossby, beta_hat=beta_hat, aspect=aspect)
+        require_non_negative(context, delta_M=delta_M, delta_S=delta_S)
+        f0 = 1.0 / rossby
+        g_prime = burger_to_g_prime(context, burger, thickness_ratio, f0=f0, length=1.0)
+        thickness = tuple(float(h) for h in thickness_ratio)
+
+        model = ReparameterizedQG.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            f0=f0,
+            beta=beta_hat,
+            n_layers=len(thickness),
+            H=thickness,
+            g_prime=g_prime,
+            lateral_viscosity=delta_M**3 * beta_hat,
+            bottom_drag=delta_S * beta_hat,
+            # The RHS applies the wind as tau0 * F / H[0], so the
+            # dimensionless group tau_hat = tau0 L**2 / (U**2 H_1)
+            # maps to a kwarg carrying the top-layer thickness.
+            wind_amplitude=(beta_hat if wind_hat is None else wind_hat) * thickness[0],
+            **create_kw,
+        )
+        scales = Scales.advective(L=1.0, U=1.0, f0=f0, H=thickness[0])
+
+        if check_resolution:
+            from somax._src.cli._assertions import (
+                check_deformation_radius,
+                check_munk_width,
+                check_stommel_width,
+            )
+
+            if delta_M > 0.0:
+                check_munk_width(None, model)
+            if delta_S > 0.0:
+                check_stommel_width(None, model)
+            check_deformation_radius(None, model)
+
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/swm/multilayer.py
+++ b/somax/_src/models/swm/multilayer.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import partial
+from typing import Any
 
 import equinox as eqx
 import jax.numpy as jnp
@@ -23,9 +25,15 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.transforms import ModalTransform, StratificationProfile
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
 from somax._src.guards import guard_finite, guard_positive
+from somax._src.models._nondim import (
+    burger_to_g_prime,
+    require_non_negative,
+    require_positive,
+)
 
 
 class MultilayerSW2DState(State):
@@ -298,6 +306,93 @@ class MultilayerShallowWater2D(SomaxModel):
             relative_vorticity=zeta,
             kinetic_energy_field=ke,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        rossby: float,
+        burger: Sequence[float],
+        thickness_ratio: Sequence[float],
+        beta_hat: float = 0.0,
+        ekman: float = 0.0,
+        ekman_lateral: float = 0.0,
+        wind_hat: float = 0.0,
+        aspect: float = 1.0,
+        **create_kw: Any,
+    ) -> tuple[MultilayerShallowWater2D, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **inertial** (:meth:`somax.Scales.inertial`), with
+        ``L = f0 = 1`` and the depth scale set by the first layer, so
+        ``T = 1/f0 = 1`` and ``U = Ro``.
+
+        Stratification comes from one Burger number **per interface**,
+        :math:`Bu_k = g'_k H_k/(f_0 L)^2`, inverted to
+        ``g_prime[k] = Bu_k / thickness_ratio[k]``. That is the
+        interface convention, not the per-mode one: the deformation
+        radii of the vertical modes are a combination of the interface
+        values, and are available on the built model as
+        ``model.modal.rossby_radii`` once the eigenproblem is solved.
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            rossby: Rossby number; sets the velocity scale.
+            burger: Per-interface Burger numbers, top to bottom.
+            thickness_ratio: Layer thicknesses relative to the depth
+                scale, ``H_k / H_1``. Same length as ``burger``.
+            beta_hat: Dimensionless planetary vorticity gradient.
+            ekman: Linear bottom-drag Ekman number.
+            ekman_lateral: Lateral-viscosity Ekman number.
+            wind_hat: Dimensionless wind acceleration.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            **create_kw: Forwarded to :meth:`create`.
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "inertial"``.
+
+        Raises:
+            ValueError: If an input is out of range or the sequences
+                disagree in length.
+        """
+        context = "MultilayerShallowWater2D.from_nondimensional"
+        require_positive(context, rossby=rossby, aspect=aspect)
+        require_non_negative(
+            context,
+            beta_hat=beta_hat,
+            ekman=ekman,
+            ekman_lateral=ekman_lateral,
+            wind_hat=wind_hat,
+        )
+        g_prime = burger_to_g_prime(
+            context, burger, thickness_ratio, f0=1.0, length=1.0
+        )
+        thickness = tuple(float(h) for h in thickness_ratio)
+
+        model = MultilayerShallowWater2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            g=g_prime[0],
+            f0=1.0,
+            beta=beta_hat,
+            n_layers=len(thickness),
+            H=thickness,
+            g_prime=g_prime,
+            lateral_viscosity=ekman_lateral,
+            bottom_drag=ekman,
+            wind_amplitude=wind_hat * rossby,
+            **create_kw,
+        )
+        scales = Scales.inertial(
+            L=1.0, f0=1.0, H=thickness[0], rossby=rossby, g=g_prime[0]
+        )
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/swm/multilayer.py
+++ b/somax/_src/models/swm/multilayer.py
@@ -31,6 +31,7 @@ from somax._src.core.types import Diagnostics, Params, PhysConsts, State, as_par
 from somax._src.guards import guard_finite, guard_positive
 from somax._src.models._nondim import (
     burger_to_g_prime,
+    reject_derived_kwargs,
     require_non_negative,
     require_positive,
 )
@@ -360,6 +361,23 @@ class MultilayerShallowWater2D(SomaxModel):
                 disagree in length.
         """
         context = "MultilayerShallowWater2D.from_nondimensional"
+        reject_derived_kwargs(
+            context,
+            (
+                "Lx",
+                "Ly",
+                "f0",
+                "beta",
+                "n_layers",
+                "H",
+                "g_prime",
+                "stratification",
+                "lateral_viscosity",
+                "bottom_drag",
+                "wind_amplitude",
+            ),
+            **create_kw,
+        )
         require_positive(context, rossby=rossby, aspect=aspect)
         require_non_negative(
             context,
@@ -386,7 +404,12 @@ class MultilayerShallowWater2D(SomaxModel):
             g_prime=g_prime,
             lateral_viscosity=ekman_lateral,
             bottom_drag=ekman,
-            wind_amplitude=wind_hat * rossby,
+            # The RHS applies the wind as tau0 * F / H[0], so the
+            # amplitude carries the top-layer thickness; without it
+            # the realised acceleration is wind_hat / H[0] whenever
+            # thickness_ratio[0] is not 1. Same convention as the
+            # layered QG factories.
+            wind_amplitude=wind_hat * rossby * thickness[0],
             **create_kw,
         )
         scales = Scales.inertial(

--- a/somax/_src/models/swm/nonlinear_2d.py
+++ b/somax/_src/models/swm/nonlinear_2d.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -20,7 +22,13 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
+from somax._src.models._nondim import (
+    require_non_negative,
+    require_positive,
+    resolve_burger,
+)
 
 
 class NonlinearSW2DState(State):
@@ -256,6 +264,99 @@ class NonlinearShallowWater2D(SomaxModel):
             relative_vorticity=zeta,
             kinetic_energy_field=ke,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        rossby: float,
+        burger: float | None = None,
+        froude: float | None = None,
+        beta_hat: float = 0.0,
+        ekman: float = 0.0,
+        ekman_lateral: float = 0.0,
+        wind_hat: float = 0.0,
+        aspect: float = 1.0,
+        **create_kw: Any,
+    ) -> tuple[NonlinearShallowWater2D, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **inertial** (:meth:`somax.Scales.inertial`), with
+        ``L = f0 = H = 1`` so that ``T = 1/f0 = 1`` and the velocity
+        scale is ``U = f0 L Ro = Ro``. The model's own velocity fields
+        are therefore ``O(Ro)``; wrap it in a
+        :class:`~somax.ScaledModel` built from the returned ``Scales``
+        to work in ``O(1)`` state instead.
+
+        ==================  ==============================  ====================
+        Input               Definition                      ``create()`` kwarg
+        ==================  ==============================  ====================
+        ``rossby``          :math:`Ro = U/(f_0 L)`          sets ``U``
+        ``burger``          :math:`Bu = gH/(f_0 L)^2`       ``g``
+        ``froude``          :math:`Fr = U/\sqrt{gH}`         ``g`` (via ``Bu``)
+        ``beta_hat``        :math:`\beta L/f_0`              ``beta``
+        ``ekman``           :math:`\kappa/f_0`               ``bottom_drag``
+        ``ekman_lateral``   :math:`\nu/(f_0 L^2)`            ``lateral_viscosity``
+        ``wind_hat``        :math:`\tau_0/(f_0 U)`           ``wind_amplitude``
+        ==================  ==============================  ====================
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            rossby: Rossby number; sets the velocity scale.
+            burger: Burger number. Give this or ``froude``, not both.
+            froude: Froude number. Equivalent to ``burger`` through
+                ``Bu = (Ro/Fr)**2``.
+            beta_hat: Dimensionless planetary vorticity gradient. Zero
+                (the default) is an f-plane.
+            ekman: Linear bottom-drag Ekman number.
+            ekman_lateral: Lateral-viscosity Ekman number.
+            wind_hat: Dimensionless wind acceleration.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            **create_kw: Forwarded to :meth:`create` (``bc``,
+                ``method``, ``wind_profile``, ``mask``).
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "inertial"``.
+
+        Raises:
+            ValueError: If an input is out of range, or if neither or
+                both of ``burger`` and ``froude`` is given.
+        """
+        context = "NonlinearShallowWater2D.from_nondimensional"
+        require_positive(context, rossby=rossby, aspect=aspect)
+        require_non_negative(
+            context,
+            beta_hat=beta_hat,
+            ekman=ekman,
+            ekman_lateral=ekman_lateral,
+            wind_hat=wind_hat,
+        )
+        bu = resolve_burger(context, burger, froude, rossby)
+
+        # Unit scales: L = f0 = H0 = 1, so every coefficient below is
+        # the dimensionless group itself. The exception is the wind,
+        # which enters the momentum equation as an acceleration and so
+        # carries the velocity scale U = Ro.
+        model = NonlinearShallowWater2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            g=bu,
+            f0=1.0,
+            beta=beta_hat,
+            H0=1.0,
+            lateral_viscosity=ekman_lateral,
+            bottom_drag=ekman,
+            wind_amplitude=wind_hat * rossby,
+            **create_kw,
+        )
+        scales = Scales.inertial(L=1.0, f0=1.0, H=1.0, rossby=rossby, g=bu)
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/swm/nonlinear_2d.py
+++ b/somax/_src/models/swm/nonlinear_2d.py
@@ -31,6 +31,7 @@ from somax._src.core.types import (
     as_parameter,
 )
 from somax._src.models._nondim import (
+    reject_derived_kwargs,
     require_non_negative,
     require_positive,
     resolve_burger,
@@ -333,6 +334,21 @@ class NonlinearShallowWater2D(SomaxModel):
                 both of ``burger`` and ``froude`` is given.
         """
         context = "NonlinearShallowWater2D.from_nondimensional"
+        reject_derived_kwargs(
+            context,
+            (
+                "Lx",
+                "Ly",
+                "g",
+                "f0",
+                "beta",
+                "H0",
+                "lateral_viscosity",
+                "bottom_drag",
+                "wind_amplitude",
+            ),
+            **create_kw,
+        )
         require_positive(context, rossby=rossby, aspect=aspect)
         require_non_negative(
             context,

--- a/tests/test_layered_nondim.py
+++ b/tests/test_layered_nondim.py
@@ -901,3 +901,101 @@ class TestArrayBackedSequencesAreAccepted:
                     thickness_ratio=maker([]),
                     delta_M=0.06,
                 )
+
+
+class TestTheModelSharesTheScalesGravity:
+    """``consts.gravity`` must agree with ``Scales.g``.
+
+    Passing ``g_prime`` alone left ``ReparameterizedQG.create`` at its
+    9.81 default, so the model's constants contradicted its own
+    stratification and the scales it was handed back with. Diagnostics
+    that read ``consts.gravity`` — ``geostrophic_imbalance`` among
+    them — then used the wrong coefficient.
+    """
+
+    @staticmethod
+    def build(**kw):
+        return ReparameterizedQG.from_nondimensional(
+            nx=64,
+            ny=64,
+            rossby=0.02,
+            beta_hat=1.0,
+            burger=(1.0, 0.1),
+            thickness_ratio=(1.0, 3.0),
+            delta_M=0.02,
+            delta_S=0.0,
+            check_resolution=False,
+            **kw,
+        )
+
+    def test_they_match(self):
+        model, scales = self.build()
+        assert float(model.swm.consts.gravity) == pytest.approx(scales.g)
+
+    def test_it_is_not_the_default(self):
+        """Otherwise the test above could pass by coincidence."""
+        _, scales = self.build()
+        assert scales.g != pytest.approx(9.81)
+
+    def test_a_forwarded_gravity_is_rejected(self):
+        with pytest.raises(ValueError, match="g"):
+            self.build(g=9.81)
+
+
+class TestTheDefaultWindGivesAUnitSverdrupVelocity:
+    """The default is a Sverdrup-balance choice, and that balances curl.
+
+    ``beta v = curl(tau) / H_1``, but the wind group this factory takes
+    is a *stress*. The underlying SWM profile is ``-cos(2 pi y / Ly)``,
+    whose curl has amplitude ``2 pi / Ly``, so passing ``beta_hat``
+    through unchanged overshot the interior velocity by that factor.
+    """
+
+    @staticmethod
+    def build(**kw):
+        return ReparameterizedQG.from_nondimensional(
+            nx=64,
+            ny=64,
+            rossby=0.01,
+            beta_hat=1.0,
+            burger=(1.0, 0.1),
+            thickness_ratio=(1.0, 3.0),
+            delta_M=0.02,
+            delta_S=0.0,
+            check_resolution=False,
+            **kw,
+        )
+
+    @staticmethod
+    def sverdrup_velocity(model):
+        swm = model.swm
+        tau = np.asarray(swm.wind_stress_x)
+        curl = -np.gradient(tau, float(swm.grid.dy), axis=0)
+        # Trim the ghost ring and its one-sided differences.
+        amplitude = float(np.abs(curl[3:-3]).max())
+        return (
+            amplitude
+            * float(model.params.wind_amplitude)
+            / (float(swm.strat.H[0]) * float(swm.consts.beta))
+        )
+
+    def test_the_double_gyre_default_is_order_one(self):
+        model, _ = self.build()
+        assert self.sverdrup_velocity(model) == pytest.approx(1.0, rel=5e-3)
+
+    def test_the_single_gyre_default_is_too(self):
+        model, _ = self.build(wind_profile="single")
+        assert self.sverdrup_velocity(model) == pytest.approx(1.0, rel=5e-3)
+
+    def test_an_explicit_wind_hat_is_a_stress_and_passes_through(self):
+        """The override is the dimensionless stress group, not a curl."""
+        model, _ = self.build(wind_hat=0.5)
+        assert float(model.params.wind_amplitude) == pytest.approx(0.5 * 1.0)
+
+    def test_the_aspect_ratio_enters_the_default(self):
+        """``Ly = aspect``, and the curl factor is ``2 pi / Ly``."""
+        square, _ = self.build()
+        tall, _ = self.build(aspect=2.0)
+        assert float(tall.params.wind_amplitude) == pytest.approx(
+            2.0 * float(square.params.wind_amplitude)
+        )

--- a/tests/test_layered_nondim.py
+++ b/tests/test_layered_nondim.py
@@ -1,0 +1,579 @@
+"""Tests for the layered models' nondimensional factories.
+
+Shallow water uses the inertial scale set, the two baroclinic QG models
+the advective one. Both take Burger numbers **per interface**, which
+invert to the stratification one-to-one; the per-mode deformation radii
+that follow from the eigenproblem are a different quantity and are
+checked separately.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from somax._src.cli._assertions import AssertionFailedError
+from somax._src.core.scales import Scales
+from somax._src.core.transforms import StateAffine
+from somax._src.models.qg.baroclinic import BaroclinicQG, BaroclinicQGState
+from somax._src.models.qg.reparameterized import ReparameterizedQG
+from somax._src.models.swm.multilayer import (
+    MultilayerShallowWater2D,
+    MultilayerSW2DState,
+)
+from somax._src.models.swm.nonlinear_2d import (
+    NonlinearShallowWater2D,
+    NonlinearSW2DState,
+)
+
+
+def relative_error(got, expected):
+    got, expected = np.asarray(got), np.asarray(expected)
+    return np.abs(got - expected).max() / np.abs(expected).max()
+
+
+class TestNonlinearShallowWaterMapping:
+    @pytest.fixture
+    def built(self):
+        return NonlinearShallowWater2D.from_nondimensional(
+            nx=16,
+            ny=16,
+            rossby=0.05,
+            burger=2.0,
+            beta_hat=0.5,
+            ekman=1e-3,
+            ekman_lateral=2e-3,
+            wind_hat=0.25,
+        )
+
+    def test_unit_coriolis_and_domain(self, built):
+        model, _ = built
+        assert float(model.consts.f0) == pytest.approx(1.0)
+        assert model.grid.Lx == pytest.approx(1.0)
+
+    def test_burger_becomes_gravity(self, built):
+        model, _ = built
+        assert float(model.consts.gravity) == pytest.approx(2.0)
+
+    def test_ekman_numbers_map_to_drag_and_viscosity(self, built):
+        model, _ = built
+        assert float(model.params.bottom_drag) == pytest.approx(1e-3)
+        assert float(model.params.lateral_viscosity) == pytest.approx(2e-3)
+
+    def test_beta_hat_maps_to_beta(self, built):
+        model, _ = built
+        assert float(model.consts.beta) == pytest.approx(0.5)
+
+    def test_wind_carries_the_velocity_scale(self, built):
+        """tau_hat = tau0/(f0 U), so the model kwarg is tau_hat * Ro."""
+        model, _ = built
+        assert float(model.params.wind_amplitude) == pytest.approx(0.25 * 0.05)
+
+    def test_velocity_scale_is_rossby(self, built):
+        _, scales = built
+        assert scales.kind == "inertial"
+        assert pytest.approx(0.05) == scales.U
+        assert pytest.approx(1.0) == scales.T
+
+    def test_burger_round_trips_through_the_scales(self, built):
+        _, scales = built
+        assert scales.burger == pytest.approx(2.0, rel=1e-9)
+
+    def test_froude_is_equivalent_to_burger(self):
+        """Bu = (Ro/Fr)**2, so the two routes must agree."""
+        rossby, burger = 0.05, 2.0
+        froude = rossby / np.sqrt(burger)
+        by_burger, _ = NonlinearShallowWater2D.from_nondimensional(
+            nx=16, ny=16, rossby=rossby, burger=burger
+        )
+        by_froude, _ = NonlinearShallowWater2D.from_nondimensional(
+            nx=16, ny=16, rossby=rossby, froude=float(froude)
+        )
+        assert float(by_froude.consts.gravity) == pytest.approx(
+            float(by_burger.consts.gravity), rel=1e-6
+        )
+
+    def test_supplying_both_burger_and_froude_is_rejected(self):
+        with pytest.raises(ValueError, match="exactly one of burger or froude"):
+            NonlinearShallowWater2D.from_nondimensional(
+                nx=16, ny=16, rossby=0.05, burger=1.0, froude=0.05
+            )
+
+    def test_supplying_neither_is_rejected(self):
+        with pytest.raises(ValueError, match="exactly one of burger or froude"):
+            NonlinearShallowWater2D.from_nondimensional(nx=16, ny=16, rossby=0.05)
+
+    @pytest.mark.parametrize(
+        ("kwargs", "message"),
+        [
+            ({"rossby": 0.0}, "rossby"),
+            ({"ekman": -1.0}, "ekman"),
+            ({"aspect": -1.0}, "aspect"),
+            ({"burger": 0.0}, "burger"),
+        ],
+    )
+    def test_rejects_out_of_range_inputs(self, kwargs, message):
+        base = {"nx": 16, "ny": 16, "rossby": 0.05, "burger": 1.0}
+        with pytest.raises(ValueError, match=message):
+            NonlinearShallowWater2D.from_nondimensional(**{**base, **kwargs})
+
+
+class TestMultilayerMapping:
+    @pytest.fixture
+    def built(self):
+        return MultilayerShallowWater2D.from_nondimensional(
+            nx=16,
+            ny=16,
+            rossby=0.05,
+            burger=[1.0, 0.1],
+            thickness_ratio=[1.0, 9.0],
+            ekman=1e-3,
+        )
+
+    def test_thickness_ratio_becomes_the_layer_depths(self, built):
+        model, _ = built
+        np.testing.assert_allclose(np.asarray(model.strat.H), [1.0, 9.0])
+
+    def test_burger_inverts_to_reduced_gravity(self, built):
+        """g'_k = Bu_k (f0 L)**2 / H_k, with f0 = L = 1."""
+        model, _ = built
+        np.testing.assert_allclose(
+            np.asarray(model.strat.g_prime), [1.0 / 1.0, 0.1 / 9.0], rtol=1e-6
+        )
+
+    def test_recovering_burger_from_the_model(self, built):
+        model, _ = built
+        g_prime = np.asarray(model.strat.g_prime)
+        H = np.asarray(model.strat.H)
+        f0 = float(model.consts.f0)
+        np.testing.assert_allclose(g_prime * H / f0**2, [1.0, 0.1], rtol=1e-6)
+
+    def test_mismatched_sequence_lengths_are_rejected(self):
+        with pytest.raises(ValueError, match="same length"):
+            MultilayerShallowWater2D.from_nondimensional(
+                nx=16, ny=16, rossby=0.05, burger=[1.0, 0.1], thickness_ratio=[1.0]
+            )
+
+    def test_non_positive_burger_is_rejected(self):
+        with pytest.raises(ValueError, match=r"burger\[1\]"):
+            MultilayerShallowWater2D.from_nondimensional(
+                nx=16,
+                ny=16,
+                rossby=0.05,
+                burger=[1.0, 0.0],
+                thickness_ratio=[1.0, 9.0],
+            )
+
+
+class TestBaroclinicQGMapping:
+    KW: ClassVar[dict] = {
+        "nx": 64,
+        "ny": 64,
+        "rossby": 0.02,
+        "beta_hat": 20.0,
+        "burger": [1.0, 0.02],
+        "thickness_ratio": [1.0, 4.0],
+        "delta_M": 0.06,
+    }
+
+    @pytest.fixture
+    def built(self):
+        return BaroclinicQG.from_nondimensional(**self.KW)
+
+    def test_rossby_sets_the_coriolis_parameter(self, built):
+        model, _ = built
+        assert float(model.consts.f0) == pytest.approx(1.0 / 0.02)
+
+    def test_delta_M_sets_the_viscosity(self, built):
+        model, _ = built
+        assert float(model.params.lateral_viscosity) == pytest.approx(
+            0.06**3 * 20.0, rel=1e-5
+        )
+
+    def test_wind_defaults_to_the_sverdrup_value(self, built):
+        model, _ = built
+        assert float(model.params.wind_amplitude) == pytest.approx(20.0)
+
+    def test_advective_unit_scales(self, built):
+        _, scales = built
+        assert scales.kind == "advective"
+        assert scales.T == 1.0
+        assert scales.rossby == pytest.approx(0.02)
+
+    def test_burger_inverts_with_the_model_f0(self, built):
+        model, _ = built
+        f0 = float(model.consts.f0)
+        g_prime = np.asarray(model.strat.g_prime)
+        H = np.asarray(model.strat.H)
+        np.testing.assert_allclose(g_prime * H / f0**2, [1.0, 0.02], rtol=1e-5)
+
+    def test_modal_radii_are_in_units_of_L(self, built):
+        """So they are directly comparable with dx, which is what the guard does."""
+        model, _ = built
+        radii = np.asarray(model.modal.rossby_radii)
+        internal = radii[np.isfinite(radii)]
+        assert internal.size == 1
+        assert 0.0 < internal[0] < 1.0
+
+    def test_modal_radius_is_not_the_interface_burger(self):
+        """The two conventions genuinely differ; the docs say so, so test it."""
+        model, _ = BaroclinicQG.from_nondimensional(**self.KW)
+        radii = np.asarray(model.modal.rossby_radii)
+        internal = float(radii[np.isfinite(radii)][0])
+        # sqrt of the second interface Burger number, the naive guess.
+        assert internal != pytest.approx(np.sqrt(0.02), rel=1e-2)
+
+    def test_modal_radius_is_near_the_rigid_lid_two_layer_formula(self):
+        """L_d**2 = g' H1 H2 / (f0**2 (H1 + H2)), up to the free surface.
+
+        The eigenproblem includes the free-surface mode through
+        ``g_prime[0]``, so the internal radius sits a few percent below
+        the rigid-lid value rather than on it.
+        """
+        model, _ = BaroclinicQG.from_nondimensional(**self.KW)
+        g_prime = np.asarray(model.strat.g_prime)
+        H = np.asarray(model.strat.H)
+        f0 = float(model.consts.f0)
+        rigid_lid = np.sqrt(g_prime[1] * H[0] * H[1] / (f0**2 * (H[0] + H[1])))
+        radii = np.asarray(model.modal.rossby_radii)
+        internal = float(radii[np.isfinite(radii)][0])
+        assert internal == pytest.approx(rigid_lid, rel=0.1)
+        assert internal < rigid_lid
+
+    def test_reparameterized_uses_the_same_mapping(self):
+        bc, _ = BaroclinicQG.from_nondimensional(**self.KW)
+        rp, _ = ReparameterizedQG.from_nondimensional(**self.KW)
+        np.testing.assert_allclose(
+            np.asarray(rp.strat.g_prime), np.asarray(bc.strat.g_prime), rtol=1e-6
+        )
+        assert float(rp.consts.f0) == pytest.approx(float(bc.consts.f0))
+
+
+class TestLayeredResolutionGuards:
+    def test_unresolved_deformation_radius_is_rejected(self):
+        """A tiny Burger number means the internal radius is sub-grid."""
+        with pytest.raises(
+            AssertionFailedError, match="deformation_radius check FAILED"
+        ):
+            BaroclinicQG.from_nondimensional(
+                nx=32,
+                ny=32,
+                rossby=0.02,
+                beta_hat=20.0,
+                burger=[1.0, 1e-6],
+                thickness_ratio=[1.0, 4.0],
+                delta_M=0.1,
+            )
+
+    def test_unresolved_munk_layer_is_rejected(self):
+        with pytest.raises(AssertionFailedError, match="munk_width check FAILED"):
+            BaroclinicQG.from_nondimensional(
+                nx=32,
+                ny=32,
+                rossby=0.02,
+                beta_hat=20.0,
+                burger=[1.0, 0.05],
+                thickness_ratio=[1.0, 4.0],
+                delta_M=0.005,
+            )
+
+    def test_check_resolution_false_skips_the_guards(self):
+        model, _ = BaroclinicQG.from_nondimensional(
+            nx=16,
+            ny=16,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=[1.0, 1e-6],
+            thickness_ratio=[1.0, 4.0],
+            delta_M=0.001,
+            check_resolution=False,
+        )
+        assert model is not None
+
+
+class TestShallowWaterDimensionalEquivalence:
+    """An inertial-set nondimensional run reproduces its dimensional twin.
+
+    With ``L``, ``f0``, ``H`` chosen and ``U = f0 L Ro``::
+
+        g    = Bu (f0 L)**2 / H       nu    = Ek_lat f0 L**2
+        beta = beta_hat f0 / L        kappa = Ek f0
+
+    and the model's own units are ``H`` for thickness and ``L f0`` for
+    velocity.
+
+    The regime is deliberately Ro = 0.2, Bu = 1: the Bernoulli term
+    carries ``g*h`` about its mean, so at small Rossby number the mean
+    thickness swamps the anomaly and float32 cancellation alone puts a
+    few times 1e-4 between two algebraically identical runs. At Ro = 0.2
+    the mean is only five times the anomaly and the comparison is clean.
+    Thickness error is measured against the anomaly for the same reason:
+    dividing by a mean of 500 would flatter any disagreement.
+    """
+
+    L = 1.0e6
+    F0 = 1.0e-4
+    H = 500.0
+    ROSSBY = 0.2
+    BURGER = 1.0
+    EKMAN_LATERAL = 2.0e-3
+    NX = NY = 24
+    T_ND = 1.0
+    N_STEPS = 80
+
+    def gravity(self):
+        return self.BURGER * (self.F0 * self.L) ** 2 / self.H
+
+    def dimensional(self):
+        return NonlinearShallowWater2D.create(
+            nx=self.NX,
+            ny=self.NY,
+            Lx=self.L,
+            Ly=self.L,
+            g=self.gravity(),
+            f0=self.F0,
+            H0=self.H,
+            lateral_viscosity=self.EKMAN_LATERAL * self.F0 * self.L**2,
+        )
+
+    def nondimensional(self):
+        return NonlinearShallowWater2D.from_nondimensional(
+            nx=self.NX,
+            ny=self.NY,
+            rossby=self.ROSSBY,
+            burger=self.BURGER,
+            ekman_lateral=self.EKMAN_LATERAL,
+        )
+
+    def dimensional_state(self, model, scales):
+        rng = np.random.RandomState(3)
+        shape = (model.grid.Ny, model.grid.Nx)
+        return NonlinearSW2DState(
+            h=jnp.asarray(self.H + 0.02 * scales.eta * rng.randn(*shape)),
+            u=jnp.asarray(0.02 * scales.U * rng.randn(*shape)),
+            v=jnp.asarray(0.02 * scales.U * rng.randn(*shape)),
+        )
+
+    def to_model_units(self, state):
+        """Dimensional state -> the nondimensional model's own units."""
+        velocity_unit = self.L * self.F0
+        return NonlinearSW2DState(
+            h=state.h / self.H,
+            u=state.u / velocity_unit,
+            v=state.v / velocity_unit,
+        )
+
+    def to_dimensional(self, state):
+        velocity_unit = self.L * self.F0
+        return NonlinearSW2DState(
+            h=state.h * self.H,
+            u=state.u * velocity_unit,
+            v=state.v * velocity_unit,
+        )
+
+    def scales(self):
+        return Scales.inertial(
+            L=self.L,
+            f0=self.F0,
+            H=self.H,
+            rossby=self.ROSSBY,
+            g=self.gravity(),
+        )
+
+    def test_model_units_match_the_scale_set(self):
+        """The unit conversion above is the one ``Scales`` describes."""
+        scales = self.scales()
+        assert pytest.approx(self.F0 * self.L * self.ROSSBY) == scales.U
+        assert pytest.approx(1.0 / self.F0) == scales.T
+
+    def test_tendencies_agree(self):
+        """The sharpest check: one RHS evaluation, no accumulation."""
+        dim = self.dimensional()
+        nd, _ = self.nondimensional()
+        state_dim = self.dimensional_state(dim, self.scales())
+        state_nd = self.to_model_units(state_dim)
+
+        acceleration_unit = self.L * self.F0 * self.F0
+        thickness_rate_unit = self.H * self.F0
+        got = nd.vector_field(0.0, state_nd)
+        expected = dim.vector_field(0.0, state_dim)
+        for field, unit in (
+            ("h", thickness_rate_unit),
+            ("u", acceleration_unit),
+            ("v", acceleration_unit),
+        ):
+            scaled = np.asarray(getattr(got, field)) * unit
+            assert relative_error(scaled, getattr(expected, field)) < 1e-4, field
+
+    def test_trajectories_agree_under_the_scales_mapping(self):
+        dim = self.dimensional()
+        nd, _ = self.nondimensional()
+        scales = self.scales()
+        state_dim = self.dimensional_state(dim, scales)
+        state_nd = self.to_model_units(state_dim)
+
+        sol_nd = nd.integrate(
+            state_nd, t0=0.0, t1=self.T_ND, dt=self.T_ND / self.N_STEPS
+        ).ys
+        sol_dim = dim.integrate(
+            state_dim,
+            t0=0.0,
+            t1=self.T_ND * scales.T,
+            dt=self.T_ND * scales.T / self.N_STEPS,
+        ).ys
+        recovered = self.to_dimensional(sol_nd)
+
+        # Thickness is compared against its anomaly about the mean.
+        anomaly = np.asarray(sol_dim.h) - self.H
+        assert (
+            np.abs(np.asarray(recovered.h) - np.asarray(sol_dim.h)).max()
+            / np.abs(anomaly).max()
+            < 1e-3
+        )
+        for field in ("u", "v"):
+            assert (
+                relative_error(getattr(recovered, field), getattr(sol_dim, field))
+                < 1e-3
+            ), field
+
+    def test_the_states_actually_evolve(self):
+        dim = self.dimensional()
+        scales = self.scales()
+        state = self.dimensional_state(dim, scales)
+        evolved = dim.integrate(
+            state,
+            t0=0.0,
+            t1=self.T_ND * scales.T,
+            dt=self.T_ND * scales.T / self.N_STEPS,
+        ).ys
+        change = np.abs(np.asarray(evolved.u) - np.asarray(state.u)).max()
+        assert change > 0.1 * np.abs(np.asarray(state.u)).max()
+
+
+class TestBaroclinicDimensionalEquivalence:
+    """An advective-set nondimensional QG run reproduces its dimensional twin."""
+
+    L = 1.0e6
+    U = 0.05
+    ROSSBY = 0.02
+    BETA_HAT = 15.0
+    BURGER = (1.0, 0.05)
+    THICKNESS = (1.0, 4.0)
+    DELTA_M = 0.08
+    NX = NY = 48
+
+    def dimensional(self):
+        f0 = self.U / (self.ROSSBY * self.L)
+        beta = self.BETA_HAT * self.U / self.L**2
+        H = tuple(h * 1000.0 for h in self.THICKNESS)
+        g_prime = tuple(
+            bu * (f0 * self.L) ** 2 / h for bu, h in zip(self.BURGER, H, strict=True)
+        )
+        return BaroclinicQG.create(
+            nx=self.NX,
+            ny=self.NY,
+            Lx=self.L,
+            Ly=self.L,
+            f0=f0,
+            beta=beta,
+            n_layers=2,
+            H=H,
+            g_prime=g_prime,
+            lateral_viscosity=self.DELTA_M**3 * self.L**3 * beta,
+            # tau_hat = tau0 L**2 / (U**2 H_1): the RHS divides by H[0].
+            wind_amplitude=self.BETA_HAT * self.U**2 * H[0] / self.L**2,
+        )
+
+    def nondimensional(self):
+        return BaroclinicQG.from_nondimensional(
+            nx=self.NX,
+            ny=self.NY,
+            rossby=self.ROSSBY,
+            beta_hat=self.BETA_HAT,
+            burger=list(self.BURGER),
+            thickness_ratio=list(self.THICKNESS),
+            delta_M=self.DELTA_M,
+        )
+
+    def test_burger_numbers_match_between_the_two(self):
+        dim = self.dimensional()
+        nd, _ = self.nondimensional()
+        for model in (dim, nd):
+            f0 = float(model.consts.f0)
+            g_prime = np.asarray(model.strat.g_prime)
+            H = np.asarray(model.strat.H)
+            L = model.grid.Lx
+            np.testing.assert_allclose(
+                g_prime * H / (f0 * L) ** 2, self.BURGER, rtol=1e-4
+            )
+
+    def test_modal_radii_match_after_rescaling(self):
+        dim = self.dimensional()
+        nd, _ = self.nondimensional()
+        dim_radii = np.asarray(dim.modal.rossby_radii) / self.L
+        nd_radii = np.asarray(nd.modal.rossby_radii)
+        finite = np.isfinite(dim_radii)
+        np.testing.assert_allclose(dim_radii[finite], nd_radii[finite], rtol=1e-3)
+
+    def test_trajectories_agree_under_the_scales_mapping(self):
+        dim = self.dimensional()
+        nd, _ = self.nondimensional()
+        scales = Scales.advective(L=self.L, U=self.U, f0=float(dim.consts.f0))
+        transform = StateAffine.from_scales(BaroclinicQGState, scales)
+
+        rng = np.random.RandomState(5)
+        field = rng.randn(2, dim.grid.Ny, dim.grid.Nx)
+        field -= field.mean(axis=(1, 2), keepdims=True)
+        state_dim = BaroclinicQGState(q=jnp.asarray(0.02 * scales.vorticity * field))
+        state_nd = transform.forward(state_dim)
+
+        t_nd, n = 0.3, 30
+        sol_nd = nd.integrate(state_nd, t0=0.0, t1=t_nd, dt=t_nd / n).ys
+        sol_dim = dim.integrate(
+            state_dim, t0=0.0, t1=t_nd * scales.T, dt=t_nd * scales.T / n
+        ).ys
+        assert relative_error(transform.inverse(sol_nd).q, sol_dim.q) < 5e-3
+
+    def test_the_states_actually_evolve(self):
+        dim = self.dimensional()
+        scales = Scales.advective(L=self.L, U=self.U, f0=float(dim.consts.f0))
+        rng = np.random.RandomState(5)
+        field = rng.randn(2, dim.grid.Ny, dim.grid.Nx)
+        field -= field.mean(axis=(1, 2), keepdims=True)
+        state = BaroclinicQGState(q=jnp.asarray(0.02 * scales.vorticity * field))
+        evolved = dim.integrate(
+            state, t0=0.0, t1=0.3 * scales.T, dt=0.3 * scales.T / 30
+        ).ys
+        change = np.abs(np.asarray(evolved.q) - np.asarray(state.q)).max()
+        assert change > 0.01 * np.abs(np.asarray(state.q)).max()
+
+
+class TestMultilayerStateTransform:
+    def test_per_layer_thickness_scales_broadcast(self):
+        """The (nl, 1, 1) override path, on a real multilayer state."""
+        model, scales = MultilayerShallowWater2D.from_nondimensional(
+            nx=12,
+            ny=12,
+            rossby=0.05,
+            burger=[1.0, 0.1],
+            thickness_ratio=[1.0, 9.0],
+        )
+        g_prime = jnp.asarray(model.strat.g_prime)[:, None, None]
+        H_k = jnp.asarray(model.strat.H)[:, None, None]
+        dH = scales.f0 * scales.U * scales.L / g_prime
+        transform = StateAffine.from_scales(
+            MultilayerSW2DState, scales, h={"loc": H_k, "scale": dH}
+        )
+        rng = np.random.RandomState(6)
+        shape = (2, model.grid.Ny, model.grid.Nx)
+        state = MultilayerSW2DState(
+            h=H_k + jnp.asarray(0.01 * rng.randn(*shape)),
+            u=jnp.asarray(0.01 * rng.randn(*shape)),
+            v=jnp.asarray(0.01 * rng.randn(*shape)),
+        )
+        assert transform.scale.h.shape == (2, 1, 1)
+        recovered = transform.inverse(transform.forward(state))
+        np.testing.assert_allclose(recovered.h, state.h, rtol=1e-5)

--- a/tests/test_layered_nondim.py
+++ b/tests/test_layered_nondim.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 
 from somax._src.cli._assertions import (
+    PREFLIGHT_ASSERTIONS,
     AssertionFailedError,
     check_deformation_radius,
 )
@@ -792,3 +793,111 @@ class TestDeformationRadiusUsesTheCoarserSpacing:
         with pytest.raises(AssertionFailedError) as excinfo:
             check_deformation_radius(None, model)
         assert f"{max(model.grid.dx, model.grid.dy):.4g}" in str(excinfo.value)
+
+
+class TestGuardsDoNotNeedTheCliExtras:
+    """A base install must reach the resolution guards.
+
+    The previous round moved the Munk and Stommel guards out of the
+    CLI package but left the factories importing them from
+    ``somax._src.cli._assertions``, which still pulls in ``loguru`` —
+    declared only in the optional ``sim`` group. The deformation-radius
+    guard was still defined there too.
+    """
+
+    def test_the_deformation_guard_lives_in_the_base_package(self):
+        from somax._src.core import resolution
+
+        assert (
+            resolution.check_deformation_radius.__module__
+            == "somax._src.core.resolution"
+        )
+
+    def test_the_cli_registry_uses_the_same_object(self):
+        from somax._src.core import resolution
+
+        assert (
+            PREFLIGHT_ASSERTIONS["deformation_radius"]
+            is resolution.check_deformation_radius
+        )
+
+    @pytest.mark.parametrize(
+        "factory",
+        ["BarotropicQG", "BaroclinicQG", "ReparameterizedQG"],
+    )
+    def test_the_factory_builds_without_loguru(self, factory):
+        import subprocess
+        import sys
+        import textwrap
+
+        layered = """burger=[1.0, 0.02], thickness_ratio=[1.0, 4.0], beta_hat=20.0"""
+        args = "beta_hat=50.0" if factory == "BarotropicQG" else layered
+        script = textwrap.dedent(f"""
+            import builtins
+            real = builtins.__import__
+            def guarded(name, *a, **k):
+                if name == "loguru":
+                    raise ModuleNotFoundError("No module named 'loguru'")
+                return real(name, *a, **k)
+            builtins.__import__ = guarded
+            from somax.models import {factory}
+            {factory}.from_nondimensional(
+                nx=128, ny=128, rossby=0.02, delta_M=0.06, {args}
+            )
+            print("ok")
+        """)
+        out = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True
+        )
+        assert out.stdout.strip() == "ok", out.stderr[-800:]
+
+
+class TestArrayBackedSequencesAreAccepted:
+    """``burger`` and ``thickness_ratio`` are sequences of numbers.
+
+    ``if not burger`` raises on a multi-element array — ambiguous truth
+    value — so array inputs were rejected before the conversion that
+    would have handled them.
+    """
+
+    def build(self, maker):
+        return BaroclinicQG.from_nondimensional(
+            nx=128,
+            ny=128,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=maker([1.0, 0.02]),
+            thickness_ratio=maker([1.0, 4.0]),
+            delta_M=0.06,
+        )
+
+    def test_a_numpy_array_works(self):
+        _, scales = self.build(np.asarray)
+        assert scales.burger == pytest.approx(1.0, rel=1e-6)
+
+    def test_a_jax_array_works(self):
+        _, scales = self.build(jnp.asarray)
+        assert scales.burger == pytest.approx(1.0, rel=1e-6)
+
+    def test_a_list_still_works(self):
+        _, scales = self.build(list)
+        assert scales.burger == pytest.approx(1.0, rel=1e-6)
+
+    def test_all_three_agree(self):
+        values = [
+            float(self.build(m)[1].burger) for m in (np.asarray, jnp.asarray, list)
+        ]
+        assert values[0] == pytest.approx(values[1]) == pytest.approx(values[2])
+
+    def test_an_empty_sequence_is_still_rejected(self):
+        for maker in (np.asarray, list):
+            with pytest.raises(ValueError, match="must not be empty"):
+                BaroclinicQG.from_nondimensional(
+                    nx=64,
+                    ny=64,
+                    rossby=0.02,
+                    beta_hat=20.0,
+                    burger=maker([]),
+                    thickness_ratio=maker([]),
+                    delta_M=0.06,
+                )

--- a/tests/test_layered_nondim.py
+++ b/tests/test_layered_nondim.py
@@ -15,7 +15,10 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from somax._src.cli._assertions import AssertionFailedError
+from somax._src.cli._assertions import (
+    AssertionFailedError,
+    check_deformation_radius,
+)
 from somax._src.core.scales import Scales
 from somax._src.core.transforms import StateAffine
 from somax._src.models.qg.baroclinic import BaroclinicQG, BaroclinicQGState
@@ -577,3 +580,215 @@ class TestMultilayerStateTransform:
         assert transform.scale.h.shape == (2, 1, 1)
         recovered = transform.inverse(transform.forward(state))
         np.testing.assert_allclose(recovered.h, state.h, rtol=1e-5)
+
+
+class TestReturnedScalesUseTheInterfaceGravity:
+    """``Scales.g`` must be ``g_prime[0]``, not standard gravity.
+
+    The scales describe the *nondimensional* model, whose surface-mode
+    gravity is the first reduced gravity. Left at 9.81 they disagree
+    with the Burger number that was asked for, and the thickness-anomaly
+    scale ``f0 U L / g`` comes out wrong by the ratio between them —
+    which can be orders of magnitude.
+    """
+
+    def build(self, cls, **kw):
+        return cls.from_nondimensional(
+            nx=64,
+            ny=64,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=[1.0, 0.02],
+            thickness_ratio=[1.0, 4.0],
+            delta_M=0.06,
+            **kw,
+        )
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_burger_round_trips(self, cls):
+        _, scales = self.build(cls)
+        assert scales.burger == pytest.approx(1.0, rel=1e-6)
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_gravity_is_the_first_reduced_gravity(self, cls):
+        model, scales = self.build(cls)
+        g_prime = float(np.asarray(model.strat.g_prime)[0])
+        assert scales.g == pytest.approx(g_prime, rel=1e-6)
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_gravity_is_not_standard_gravity(self, cls):
+        _, scales = self.build(cls)
+        assert scales.g != pytest.approx(9.81)
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_the_height_scale_follows(self, cls):
+        """``eta = f0 U L / g`` is what a StateAffine gives ``h``."""
+        _, scales = self.build(cls)
+        assert scales.eta == pytest.approx(scales.f0 / scales.g, rel=1e-6)
+
+    def test_a_different_burger_gives_a_different_gravity(self):
+        _, low = self.build(BaroclinicQG)
+        _, high = BaroclinicQG.from_nondimensional(
+            nx=64,
+            ny=64,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=[4.0, 0.02],
+            thickness_ratio=[1.0, 4.0],
+            delta_M=0.06,
+        )
+        assert high.g == pytest.approx(4.0 * low.g, rel=1e-6)
+
+
+class TestForwardedKwargsCannotOverrideDerivedValues:
+    """``**create_kw`` must not smuggle in a second stratification.
+
+    ``create`` prefers an explicit ``stratification`` over the ``H`` /
+    ``g_prime`` / ``n_layers`` the factory derived, while the returned
+    scales and the wind normalisation still describe the derived ones —
+    so the model and its scales would be different systems.
+    """
+
+    def base(self):
+        return dict(
+            nx=64,
+            ny=64,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=[1.0, 0.02],
+            thickness_ratio=[1.0, 4.0],
+            delta_M=0.06,
+        )
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    @pytest.mark.parametrize(
+        "name", ["stratification", "H", "g_prime", "n_layers", "f0", "beta"]
+    )
+    def test_a_derived_argument_is_rejected(self, cls, name):
+        with pytest.raises(ValueError, match="derived from the dimensionless"):
+            cls.from_nondimensional(**self.base(), **{name: None})
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_an_unrelated_argument_still_goes_through(self, cls):
+        model, _ = cls.from_nondimensional(**self.base(), wind_profile="single")
+        assert model is not None
+
+    def test_the_shallow_water_factory_guards_too(self):
+        with pytest.raises(ValueError, match="derived from the dimensionless"):
+            NonlinearShallowWater2D.from_nondimensional(
+                nx=32, ny=32, rossby=0.1, burger=1.0, g=9.81
+            )
+
+    def test_the_message_names_the_offending_argument(self):
+        with pytest.raises(ValueError, match=r"\['stratification'\]"):
+            BaroclinicQG.from_nondimensional(**self.base(), stratification=None)
+
+
+class TestExplicitWindAmplitudeIsValidated:
+    """Every other coefficient is checked; ``wind_hat`` was not.
+
+    A non-finite value went straight into ``wind_amplitude`` and made
+    the tendencies non-finite on the first step.
+    """
+
+    def base(self):
+        return dict(
+            nx=64,
+            ny=64,
+            rossby=0.02,
+            beta_hat=20.0,
+            burger=[1.0, 0.02],
+            thickness_ratio=[1.0, 4.0],
+            delta_M=0.06,
+        )
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), -1.0])
+    def test_a_bad_wind_hat_is_rejected(self, cls, bad):
+        with pytest.raises(ValueError, match="wind_hat"):
+            cls.from_nondimensional(**self.base(), wind_hat=bad)
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_zero_is_still_allowed(self, cls):
+        model, _ = cls.from_nondimensional(**self.base(), wind_hat=0.0)
+        assert float(np.asarray(model.params.wind_amplitude)) == 0.0
+
+    @pytest.mark.parametrize("cls", [BaroclinicQG, ReparameterizedQG])
+    def test_the_default_still_works(self, cls):
+        model, _ = cls.from_nondimensional(**self.base())
+        assert float(np.asarray(model.params.wind_amplitude)) > 0.0
+
+
+class TestMultilayerWindCarriesTheTopLayerThickness:
+    """The RHS divides by ``H[0]``, so the factory must multiply by it.
+
+    Otherwise the realised acceleration is ``wind_hat / H[0]`` whenever
+    ``thickness_ratio[0]`` is not 1 — silently not the wind that was
+    asked for.
+    """
+
+    def build(self, first_layer):
+        return MultilayerShallowWater2D.from_nondimensional(
+            nx=32,
+            ny=32,
+            rossby=0.1,
+            burger=[1.0, 0.05],
+            thickness_ratio=[first_layer, 4.0],
+            wind_hat=0.5,
+        )
+
+    def realised(self, model):
+        """The acceleration the RHS actually applies to the top layer."""
+        tau0 = float(np.asarray(model.params.wind_amplitude))
+        return tau0 / float(np.asarray(model.strat.H)[0])
+
+    def test_the_requested_wind_is_what_the_rhs_applies(self):
+        model, scales = self.build(first_layer=2.0)
+        assert self.realised(model) == pytest.approx(0.5 * scales.U, rel=1e-6)
+
+    def test_a_unit_top_layer_is_unchanged(self):
+        """The case that used to work, so the fix is not a regression."""
+        model, scales = self.build(first_layer=1.0)
+        assert self.realised(model) == pytest.approx(0.5 * scales.U, rel=1e-6)
+
+    def test_the_thickness_actually_varies_the_amplitude(self):
+        thin, _ = self.build(first_layer=1.0)
+        thick, _ = self.build(first_layer=2.0)
+        assert float(np.asarray(thick.params.wind_amplitude)) == pytest.approx(
+            2.0 * float(np.asarray(thin.params.wind_amplitude)), rel=1e-6
+        )
+
+
+class TestDeformationRadiusUsesTheCoarserSpacing:
+    """A deformation radius is isotropic, so both directions must span it.
+
+    Taking the finer spacing passes a grid that resolves it along one
+    axis only.
+    """
+
+    def model(self, nx, ny):
+        return BaroclinicQG.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=1.0,
+            f0=50.0,
+            beta=20.0,
+            n_layers=2,
+            H=(1.0, 4.0),
+            g_prime=(2500.0, 50.0),
+        )
+
+    def test_an_anisotropic_grid_no_longer_passes(self):
+        with pytest.raises(AssertionFailedError, match="L_d/dx"):
+            check_deformation_radius(None, self.model(nx=4, ny=256))
+
+    def test_the_isotropic_grid_at_the_finer_spacing_passes(self):
+        """So the failure above is about the coarse axis, not the model."""
+        check_deformation_radius(None, self.model(nx=256, ny=256))
+
+    def test_the_reported_spacing_is_the_coarser_one(self):
+        model = self.model(nx=4, ny=256)
+        with pytest.raises(AssertionFailedError) as excinfo:
+            check_deformation_radius(None, model)
+        assert f"{max(model.grid.dx, model.grid.dy):.4g}" in str(excinfo.value)


### PR DESCRIPTION
Closes #174. Stacked on #183 (epic #170).

## What this adds

Extends the factory pattern to `NonlinearShallowWater2D` and `MultilayerShallowWater2D` on the **inertial** scale set, and to `BaroclinicQG` and `ReparameterizedQG` on the **advective** one.

Shallow water takes `Ro` with either `Bu` or `Fr`, plus Ekman numbers for drag and viscosity. The QG models add `delta_M` / `delta_S` from #182 plus stratification.

## Decisions worth review

**`burger` and `froude` are mutually exclusive.** They are not independent once `Ro` is fixed (`Bu = (Ro/Fr)**2`), so accepting both would let a caller state an inconsistent pair.

**Stratification is one Burger number *per interface*, not per mode.** This is a deviation from the issue's wording and the reason is in `somax/_src/models/_nondim.py`: a mode's deformation radius combines the interface values (for two layers, `L_d**2 = g' H_1 H_2 / (f0**2 (H_1+H_2))`), so prescribing the radii directly would mean inverting the eigenproblem. The interface convention inverts one-to-one. The built model reports the resulting radii in units of `L` for the `deformation_radius` guard to read, and a test pins that the two conventions genuinely differ.

**The inertial set leaves the model's own velocities at `O(Ro)`, not `O(1)`,** since it puts `L`, `f0` and `H` at unity. The returned `Scales` is what makes them `O(1)` through a `ScaledModel`. Documented on the factory, because it surprises.

**The wind kwarg carries the top-layer thickness,** because the layered QG RHS applies wind as `tau0 * F / H[0]`; the dimensionless group is `tau_hat = tau0 L**2 / (U**2 H_1)`. This was found by the equivalence test failing at exactly a factor of `H_1`.

## Also here

`check_deformation_radius` printed `L_d=0 m, dx=0 m` for a nondimensional model whose lengths are below 1 — actively misleading now that such models are first class. Two format specifiers widened.

## Testing note worth reading

The shallow-water equivalence test runs at `Ro = 0.2` rather than a more typical `0.02`, and measures thickness against its **anomaly**. The Bernoulli term carries `g*h` about its mean, so at small `Ro` the mean swamps the anomaly and float32 cancellation alone separates two algebraically identical runs by a few times `1e-4`. A tendency-level test pins the mapping at `1e-4` with no accumulation; the trajectory test then holds to `1e-3` over a full inertial period. Both are documented in the test docstring.

40 new tests. Full suite 961 → 1001 passing; lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg)_