### PR TITLE
feat(models): from_nondimensional for pde1d and pde2d

### DIFF
--- a/somax/_src/core/scales.py
+++ b/somax/_src/core/scales.py
@@ -285,13 +285,17 @@ class Scales(eqx.Module):
         and the bound accounts for all of them. A single ``int`` is the
         1-D case.
 
-        The advective bound is :math:`C \min_i \Delta x_i / \hat u`
-        and the diffusive one
-        :math:`C / (2 \hat\kappa \sum_i \Delta x_i^{-2})`, both in
-        nondimensional units, where
-        :math:`\hat u = U T / L` is the nondimensional velocity and
-        :math:`\hat\kappa = \kappa T / L^2` the nondimensional
-        diffusivity.
+        The advective bound is
+        :math:`C / (\hat u \sum_i |c_i| / \Delta x_i)` for a known unit
+        direction :math:`c`, and
+        :math:`C / (\hat u \sqrt{\sum_i \Delta x_i^{-2}})` without one
+        — the worst case over every direction of that speed, since
+        Cauchy-Schwarz maximises the directional sum there. The
+        diffusive bound is
+        :math:`C / (2 \hat\kappa \sum_i \Delta x_i^{-2})`. Both are in
+        nondimensional units, where :math:`\hat u = U T / L` is the
+        nondimensional velocity and :math:`\hat\kappa = \kappa T / L^2`
+        the nondimensional diffusivity.
 
         Args:
             cfl: Target Courant number.

--- a/somax/_src/core/scales.py
+++ b/somax/_src/core/scales.py
@@ -25,6 +25,7 @@ and read it back off :attr:`Scales.kind`.
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import Literal
 
 import equinox as eqx
@@ -201,9 +202,10 @@ class Scales(eqx.Module):
             A ``Scales`` with ``kind="diffusive"``.
 
         Raises:
-            ValueError: If ``L`` or ``kappa`` is not strictly positive.
+            ValueError: If ``L``, ``kappa`` or ``g`` is not strictly
+                positive.
         """
-        _require_positive(L=L, kappa=kappa)
+        _require_positive(L=L, kappa=kappa, g=g)
         return cls(
             L=L,
             U=kappa / L,
@@ -270,39 +272,103 @@ class Scales(eqx.Module):
     def dt_from_cfl(
         self,
         cfl: float,
-        n_cells: int,
+        n_cells: int | Sequence[int],
         *,
         mode: str | None = None,
+        diffusivity: float | None = None,
+        extent: float | Sequence[float] | None = None,
     ) -> float:
-        """Largest time step meeting a CFL target, in this set's time unit.
+        r"""Largest time step meeting a CFL target, in this set's time unit.
+
+        Multi-dimensional by construction: pass one cell count per axis
+        and the bound accounts for all of them. A single ``int`` is the
+        1-D case.
+
+        The advective bound is :math:`C \min_i \Delta x_i / \hat u`
+        and the diffusive one
+        :math:`C / (2 \hat\kappa \sum_i \Delta x_i^{-2})`, both in
+        nondimensional units, where
+        :math:`\hat u = U T / L` is the nondimensional velocity and
+        :math:`\hat\kappa = \kappa T / L^2` the nondimensional
+        diffusivity.
 
         Args:
             cfl: Target Courant number.
-            n_cells: Interior cells across ``L``, so ``dx = L/n_cells``.
-            mode: ``"advective"`` for ``dt <= C dx / U``, ``"diffusive"``
-                for ``dt <= C dx**2 / (2 kappa)``. Defaults to the
+            n_cells: Interior cells across each axis. An ``int`` means
+                one axis; a sequence gives one count per axis.
+            mode: ``"advective"`` or ``"diffusive"``. Defaults to the
                 diffusive form for a diffusive scale set and the
                 advective form otherwise.
+            diffusivity: Nondimensional diffusivity :math:`\kappa T/L^2`
+                for the diffusive bound. For the models whose factories
+                take a Reynolds or Péclet number this is ``1/Re`` or
+                ``1/Pe`` — the value the model actually carries, which
+                the scale set cannot know. Defaults to 1 for a
+                diffusive scale set, where the scaling makes it exactly
+                1 by construction; required otherwise.
+            extent: Domain length along each axis in units of ``L``.
+                Defaults to 1 per axis; pass ``(1.0, aspect)`` for a
+                rectangular 2-D domain, whose ``y`` spacing is
+                ``aspect/ny`` rather than ``1/ny``.
 
         Returns:
             The time step, expressed in units of :attr:`T` — the unit a
             nondimensional model built from these scales expects.
 
         Raises:
-            ValueError: If ``cfl`` or ``n_cells`` is not positive, or
-                ``mode`` is unrecognised.
+            ValueError: If ``cfl``, a cell count or an extent is not
+                positive, if ``mode`` is unrecognised, if ``extent``
+                and ``n_cells`` disagree in length, or if the diffusive
+                bound is asked for without a diffusivity on a
+                non-diffusive set.
         """
-        _require_positive(cfl=cfl, n_cells=float(n_cells))
+        _require_positive(cfl=cfl)
+        counts = (n_cells,) if isinstance(n_cells, int) else tuple(n_cells)
+        if not counts:
+            raise ValueError("dt_from_cfl: n_cells must name at least one axis.")
+        for axis, count in enumerate(counts):
+            _require_positive(**{f"n_cells[{axis}]": float(count)})
+
+        if extent is None:
+            extents = (1.0,) * len(counts)
+        else:
+            extents = (
+                (float(extent),)
+                if isinstance(extent, (int, float))
+                else tuple(float(e) for e in extent)
+            )
+        if len(extents) != len(counts):
+            raise ValueError(
+                f"dt_from_cfl: extent names {len(extents)} axes but n_cells "
+                f"names {len(counts)}."
+            )
+        for axis, value in enumerate(extents):
+            _require_positive(**{f"extent[{axis}]": value})
+
+        spacings = tuple(e / c for e, c in zip(extents, counts, strict=True))
+
         if mode is None:
             mode = "diffusive" if self.kind == "diffusive" else "advective"
-        dx = 1.0 / n_cells  # in units of L
+
         if mode == "advective":
-            # dt <= C dx/U; in units of T = L/U for the advective set the
-            # velocity is 1, so this is C * dx scaled by T/(L/U).
-            return cfl * dx * (self.T / (self.L / self.U))
+            # u_hat = U T / L: the speed the nondimensional model
+            # actually carries. Dividing by it — the advective set is
+            # the only one where it is 1.
+            velocity = self.U * self.T / self.L
+            return cfl * min(spacings) / velocity
         if mode == "diffusive":
-            kappa = self.L * self.U  # the diffusivity implied by the set
-            return cfl * dx**2 / 2.0 * (self.T * kappa / self.L**2)
+            if diffusivity is None:
+                if self.kind != "diffusive":
+                    raise ValueError(
+                        "dt_from_cfl: the diffusive bound needs the model's "
+                        "nondimensional diffusivity (1/Re for the Burgers and "
+                        "Navier-Stokes factories, 1/Pe where a Peclet number "
+                        "is used). Only a diffusive scale set fixes it at 1."
+                    )
+                diffusivity = 1.0
+            _require_positive(diffusivity=diffusivity)
+            inverse_squares = sum(1.0 / spacing**2 for spacing in spacings)
+            return cfl / (2.0 * diffusivity * inverse_squares)
         raise ValueError(
             f"dt_from_cfl: mode must be 'advective' or 'diffusive'; got {mode!r}."
         )

--- a/somax/_src/core/scales.py
+++ b/somax/_src/core/scales.py
@@ -15,9 +15,11 @@ constant and dimensionless groups can be used in Python control flow
 There is no universal scale set. The characteristic time in particular
 is *part of* the choice, not something derivable from ``L`` and ``U``:
 quasi-geostrophic models are advective (``T = L/U``), shallow-water
-models are inertial (``T = 1/f0``), and spherical models are planetary
-(``T = 1/Omega``). Pick the set that matches the equation family with
-the corresponding classmethod, and read it back off :attr:`Scales.kind`.
+models are inertial (``T = 1/f0``), spherical models are planetary
+(``T = 1/Omega``), and a pure diffusion problem has no velocity scale at
+all, so its time scale is diffusive (``T = L**2/kappa``). Pick the set
+that matches the equation family with the corresponding classmethod,
+and read it back off :attr:`Scales.kind`.
 """
 
 from __future__ import annotations
@@ -28,7 +30,7 @@ from typing import Literal
 import equinox as eqx
 
 
-ScaleKind = Literal["advective", "inertial", "planetary"]
+ScaleKind = Literal["advective", "inertial", "planetary", "diffusive"]
 
 #: Standard gravity (m/s^2), the default for the ``g`` field.
 GRAVITY = 9.81
@@ -171,6 +173,46 @@ class Scales(eqx.Module):
             kind="planetary",
         )
 
+    @classmethod
+    def diffusive(
+        cls,
+        L: float,
+        kappa: float,
+        g: float = GRAVITY,
+    ) -> Scales:
+        """Diffusive set: ``T = L**2 / kappa``.
+
+        The set for a pure diffusion problem, which has no velocity to
+        build a time scale from. The implied velocity ``U = L/T =
+        kappa/L`` is recorded so the derived properties stay
+        well-defined, but it is a bookkeeping quantity rather than a
+        physical flow speed.
+
+        Under this scaling the nondimensional diffusivity is exactly 1,
+        so a diffusion model has no free dimensionless number left.
+
+        Args:
+            L: Horizontal length scale [m].
+            kappa: Diffusivity [m^2/s].
+            g: Gravitational acceleration [m/s^2].
+
+        Returns:
+            A ``Scales`` with ``kind="diffusive"``.
+
+        Raises:
+            ValueError: If ``L`` or ``kappa`` is not strictly positive.
+        """
+        _require_positive(L=L, kappa=kappa)
+        return cls(
+            L=L,
+            U=kappa / L,
+            H=1.0,
+            f0=1.0,
+            T=L**2 / kappa,
+            g=g,
+            kind="diffusive",
+        )
+
     # ------------------------------------------------------------------
     # Derived dimensionless groups
     # ------------------------------------------------------------------
@@ -224,6 +266,46 @@ class Scales(eqx.Module):
         """Planet angular velocity ``f0 / 2`` [rad/s]."""
         return self.f0 / 2.0
 
+    def dt_from_cfl(
+        self,
+        cfl: float,
+        n_cells: int,
+        *,
+        mode: str | None = None,
+    ) -> float:
+        """Largest time step meeting a CFL target, in this set's time unit.
+
+        Args:
+            cfl: Target Courant number.
+            n_cells: Interior cells across ``L``, so ``dx = L/n_cells``.
+            mode: ``"advective"`` for ``dt <= C dx / U``, ``"diffusive"``
+                for ``dt <= C dx**2 / (2 kappa)``. Defaults to the
+                diffusive form for a diffusive scale set and the
+                advective form otherwise.
+
+        Returns:
+            The time step, expressed in units of :attr:`T` — the unit a
+            nondimensional model built from these scales expects.
+
+        Raises:
+            ValueError: If ``cfl`` or ``n_cells`` is not positive, or
+                ``mode`` is unrecognised.
+        """
+        _require_positive(cfl=cfl, n_cells=float(n_cells))
+        if mode is None:
+            mode = "diffusive" if self.kind == "diffusive" else "advective"
+        dx = 1.0 / n_cells  # in units of L
+        if mode == "advective":
+            # dt <= C dx/U; in units of T = L/U for the advective set the
+            # velocity is 1, so this is C * dx scaled by T/(L/U).
+            return cfl * dx * (self.T / (self.L / self.U))
+        if mode == "diffusive":
+            kappa = self.L * self.U  # the diffusivity implied by the set
+            return cfl * dx**2 / 2.0 * (self.T * kappa / self.L**2)
+        raise ValueError(
+            f"dt_from_cfl: mode must be 'advective' or 'diffusive'; got {mode!r}."
+        )
+
     def nondimensional(self) -> Scales:
         """The unit scale set of the same family.
 
@@ -240,6 +322,8 @@ class Scales(eqx.Module):
             return Scales.advective(L=1.0, U=1.0, f0=1.0 / self.rossby, H=1.0, g=self.g)
         if self.kind == "inertial":
             return Scales.inertial(L=1.0, f0=1.0, H=1.0, rossby=self.rossby, g=self.g)
+        if self.kind == "diffusive":
+            return Scales.diffusive(L=1.0, kappa=1.0, g=self.g)
         return Scales.planetary(a=1.0, Omega=1.0, H=1.0, rossby=self.rossby, g=self.g)
 
 

--- a/somax/_src/core/scales.py
+++ b/somax/_src/core/scales.py
@@ -277,6 +277,7 @@ class Scales(eqx.Module):
         mode: str | None = None,
         diffusivity: float | None = None,
         extent: float | Sequence[float] | None = None,
+        direction: Sequence[float] | None = None,
     ) -> float:
         r"""Largest time step meeting a CFL target, in this set's time unit.
 
@@ -310,6 +311,14 @@ class Scales(eqx.Module):
                 Defaults to 1 per axis; pass ``(1.0, aspect)`` for a
                 rectangular 2-D domain, whose ``y`` spacing is
                 ``aspect/ny`` rather than ``1/ny``.
+            direction: Advection direction, one component per axis, for
+                the advective bound. Given, the bound is exact:
+                ``C / sum_i |c_i|/dx_i``. Omitted, the worst case over
+                all directions of the same speed is used, which is
+                never larger than the requested Courant number but can
+                be up to ``sqrt(ndim)`` smaller than a direction-aware
+                step. Ignored by the diffusive bound, which is
+                isotropic.
 
         Returns:
             The time step, expressed in units of :attr:`T` — the unit a
@@ -352,10 +361,33 @@ class Scales(eqx.Module):
 
         if mode == "advective":
             # u_hat = U T / L: the speed the nondimensional model
-            # actually carries. Dividing by it — the advective set is
-            # the only one where it is 1.
+            # actually carries. The advective set is the only one where
+            # it is 1.
             velocity = self.U * self.T / self.L
-            return cfl * min(spacings) / velocity
+            if direction is None:
+                # Worst case over every direction of that speed. The
+                # Courant number is ``dt * sum_i |c_i| / dx_i``, and for
+                # a fixed magnitude Cauchy-Schwarz maximises that sum at
+                # ``|c| * sqrt(sum_i dx_i**-2)`` — reached when the
+                # velocity leans towards the finer axes. Using
+                # ``min(dx)`` instead assumes all the speed lies on one
+                # axis, which understates the sum by up to sqrt(ndim):
+                # the default diagonal 2-D convection direction really
+                # does exceed it by sqrt(2).
+                courant_per_unit_time = math.sqrt(
+                    sum(1.0 / spacing**2 for spacing in spacings)
+                )
+            else:
+                components = _unit_components(direction, len(spacings))
+                courant_per_unit_time = sum(
+                    abs(component) / spacing
+                    for component, spacing in zip(components, spacings, strict=True)
+                )
+                if courant_per_unit_time == 0.0:
+                    raise ValueError(
+                        "dt_from_cfl: direction must not be the zero vector."
+                    )
+            return cfl / (velocity * courant_per_unit_time)
         if mode == "diffusive":
             if diffusivity is None:
                 if self.kind != "diffusive":
@@ -408,6 +440,39 @@ class Scales(eqx.Module):
         return Scales.planetary(
             a=1.0, Omega=1.0, H=1.0, rossby=self.rossby, g=4.0 * burger
         )
+
+
+def _unit_components(direction: Sequence[float], n_axes: int) -> tuple[float, ...]:
+    """Normalise an advection direction to unit speed, one per axis.
+
+    Args:
+        direction: One component per axis.
+        n_axes: How many axes the cell counts described.
+
+    Returns:
+        The components scaled to unit magnitude.
+
+    Raises:
+        ValueError: If the length disagrees with ``n_axes``, a
+            component is not finite, or the vector is zero.
+    """
+    components = tuple(float(c) for c in direction)
+    if len(components) != n_axes:
+        raise ValueError(
+            f"dt_from_cfl: direction names {len(components)} axes but "
+            f"n_cells names {n_axes}."
+        )
+    if not all(math.isfinite(c) for c in components):
+        raise ValueError(
+            f"dt_from_cfl: direction components must be finite; got {direction!r}."
+        )
+    speed = math.sqrt(sum(c * c for c in components))
+    if speed == 0.0:
+        raise ValueError(
+            "dt_from_cfl: direction must not be the zero vector — there is no "
+            "direction to normalise."
+        )
+    return tuple(c / speed for c in components)
 
 
 def _require_positive(**values: float) -> None:

--- a/somax/_src/models/pde1d/burgers.py
+++ b/somax/_src/models/pde1d/burgers.py
@@ -122,8 +122,10 @@ class Burgers1D(SomaxModel):
                 ``method``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
-            to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, nx)`` gives a
+            step in the same time unit; for the diffusive bound pass
+            ``mode="diffusive", diffusivity=1/reynolds``, since the
+            scale set cannot know the model's Reynolds number.
 
         Raises:
             ValueError: If an input is not positive.

--- a/somax/_src/models/pde1d/burgers.py
+++ b/somax/_src/models/pde1d/burgers.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import Advection1D, CartesianGrid1D, Difference1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
+from somax._src.models._nondim import require_positive
 
 
 class Burgers1DParams(Params):
@@ -89,6 +93,47 @@ class Burgers1D(SomaxModel):
         """Compute energy diagnostic."""
         energy = 0.5 * jnp.sum(state.u[1:-1] ** 2) * self.grid.dx
         return Burgers1DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 100,
+        reynolds: float,
+        **create_kw: Any,
+    ) -> tuple[Burgers1D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = U = 1``, so ``T = L/U = 1`` and the equation reads
+        ``d_t u + u . grad u = Re**-1 laplacian(u)``. The Reynolds
+        number is the only free number: ``nu = 1/Re``.
+
+
+        Args:
+            nx: Interior grid cells.
+            reynolds: Reynolds number ``Re = U L / nu``; sets
+                ``nu = 1/Re``.
+            **create_kw: Forwarded to :meth:`create` (``periodic``,
+                ``method``, ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
+            to pick a step size in the same time unit.
+
+        Raises:
+            ValueError: If an input is not positive.
+        """
+        context = "Burgers1D.from_nondimensional"
+        require_positive(context, reynolds=reynolds)
+        model = Burgers1D.create(
+            nx=nx,
+            Lx=1.0,
+            nu=1.0 / reynolds,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde1d/diffusion.py
+++ b/somax/_src/models/pde1d/diffusion.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import CartesianGrid1D, Difference1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
 
 
@@ -84,6 +87,41 @@ class Diffusion1D(SomaxModel):
         """Compute energy diagnostic."""
         energy = 0.5 * jnp.sum(state.u[1:-1] ** 2) * self.grid.dx
         return Diffusion1DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 100,
+        **create_kw: Any,
+    ) -> tuple[Diffusion1D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Diffusive scale set (:meth:`somax.Scales.diffusive`) with
+        ``L = kappa = 1``, so ``T = L**2/kappa = 1`` and the equation
+        reads ``d_t u = laplacian(u)``. Pure diffusion has no velocity
+        scale, so this scaling leaves no free dimensionless number:
+        every diffusion problem is the same problem once rescaled, and
+        only the grid and the initial condition remain to be chosen.
+
+
+        Args:
+            nx: Interior grid cells.
+            **create_kw: Forwarded to :meth:`create` (``periodic``,
+                ``method``, ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
+            to pick a step size in the same time unit.
+        """
+        model = Diffusion1D.create(
+            nx=nx,
+            Lx=1.0,
+            nu=1.0,
+            **create_kw,
+        )
+        return model, Scales.diffusive(L=1.0, kappa=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde1d/diffusion.py
+++ b/somax/_src/models/pde1d/diffusion.py
@@ -111,12 +111,11 @@ class Diffusion1D(SomaxModel):
 
         Args:
             nx: Interior grid cells.
-            **create_kw: Forwarded to :meth:`create` (``periodic``,
-                ``method``, ``mask``).
+            **create_kw: Forwarded to :meth:`create` (``periodic``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
-            to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, nx)`` gives a
+            step in the same time unit.
         """
         model = Diffusion1D.create(
             nx=nx,

--- a/somax/_src/models/pde1d/linear_convection.py
+++ b/somax/_src/models/pde1d/linear_convection.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import CartesianGrid1D, Difference1D, Interpolation1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
 
 
@@ -90,6 +93,41 @@ class LinearConvection1D(SomaxModel):
         """Compute energy diagnostic."""
         energy = 0.5 * jnp.sum(state.u[1:-1] ** 2) * self.grid.dx
         return LinearConvection1DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 100,
+        **create_kw: Any,
+    ) -> tuple[LinearConvection1D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = 1`` and the wave speed as the velocity scale, so ``T = 1``
+        and the equation reads ``d_t u + grad u = 0``. Scaling out the
+        speed leaves no free dimensionless number; the Courant number
+        is a time-step choice, not a property of the problem, so use
+        ``scales.dt_from_cfl``.
+
+
+        Args:
+            nx: Interior grid cells.
+            **create_kw: Forwarded to :meth:`create` (``periodic``,
+                ``method``, ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
+            to pick a step size in the same time unit.
+        """
+        model = LinearConvection1D.create(
+            nx=nx,
+            Lx=1.0,
+            c=1.0,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde1d/linear_convection.py
+++ b/somax/_src/models/pde1d/linear_convection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, ClassVar
 
 import equinox as eqx
@@ -101,6 +102,7 @@ class LinearConvection1D(SomaxModel):
     def from_nondimensional(
         *,
         nx: int = 100,
+        direction: float = 1.0,
         **create_kw: Any,
     ) -> tuple[LinearConvection1D, Scales]:
         r"""Build the model at unit scales instead of SI coefficients.
@@ -109,25 +111,38 @@ class LinearConvection1D(SomaxModel):
         --------------------
         Advective scale set (:meth:`somax.Scales.advective`) with
         ``L = 1`` and the wave speed as the velocity scale, so ``T = 1``
-        and the equation reads ``d_t u + grad u = 0``. Scaling out the
-        speed leaves no free dimensionless number; the Courant number
-        is a time-step choice, not a property of the problem, so use
-        ``scales.dt_from_cfl``.
+        and the equation reads ``d_t u + c d_x u = 0`` with ``|c| = 1``.
+
+        Scaling out the *speed* leaves no free dimensionless number,
+        but it does not remove the sign: left-going and right-going
+        propagation are different problems, and only the magnitude is
+        a unit choice. The Courant number is a time-step choice rather
+        than a property of the problem, so use ``scales.dt_from_cfl``.
 
 
         Args:
             nx: Interior grid cells.
+            direction: Propagation direction; normalised to unit speed,
+                so any positive value means rightward and any negative
+                value leftward.
             **create_kw: Forwarded to :meth:`create` (``periodic``,
-                ``method``, ``mask``).
+                ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
-            to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, nx)`` gives a
+            step in the same time unit.
         """
+        context = "LinearConvection1D.from_nondimensional"
+        if not math.isfinite(direction) or direction == 0.0:
+            raise ValueError(
+                f"{context}: direction must be a finite non-zero number; got "
+                f"{direction!r}. Zero has no direction to normalise, and the "
+                f"equation would be trivial."
+            )
         model = LinearConvection1D.create(
             nx=nx,
             Lx=1.0,
-            c=1.0,
+            c=math.copysign(1.0, direction),
             **create_kw,
         )
         return model, Scales.advective(L=1.0, U=1.0)

--- a/somax/_src/models/pde1d/nonlinear_convection.py
+++ b/somax/_src/models/pde1d/nonlinear_convection.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import Advection1D, CartesianGrid1D, Mask1D
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, State
 
 
@@ -72,6 +75,40 @@ class NonlinearConvection1D(SomaxModel):
         """Compute energy diagnostic."""
         energy = 0.5 * jnp.sum(state.u[1:-1] ** 2) * self.grid.dx
         return NonlinearConvection1DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 100,
+        **create_kw: Any,
+    ) -> tuple[NonlinearConvection1D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = U = 1``, so ``T = 1`` and the equation reads
+        ``d_t u + u . grad u = 0``. Inviscid nonlinear convection has no
+        coefficient to scale out, so this factory only fixes the domain
+        and reports the scale set; it exists so the family presents one
+        interface.
+
+
+        Args:
+            nx: Interior grid cells.
+            **create_kw: Forwarded to :meth:`create` (``periodic``,
+                ``method``, ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
+            to pick a step size in the same time unit.
+        """
+        model = NonlinearConvection1D.create(
+            nx=nx,
+            Lx=1.0,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde1d/nonlinear_convection.py
+++ b/somax/_src/models/pde1d/nonlinear_convection.py
@@ -103,8 +103,8 @@ class NonlinearConvection1D(SomaxModel):
                 ``method``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with ``nx``
-            to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, nx)`` gives a
+            step in the same time unit.
         """
         model = NonlinearConvection1D.create(
             nx=nx,

--- a/somax/_src/models/pde2d/burgers.py
+++ b/somax/_src/models/pde2d/burgers.py
@@ -136,12 +136,15 @@ class Burgers2D(SomaxModel):
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
             reynolds: Reynolds number ``Re = U L / nu``; sets
                 ``nu = 1/Re``.
-            **create_kw: Forwarded to :meth:`create` (``method``,
-                ``mask``).
+            **create_kw: Forwarded to :meth:`create` (``method``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
-            cell count to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
+            extent=(1.0, aspect))`` gives a step in the same time unit;
+            pass both cell counts and the aspect ratio, since the bound
+            depends on the *smaller* spacing. For the diffusive bound
+            add ``mode="diffusive", diffusivity=1/reynolds`` — the
+            scale set cannot know the model's Reynolds number.
 
         Raises:
             ValueError: If an input is not positive.

--- a/somax/_src/models/pde2d/burgers.py
+++ b/somax/_src/models/pde2d/burgers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -15,7 +17,9 @@ from finitevolx import (
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
+from somax._src.models._nondim import require_positive
 
 
 class Burgers2DParams(Params):
@@ -103,6 +107,54 @@ class Burgers2D(SomaxModel):
         ui, vi = state.u[1:-1, 1:-1], state.v[1:-1, 1:-1]
         ke = 0.5 * jnp.sum(ui**2 + vi**2) * self.grid.dx * self.grid.dy
         return Burgers2DDiagnostics(kinetic_energy=ke)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        aspect: float = 1.0,
+        reynolds: float,
+        **create_kw: Any,
+    ) -> tuple[Burgers2D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = U = 1``, so ``T = L/U = 1`` and the equation reads
+        ``d_t u + u . grad u = Re**-1 laplacian(u)``. The Reynolds
+        number is the only free number: ``nu = 1/Re``.
+
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            reynolds: Reynolds number ``Re = U L / nu``; sets
+                ``nu = 1/Re``.
+            **create_kw: Forwarded to :meth:`create` (``method``,
+                ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
+            cell count to pick a step size in the same time unit.
+
+        Raises:
+            ValueError: If an input is not positive.
+        """
+        context = "Burgers2D.from_nondimensional"
+        require_positive(context, aspect=aspect)
+        require_positive(context, reynolds=reynolds)
+        model = Burgers2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            nu=1.0 / reynolds,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde2d/diffusion.py
+++ b/somax/_src/models/pde2d/diffusion.py
@@ -106,12 +106,13 @@ class Diffusion2D(SomaxModel):
             nx: Interior cells in x.
             ny: Interior cells in y.
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
-            **create_kw: Forwarded to :meth:`create` (``method``,
-                ``mask``).
+            **create_kw: Forwarded to :meth:`create` (``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
-            cell count to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
+            extent=(1.0, aspect))`` gives a step in the same time unit;
+            pass both cell counts and the aspect ratio, since the bound
+            depends on the *smaller* spacing.
         """
         context = "Diffusion2D.from_nondimensional"
         require_positive(context, aspect=aspect)

--- a/somax/_src/models/pde2d/diffusion.py
+++ b/somax/_src/models/pde2d/diffusion.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import CartesianGrid2D, Difference2D, Mask2D, enforce_periodic
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
+from somax._src.models._nondim import require_positive
 
 
 class Diffusion2DParams(Params):
@@ -74,6 +78,49 @@ class Diffusion2D(SomaxModel):
         interior = state.u[1:-1, 1:-1]
         energy = 0.5 * jnp.sum(interior**2) * self.grid.dx * self.grid.dy
         return Diffusion2DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        aspect: float = 1.0,
+        **create_kw: Any,
+    ) -> tuple[Diffusion2D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Diffusive scale set (:meth:`somax.Scales.diffusive`) with
+        ``L = kappa = 1``, so ``T = L**2/kappa = 1`` and the equation
+        reads ``d_t u = laplacian(u)``. Pure diffusion has no velocity
+        scale, so this scaling leaves no free dimensionless number:
+        every diffusion problem is the same problem once rescaled, and
+        only the grid and the initial condition remain to be chosen.
+
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            **create_kw: Forwarded to :meth:`create` (``method``,
+                ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
+            cell count to pick a step size in the same time unit.
+        """
+        context = "Diffusion2D.from_nondimensional"
+        require_positive(context, aspect=aspect)
+        model = Diffusion2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            nu=1.0,
+            **create_kw,
+        )
+        return model, Scales.diffusive(L=1.0, kappa=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde2d/linear_convection.py
+++ b/somax/_src/models/pde2d/linear_convection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from typing import Any, ClassVar
 
 import equinox as eqx
@@ -102,6 +103,7 @@ class LinearConvection2D(SomaxModel):
         nx: int = 64,
         ny: int = 64,
         aspect: float = 1.0,
+        direction: tuple[float, float] = (1.0, 1.0),
         **create_kw: Any,
     ) -> tuple[LinearConvection2D, Scales]:
         r"""Build the model at unit scales instead of SI coefficients.
@@ -110,32 +112,42 @@ class LinearConvection2D(SomaxModel):
         --------------------
         Advective scale set (:meth:`somax.Scales.advective`) with
         ``L = 1`` and the wave speed as the velocity scale, so ``T = 1``
-        and the equation reads ``d_t u + grad u = 0``. Scaling out the
-        speed leaves no free dimensionless number; the Courant number
-        is a time-step choice, not a property of the problem, so use
-        ``scales.dt_from_cfl``.
+        and the equation reads ``d_t u + c.grad u = 0`` with ``|c| = 1``.
+
+        Scaling out the *speed* leaves no free dimensionless number,
+        but it does not remove the *direction*: ``(1, 0)``, ``(1, 1)``
+        and ``(-1, 2)`` are different problems on the same grid, and
+        only their common magnitude is a unit choice. ``direction``
+        carries that, normalised so the speed stays 1. The Courant
+        number is a time-step choice rather than a property of the
+        problem, so use ``scales.dt_from_cfl``.
 
 
         Args:
             nx: Interior cells in x.
             ny: Interior cells in y.
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
-            **create_kw: Forwarded to :meth:`create` (``method``,
-                ``mask``).
+            direction: Propagation direction ``(cx, cy)``, normalised
+                to unit speed. Components may be zero or negative;
+                only the zero vector is rejected.
+            **create_kw: Forwarded to :meth:`create` (``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
-            cell count to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
+            extent=(1.0, aspect))`` gives a step in the same time unit;
+            pass both cell counts and the aspect ratio, since the bound
+            depends on the *smaller* spacing.
         """
         context = "LinearConvection2D.from_nondimensional"
         require_positive(context, aspect=aspect)
+        cx, cy = _unit_direction(context, direction)
         model = LinearConvection2D.create(
             nx=nx,
             ny=ny,
             Lx=1.0,
             Ly=aspect,
-            cx=1.0,
-            cy=1.0,
+            cx=cx,
+            cy=cy,
             **create_kw,
         )
         return model, Scales.advective(L=1.0, U=1.0)
@@ -171,3 +183,37 @@ class LinearConvection2D(SomaxModel):
         return LinearConvection2D(
             params=params, grid=grid, diff=diff, interp=interp, mask=mask
         )
+
+
+def _unit_direction(
+    context: str, direction: tuple[float, float]
+) -> tuple[float, float]:
+    """Normalise a propagation direction to unit speed.
+
+    Args:
+        context: Caller name, for error messages.
+        direction: ``(cx, cy)``; components may be zero or negative.
+
+    Returns:
+        ``(cx, cy)`` scaled so ``cx**2 + cy**2 == 1``.
+
+    Raises:
+        ValueError: If the pair is not two finite numbers, or is the
+            zero vector, which has no direction to normalise.
+    """
+    if len(direction) != 2:
+        raise ValueError(
+            f"{context}: direction must be a (cx, cy) pair; got {direction!r}."
+        )
+    cx, cy = (float(c) for c in direction)
+    if not (math.isfinite(cx) and math.isfinite(cy)):
+        raise ValueError(
+            f"{context}: direction components must be finite; got {direction!r}."
+        )
+    speed = math.hypot(cx, cy)
+    if speed == 0.0:
+        raise ValueError(
+            f"{context}: direction must not be the zero vector — there is no "
+            f"direction to normalise, and the equation would be trivial."
+        )
+    return cx / speed, cy / speed

--- a/somax/_src/models/pde2d/linear_convection.py
+++ b/somax/_src/models/pde2d/linear_convection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -14,7 +16,9 @@ from finitevolx import (
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
+from somax._src.models._nondim import require_positive
 
 
 class LinearConvection2DParams(Params):
@@ -88,6 +92,50 @@ class LinearConvection2D(SomaxModel):
         interior = state.u[1:-1, 1:-1]
         energy = 0.5 * jnp.sum(interior**2) * self.grid.dx * self.grid.dy
         return LinearConvection2DDiagnostics(energy=energy)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        aspect: float = 1.0,
+        **create_kw: Any,
+    ) -> tuple[LinearConvection2D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = 1`` and the wave speed as the velocity scale, so ``T = 1``
+        and the equation reads ``d_t u + grad u = 0``. Scaling out the
+        speed leaves no free dimensionless number; the Courant number
+        is a time-step choice, not a property of the problem, so use
+        ``scales.dt_from_cfl``.
+
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            **create_kw: Forwarded to :meth:`create` (``method``,
+                ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
+            cell count to pick a step size in the same time unit.
+        """
+        context = "LinearConvection2D.from_nondimensional"
+        require_positive(context, aspect=aspect)
+        model = LinearConvection2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            cx=1.0,
+            cy=1.0,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde2d/linear_convection.py
+++ b/somax/_src/models/pde2d/linear_convection.py
@@ -134,9 +134,12 @@ class LinearConvection2D(SomaxModel):
 
         Returns:
             ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
-            extent=(1.0, aspect))`` gives a step in the same time unit;
-            pass both cell counts and the aspect ratio, since the bound
-            depends on the *smaller* spacing.
+            extent=(1.0, aspect))`` gives a step in the same time unit.
+            Pass ``direction=`` as well, the same pair given here: the
+            advective bound sums ``|c_i|/dx_i`` over the axes, so
+            without it the worst case over all directions is used and
+            the step comes out up to ``sqrt(2)`` smaller than it needs
+            to be.
         """
         context = "LinearConvection2D.from_nondimensional"
         require_positive(context, aspect=aspect)

--- a/somax/_src/models/pde2d/navier_stokes.py
+++ b/somax/_src/models/pde2d/navier_stokes.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -16,7 +18,9 @@ from finitevolx import (
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, State
+from somax._src.models._nondim import require_positive
 
 
 class NSVorticityState(State):
@@ -279,6 +283,54 @@ class IncompressibleNS2D(SomaxModel):
             kinetic_energy=ke,
             enstrophy=enstrophy,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        aspect: float = 1.0,
+        reynolds: float,
+        **create_kw: Any,
+    ) -> tuple[IncompressibleNS2D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = U = 1``, so ``T = L/U = 1`` and the equation reads
+        ``d_t u + u . grad u = Re**-1 laplacian(u)``. The Reynolds
+        number is the only free number: ``nu = 1/Re``.
+
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            reynolds: Reynolds number ``Re = U L / nu``; sets
+                ``nu = 1/Re``.
+            **create_kw: Forwarded to :meth:`create` (``method``,
+                ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
+            cell count to pick a step size in the same time unit.
+
+        Raises:
+            ValueError: If an input is not positive.
+        """
+        context = "IncompressibleNS2D.from_nondimensional"
+        require_positive(context, aspect=aspect)
+        require_positive(context, reynolds=reynolds)
+        model = IncompressibleNS2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            nu=1.0 / reynolds,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde2d/navier_stokes.py
+++ b/somax/_src/models/pde2d/navier_stokes.py
@@ -314,12 +314,16 @@ class IncompressibleNS2D(SomaxModel):
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
             reynolds: Reynolds number ``Re = U L / nu``; sets
                 ``nu = 1/Re``.
-            **create_kw: Forwarded to :meth:`create` (``method``,
-                ``mask``).
+            **create_kw: Forwarded to :meth:`create` (``problem``,
+                ``u_lid``, ``body_force``, ``method``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
-            cell count to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
+            extent=(1.0, aspect))`` gives a step in the same time unit;
+            pass both cell counts and the aspect ratio, since the bound
+            depends on the *smaller* spacing. For the diffusive bound
+            add ``mode="diffusive", diffusivity=1/reynolds`` — the
+            scale set cannot know the model's Reynolds number.
 
         Raises:
             ValueError: If an input is not positive.

--- a/somax/_src/models/pde2d/nonlinear_convection.py
+++ b/somax/_src/models/pde2d/nonlinear_convection.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -14,7 +16,9 @@ from finitevolx import (
 from jaxtyping import Array, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, State
+from somax._src.models._nondim import require_positive
 
 
 class NonlinearConvection2DState(State):
@@ -87,6 +91,48 @@ class NonlinearConvection2D(SomaxModel):
         ui, vi = state.u[1:-1, 1:-1], state.v[1:-1, 1:-1]
         ke = 0.5 * jnp.sum(ui**2 + vi**2) * self.grid.dx * self.grid.dy
         return NonlinearConvection2DDiagnostics(kinetic_energy=ke)
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 64,
+        ny: int = 64,
+        aspect: float = 1.0,
+        **create_kw: Any,
+    ) -> tuple[NonlinearConvection2D, Scales]:
+        r"""Build the model at unit scales instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Advective scale set (:meth:`somax.Scales.advective`) with
+        ``L = U = 1``, so ``T = 1`` and the equation reads
+        ``d_t u + u . grad u = 0``. Inviscid nonlinear convection has no
+        coefficient to scale out, so this factory only fixes the domain
+        and reports the scale set; it exists so the family presents one
+        interface.
+
+
+        Args:
+            nx: Interior cells in x.
+            ny: Interior cells in y.
+            aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
+            **create_kw: Forwarded to :meth:`create` (``method``,
+                ``mask``).
+
+        Returns:
+            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
+            cell count to pick a step size in the same time unit.
+        """
+        context = "NonlinearConvection2D.from_nondimensional"
+        require_positive(context, aspect=aspect)
+        model = NonlinearConvection2D.create(
+            nx=nx,
+            ny=ny,
+            Lx=1.0,
+            Ly=aspect,
+            **create_kw,
+        )
+        return model, Scales.advective(L=1.0, U=1.0)
 
     @staticmethod
     def create(

--- a/somax/_src/models/pde2d/nonlinear_convection.py
+++ b/somax/_src/models/pde2d/nonlinear_convection.py
@@ -119,12 +119,13 @@ class NonlinearConvection2D(SomaxModel):
             nx: Interior cells in x.
             ny: Interior cells in y.
             aspect: ``Ly / Lx``; the domain is ``Lx = 1``.
-            **create_kw: Forwarded to :meth:`create` (``method``,
-                ``mask``).
+            **create_kw: Forwarded to :meth:`create` (``method``, ``mask``).
 
         Returns:
-            ``(model, scales)``. Pair ``scales.dt_from_cfl`` with the
-            cell count to pick a step size in the same time unit.
+            ``(model, scales)``. ``scales.dt_from_cfl(C, (nx, ny),
+            extent=(1.0, aspect))`` gives a step in the same time unit;
+            pass both cell counts and the aspect ratio, since the bound
+            depends on the *smaller* spacing.
         """
         context = "NonlinearConvection2D.from_nondimensional"
         require_positive(context, aspect=aspect)

--- a/tests/test_pde_nondim.py
+++ b/tests/test_pde_nondim.py
@@ -352,9 +352,12 @@ class TestCflAccountsForEveryAxis:
             scales.dt_from_cfl(0.5, 100) / 2
         )
 
-    def test_the_advective_bound_uses_the_smallest_spacing(self):
+    def test_the_advective_bound_is_dominated_by_the_smallest_spacing(self):
+        """But not equal to it — every axis contributes to the sum."""
         scales = Scales.advective(L=1.0, U=1.0)
-        assert scales.dt_from_cfl(0.5, (10, 100)) == pytest.approx(0.5 / 100)
+        got = scales.dt_from_cfl(0.5, (10, 100))
+        assert got == pytest.approx(0.5 / np.sqrt(10.0**2 + 100.0**2))
+        assert got < 0.5 / 100
 
     def test_extent_must_match_the_axes(self):
         scales = Scales.advective(L=1.0, U=1.0)
@@ -507,3 +510,85 @@ class TestDocumentedKwargsAreAccepted:
             f"{name} advertises {sorted(documented - accepted)}, which "
             f"create() does not accept"
         )
+
+
+class TestAdvectiveBoundAccountsForDirection:
+    """Courant is ``dt * sum_i |c_i|/dx_i``, not ``dt * |c|/min(dx)``.
+
+    On a square grid the default diagonal convection direction has
+    ``cx = cy = 1/sqrt(2)``, so a step taken from the minimum spacing
+    alone overshoots the requested Courant number by ``sqrt(2)``.
+    """
+
+    def scales(self):
+        return Scales.advective(L=1.0, U=1.0)
+
+    def courant(self, dt, spacings, components):
+        return dt * sum(abs(c) / s for c, s in zip(components, spacings, strict=True))
+
+    def test_the_default_diagonal_no_longer_overshoots(self):
+        dt = self.scales().dt_from_cfl(0.5, (100, 100))
+        unit = 1.0 / np.sqrt(2.0)
+        got = self.courant(dt, (0.01, 0.01), (unit, unit))
+        assert got == pytest.approx(0.5, rel=1e-6)
+
+    def test_the_old_formula_really_did_overshoot(self):
+        """Otherwise the test above would pass for the wrong reason."""
+        unit = 1.0 / np.sqrt(2.0)
+        naive_dt = 0.5 * 0.01  # C * min(dx) / |c|, with |c| = 1
+        got = self.courant(naive_dt, (0.01, 0.01), (unit, unit))
+        assert got == pytest.approx(0.5 * np.sqrt(2.0), rel=1e-6)
+
+    def test_an_axis_aligned_direction_gets_the_exact_bound(self):
+        dt = self.scales().dt_from_cfl(0.5, (100, 100), direction=(1.0, 0.0))
+        assert dt == pytest.approx(0.5 / 100)
+        assert self.courant(dt, (0.01, 0.01), (1.0, 0.0)) == pytest.approx(0.5)
+
+    def test_a_known_direction_is_never_more_restrictive_than_the_default(self):
+        scales = self.scales()
+        default = scales.dt_from_cfl(0.5, (100, 100))
+        for direction in ((1.0, 0.0), (0.0, 1.0), (1.0, 1.0), (3.0, 4.0)):
+            assert scales.dt_from_cfl(0.5, (100, 100), direction=direction) >= default
+
+    def test_the_direction_magnitude_does_not_matter(self):
+        scales = self.scales()
+        one = scales.dt_from_cfl(0.5, (100, 100), direction=(1.0, 2.0))
+        ten = scales.dt_from_cfl(0.5, (100, 100), direction=(10.0, 20.0))
+        assert one == pytest.approx(ten)
+
+    def test_a_negative_component_behaves_like_its_magnitude(self):
+        scales = self.scales()
+        assert scales.dt_from_cfl(
+            0.5, (100, 100), direction=(-1.0, 0.0)
+        ) == pytest.approx(scales.dt_from_cfl(0.5, (100, 100), direction=(1.0, 0.0)))
+
+    def test_the_one_dimensional_bound_is_unchanged(self):
+        assert self.scales().dt_from_cfl(0.5, 100) == pytest.approx(0.5 / 100)
+
+    def test_a_mismatched_direction_is_rejected(self):
+        with pytest.raises(ValueError, match="direction names"):
+            self.scales().dt_from_cfl(0.5, (10, 10), direction=(1.0,))
+
+    def test_the_zero_vector_is_rejected(self):
+        with pytest.raises(ValueError, match="zero vector"):
+            self.scales().dt_from_cfl(0.5, (10, 10), direction=(0.0, 0.0))
+
+    def test_a_non_finite_direction_is_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            self.scales().dt_from_cfl(0.5, (10, 10), direction=(float("nan"), 1.0))
+
+    def test_the_diffusive_bound_ignores_direction(self):
+        """Diffusion is isotropic, so a direction says nothing about it."""
+        scales = Scales.diffusive(L=1.0, kappa=1.0)
+        assert scales.dt_from_cfl(0.5, (50, 50)) == pytest.approx(
+            scales.dt_from_cfl(0.5, (50, 50), direction=(1.0, 0.0))
+        )
+
+    def test_the_convection_factory_direction_can_be_reused(self):
+        """The factory and the step helper speak the same language."""
+        model, scales = LinearConvection2D.from_nondimensional(
+            nx=64, ny=64, direction=(1.0, 0.0)
+        )
+        dt = scales.dt_from_cfl(0.4, (64, 64), direction=(1.0, 0.0))
+        assert dt == pytest.approx(0.4 / 64)
+        assert float(model.params.cy) == pytest.approx(0.0)

--- a/tests/test_pde_nondim.py
+++ b/tests/test_pde_nondim.py
@@ -143,10 +143,11 @@ class TestConvectionSpeed:
         assert float(model.params.c) == pytest.approx(1.0)
         assert scales.kind == "advective"
 
-    def test_linear_convection_2d_speeds_are_unity(self):
+    def test_linear_convection_2d_speed_is_unity(self):
+        """The *speed*, not each component — the default is diagonal."""
         model, _ = LinearConvection2D.from_nondimensional(nx=16, ny=16)
-        assert float(model.params.cx) == pytest.approx(1.0)
-        assert float(model.params.cy) == pytest.approx(1.0)
+        speed = np.hypot(float(model.params.cx), float(model.params.cy))
+        assert speed == pytest.approx(1.0)
 
 
 class TestCflHelper:
@@ -160,9 +161,8 @@ class TestCflHelper:
 
     def test_mode_can_be_forced(self):
         scales = Scales.advective(L=1.0, U=1.0)
-        assert scales.dt_from_cfl(0.5, 10, mode="diffusive") == pytest.approx(
-            0.5 * (1 / 10) ** 2 / 2
-        )
+        got = scales.dt_from_cfl(0.5, 10, mode="diffusive", diffusivity=1.0)
+        assert got == pytest.approx(0.5 * (1 / 10) ** 2 / 2)
 
     def test_unknown_mode_is_rejected(self):
         with pytest.raises(ValueError, match=r"advective.*diffusive"):
@@ -272,4 +272,238 @@ class TestDimensionalEquivalenceDiffusion:
         ).ys
         assert (
             np.abs(np.asarray(out.u)).max() < 0.95 * np.abs(np.asarray(state.u)).max()
+        )
+
+
+class TestCflStepInTheCorrectDirection:
+    """The conversion into the set's time unit was inverted.
+
+    Converting a dimensional bound ``C dx / U`` into units of ``T``
+    divides by ``T``, so the factor is ``(L/U)/T`` — the reciprocal of
+    what was applied. Only the advective set, where that factor is
+    exactly 1, was unaffected.
+    """
+
+    def test_the_inertial_step_grows_as_the_rossby_number_shrinks(self):
+        """A slower flow may take longer steps, not shorter ones."""
+        slow = Scales.inertial(L=1.0e6, f0=1.0e-4, H=500.0, rossby=0.001)
+        fast = Scales.inertial(L=1.0e6, f0=1.0e-4, H=500.0, rossby=0.1)
+        assert slow.dt_from_cfl(0.5, 100) > fast.dt_from_cfl(0.5, 100)
+
+    def test_the_inertial_step_is_the_nondimensional_courant_bound(self):
+        rossby = 0.01
+        scales = Scales.inertial(L=1.0e6, f0=1.0e-4, H=500.0, rossby=rossby)
+        # u_hat = U T / L = Ro for this set.
+        assert scales.dt_from_cfl(0.5, 100) == pytest.approx(0.5 / 100 / rossby)
+
+    def test_the_planetary_step_uses_twice_the_rossby_number(self):
+        """``U = 2 Omega a Ro``, so ``u_hat`` is ``2 Ro``, not ``Ro``."""
+        rossby = 0.05
+        scales = Scales.planetary(a=6.371e6, Omega=7.292e-5, H=3000.0, rossby=rossby)
+        assert scales.dt_from_cfl(0.5, 100) == pytest.approx(0.5 / 100 / (2 * rossby))
+
+    def test_the_advective_set_is_unchanged(self):
+        scales = Scales.advective(L=2.0, U=1.0)
+        assert scales.dt_from_cfl(0.4, 100) == pytest.approx(0.4 / 100)
+
+    def test_the_bound_is_advective_only(self):
+        """It bounds advection, so a caller must still cover waves.
+
+        A shallow-water run is limited by its gravity wave, whose
+        nondimensional speed is ``sqrt(Bu)/Ro`` — much faster than the
+        flow at small Rossby number. ``dt_from_cfl`` deliberately does
+        not guess at that; this pins the ratio so the omission stays
+        visible.
+        """
+        rossby, burger = 0.1, 1.0
+        scales = Scales.inertial(L=1.0, f0=1.0, H=1.0, rossby=rossby, g=burger)
+        advective = scales.dt_from_cfl(0.2, 32)
+
+        # Nondimensional speeds: the flow is Ro, the gravity wave
+        # sqrt(Bu)/Ro. The two bounds differ by their ratio.
+        flow_speed = rossby
+        wave_speed = np.sqrt(burger) / rossby
+        wave_bound = 0.2 / 32 / wave_speed
+        assert advective / wave_bound == pytest.approx(wave_speed / flow_speed)
+
+
+class TestCflAccountsForEveryAxis:
+    """A 2-D bound depends on both spacings, not just one.
+
+    With a flat domain the ``y`` spacing can be far smaller than the
+    ``x`` one, and a single-axis bound then returns a step orders of
+    magnitude too large.
+    """
+
+    def test_a_flat_domain_gives_a_smaller_step(self):
+        scales = Scales.diffusive(L=1.0, kappa=1.0)
+        square = scales.dt_from_cfl(0.5, (64, 64))
+        flat = scales.dt_from_cfl(0.5, (64, 64), extent=(1.0, 0.1))
+        assert flat < square / 50
+
+    def test_the_one_dimensional_bound_is_recovered(self):
+        scales = Scales.diffusive(L=1.0, kappa=1.0)
+        assert scales.dt_from_cfl(0.5, 100) == pytest.approx(0.5 * (1 / 100) ** 2 / 2)
+
+    def test_two_equal_axes_halve_the_one_dimensional_bound(self):
+        """``sum 1/dx_i**2`` doubles when a second identical axis appears."""
+        scales = Scales.diffusive(L=1.0, kappa=1.0)
+        assert scales.dt_from_cfl(0.5, (100, 100)) == pytest.approx(
+            scales.dt_from_cfl(0.5, 100) / 2
+        )
+
+    def test_the_advective_bound_uses_the_smallest_spacing(self):
+        scales = Scales.advective(L=1.0, U=1.0)
+        assert scales.dt_from_cfl(0.5, (10, 100)) == pytest.approx(0.5 / 100)
+
+    def test_extent_must_match_the_axes(self):
+        scales = Scales.advective(L=1.0, U=1.0)
+        with pytest.raises(ValueError, match="names 1 axes"):
+            scales.dt_from_cfl(0.5, (10, 10), extent=1.0)
+
+    def test_a_non_positive_cell_count_is_rejected(self):
+        scales = Scales.advective(L=1.0, U=1.0)
+        with pytest.raises(ValueError, match=r"n_cells\[1\]"):
+            scales.dt_from_cfl(0.5, (10, 0))
+
+
+class TestDiffusiveBoundNeedsTheModelsDiffusivity:
+    """``L * U`` is not the diffusivity the pde models carry.
+
+    Their nondimensional diffusivity is ``1/Re``, and ``L * U`` is
+    identically 1 for the scales they return — so the bound came out a
+    factor of ``Re`` too large.
+    """
+
+    def test_it_refuses_to_guess_on_a_non_diffusive_set(self):
+        scales = Scales.advective(L=1.0, U=1.0)
+        with pytest.raises(ValueError, match="nondimensional diffusivity"):
+            scales.dt_from_cfl(0.5, 64, mode="diffusive")
+
+    def test_a_diffusive_set_still_knows_its_own(self):
+        scales = Scales.diffusive(L=1.0, kappa=1.0)
+        assert scales.dt_from_cfl(0.5, 64) > 0.0
+
+    def test_the_reynolds_number_enters_the_bound(self):
+        _, scales = Burgers1D.from_nondimensional(nx=64, reynolds=100.0)
+        low = scales.dt_from_cfl(0.4, 64, mode="diffusive", diffusivity=1 / 10.0)
+        high = scales.dt_from_cfl(0.4, 64, mode="diffusive", diffusivity=1 / 1000.0)
+        assert high == pytest.approx(100.0 * low)
+
+    def test_the_bound_matches_the_explicit_formula(self):
+        _, scales = Burgers1D.from_nondimensional(nx=64, reynolds=100.0)
+        got = scales.dt_from_cfl(0.4, 64, mode="diffusive", diffusivity=1 / 100.0)
+        assert got == pytest.approx(0.4 * (1 / 64) ** 2 / (2 / 100.0))
+
+    def test_a_low_reynolds_run_stays_finite_at_the_diffusive_bound(self):
+        model, scales = Burgers1D.from_nondimensional(nx=64, reynolds=2.0)
+        dt = scales.dt_from_cfl(0.4, 64, mode="diffusive", diffusivity=1 / 2.0)
+        x = jnp.linspace(0.0, 1.0, model.grid.Nx)
+        state = Burgers1DState(u=jnp.sin(2.0 * jnp.pi * x))
+        out = model.integrate(state, t0=0.0, t1=20 * dt, dt=dt).ys
+        assert np.isfinite(np.asarray(out.u)).all()
+
+
+class TestConvectionKeepsItsDirection:
+    """Scaling out the speed must not scale out the direction.
+
+    ``(1, 0)``, ``(1, 1)`` and ``(-1, 2)`` are different problems on
+    the same grid; only their common magnitude is a unit choice.
+    """
+
+    def test_a_purely_zonal_direction_is_representable(self):
+        model, _ = LinearConvection2D.from_nondimensional(
+            nx=16, ny=16, direction=(1.0, 0.0)
+        )
+        assert float(model.params.cx) == pytest.approx(1.0)
+        assert float(model.params.cy) == pytest.approx(0.0)
+
+    def test_an_unequal_ratio_is_preserved(self):
+        model, _ = LinearConvection2D.from_nondimensional(
+            nx=16, ny=16, direction=(3.0, 4.0)
+        )
+        assert float(model.params.cx) == pytest.approx(0.6)
+        assert float(model.params.cy) == pytest.approx(0.8)
+
+    def test_the_speed_is_still_one(self):
+        model, _ = LinearConvection2D.from_nondimensional(
+            nx=16, ny=16, direction=(-1.0, 2.0)
+        )
+        speed = np.hypot(float(model.params.cx), float(model.params.cy))
+        assert speed == pytest.approx(1.0)
+
+    def test_negative_propagation_is_representable(self):
+        model, _ = LinearConvection2D.from_nondimensional(
+            nx=16, ny=16, direction=(-1.0, 0.0)
+        )
+        assert float(model.params.cx) == pytest.approx(-1.0)
+
+    def test_the_default_is_the_previous_behaviour(self):
+        """Diagonal, now normalised so the speed really is the scale."""
+        model, _ = LinearConvection2D.from_nondimensional(nx=16, ny=16)
+        assert float(model.params.cx) == pytest.approx(float(model.params.cy))
+        assert float(model.params.cx) == pytest.approx(1.0 / np.sqrt(2.0))
+
+    def test_the_zero_vector_is_rejected(self):
+        with pytest.raises(ValueError, match="zero vector"):
+            LinearConvection2D.from_nondimensional(nx=8, ny=8, direction=(0.0, 0.0))
+
+    def test_a_non_finite_direction_is_rejected(self):
+        with pytest.raises(ValueError, match="finite"):
+            LinearConvection2D.from_nondimensional(
+                nx=8, ny=8, direction=(float("nan"), 1.0)
+            )
+
+    def test_the_one_dimensional_sign_is_preserved(self):
+        model, _ = LinearConvection1D.from_nondimensional(nx=32, direction=-2.0)
+        assert float(model.params.c) == pytest.approx(-1.0)
+
+    def test_the_one_dimensional_default_is_rightward(self):
+        model, _ = LinearConvection1D.from_nondimensional(nx=32)
+        assert float(model.params.c) == pytest.approx(1.0)
+
+    def test_a_zero_one_dimensional_direction_is_rejected(self):
+        with pytest.raises(ValueError, match="non-zero"):
+            LinearConvection1D.from_nondimensional(nx=32, direction=0.0)
+
+
+#: Every model whose factory advertises forwarded ``create`` kwargs.
+FACTORY_CLASSES = [
+    Diffusion1D,
+    LinearConvection1D,
+    Burgers1D,
+    NonlinearConvection1D,
+    Diffusion2D,
+    LinearConvection2D,
+    Burgers2D,
+    NonlinearConvection2D,
+    IncompressibleNS2D,
+]
+
+
+class TestDocumentedKwargsAreAccepted:
+    """Every forwarded argument a factory advertises must exist.
+
+    ``method`` was listed on four factories whose ``create()`` has no
+    such parameter, so following the docstring raised ``TypeError``.
+    """
+
+    @pytest.mark.parametrize(
+        "cls", FACTORY_CLASSES, ids=[c.__name__ for c in FACTORY_CLASSES]
+    )
+    def test_documented_kwargs_exist_on_create(self, cls):
+        import inspect
+        import re
+
+        name = cls.__name__
+        doc = cls.from_nondimensional.__doc__
+        match = re.search(
+            r"\*\*create_kw: Forwarded to :meth:`create` \(([^)]*)\)", doc, re.S
+        )
+        assert match, f"{name}: no forwarded-kwargs line to check"
+        documented = set(re.findall(r"``(\w+)``", match.group(1)))
+        accepted = set(inspect.signature(cls.create).parameters)
+        assert documented <= accepted, (
+            f"{name} advertises {sorted(documented - accepted)}, which "
+            f"create() does not accept"
         )

--- a/tests/test_pde_nondim.py
+++ b/tests/test_pde_nondim.py
@@ -1,0 +1,275 @@
+"""Tests for the pde1d / pde2d nondimensional factories."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from somax._src.core.scales import Scales
+from somax._src.models.pde1d.burgers import Burgers1D, Burgers1DState
+from somax._src.models.pde1d.diffusion import Diffusion1D, Diffusion1DState
+from somax._src.models.pde1d.linear_convection import LinearConvection1D
+from somax._src.models.pde1d.nonlinear_convection import NonlinearConvection1D
+from somax._src.models.pde2d.burgers import Burgers2D
+from somax._src.models.pde2d.diffusion import Diffusion2D
+from somax._src.models.pde2d.linear_convection import LinearConvection2D
+from somax._src.models.pde2d.navier_stokes import IncompressibleNS2D
+from somax._src.models.pde2d.nonlinear_convection import NonlinearConvection2D
+
+
+def relative_error(got, expected):
+    got, expected = np.asarray(got), np.asarray(expected)
+    return np.abs(got - expected).max() / np.abs(expected).max()
+
+
+ONE_D = [
+    ("Burgers1D", lambda: Burgers1D.from_nondimensional(nx=32, reynolds=100.0)),
+    ("Diffusion1D", lambda: Diffusion1D.from_nondimensional(nx=32)),
+    ("LinearConvection1D", lambda: LinearConvection1D.from_nondimensional(nx=32)),
+    (
+        "NonlinearConvection1D",
+        lambda: NonlinearConvection1D.from_nondimensional(nx=32),
+    ),
+]
+
+TWO_D = [
+    (
+        "Burgers2D",
+        lambda: Burgers2D.from_nondimensional(nx=16, ny=16, reynolds=100.0),
+    ),
+    ("Diffusion2D", lambda: Diffusion2D.from_nondimensional(nx=16, ny=16)),
+    (
+        "IncompressibleNS2D",
+        lambda: IncompressibleNS2D.from_nondimensional(nx=16, ny=16, reynolds=100.0),
+    ),
+    (
+        "LinearConvection2D",
+        lambda: LinearConvection2D.from_nondimensional(nx=16, ny=16),
+    ),
+    (
+        "NonlinearConvection2D",
+        lambda: NonlinearConvection2D.from_nondimensional(nx=16, ny=16),
+    ),
+]
+
+ALL_MODELS = ONE_D + TWO_D
+
+
+class TestCommonContract:
+    @pytest.mark.parametrize(
+        ("name", "build"), ALL_MODELS, ids=[n for n, _ in ALL_MODELS]
+    )
+    def test_returns_model_and_scales(self, name, build):
+        model, scales = build()
+        assert model is not None
+        assert isinstance(scales, Scales)
+
+    @pytest.mark.parametrize(
+        ("name", "build"), ALL_MODELS, ids=[n for n, _ in ALL_MODELS]
+    )
+    def test_domain_is_unit_length(self, name, build):
+        model, _ = build()
+        assert model.grid.Lx == pytest.approx(1.0)
+
+    @pytest.mark.parametrize(
+        ("name", "build"), ALL_MODELS, ids=[n for n, _ in ALL_MODELS]
+    )
+    def test_time_scale_is_unity(self, name, build):
+        """Every set is arranged so the model's own time unit is 1."""
+        _, scales = build()
+        assert pytest.approx(1.0) == scales.T
+
+    @pytest.mark.parametrize(("name", "build"), TWO_D, ids=[n for n, _ in TWO_D])
+    def test_aspect_only_stretches_y(self, name, build):
+        model, _ = build()
+        assert model.grid.Ly == pytest.approx(1.0)
+
+
+class TestReynolds:
+    @pytest.mark.parametrize("reynolds", [1.0, 100.0, 1e4])
+    def test_burgers_1d_viscosity_is_the_inverse(self, reynolds):
+        model, _ = Burgers1D.from_nondimensional(nx=32, reynolds=reynolds)
+        assert float(model.params.nu) == pytest.approx(1.0 / reynolds, rel=1e-6)
+
+    def test_burgers_2d_viscosity_is_the_inverse(self):
+        model, _ = Burgers2D.from_nondimensional(nx=16, ny=16, reynolds=250.0)
+        assert float(model.params.nu) == pytest.approx(1.0 / 250.0, rel=1e-6)
+
+    def test_navier_stokes_viscosity_is_the_inverse(self):
+        model, _ = IncompressibleNS2D.from_nondimensional(nx=16, ny=16, reynolds=500.0)
+        assert float(model.params.nu) == pytest.approx(1.0 / 500.0, rel=1e-6)
+
+    def test_advective_scale_set(self):
+        _, scales = Burgers1D.from_nondimensional(nx=32, reynolds=100.0)
+        assert scales.kind == "advective"
+        assert scales.L == 1.0
+        assert scales.U == 1.0
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0])
+    def test_non_positive_reynolds_is_rejected(self, bad):
+        with pytest.raises(ValueError, match="reynolds"):
+            Burgers1D.from_nondimensional(nx=32, reynolds=bad)
+
+    def test_negative_aspect_is_rejected(self):
+        with pytest.raises(ValueError, match="aspect"):
+            Burgers2D.from_nondimensional(nx=16, ny=16, reynolds=100.0, aspect=-1.0)
+
+
+class TestDiffusiveSet:
+    def test_nondimensional_diffusivity_is_one(self):
+        """The diffusive scaling leaves no free number: kappa becomes 1."""
+        model, scales = Diffusion1D.from_nondimensional(nx=32)
+        assert float(model.params.nu) == pytest.approx(1.0)
+        assert scales.kind == "diffusive"
+
+    def test_two_dimensional_case_matches(self):
+        model, scales = Diffusion2D.from_nondimensional(nx=16, ny=16)
+        assert float(model.params.nu) == pytest.approx(1.0)
+        assert scales.kind == "diffusive"
+
+    def test_diffusive_scales_recover_the_time_scale(self):
+        scales = Scales.diffusive(L=2.0, kappa=0.01)
+        assert pytest.approx(2.0**2 / 0.01) == scales.T
+
+    def test_diffusive_rejects_non_positive_inputs(self):
+        with pytest.raises(ValueError, match="kappa"):
+            Scales.diffusive(L=1.0, kappa=0.0)
+
+
+class TestConvectionSpeed:
+    def test_linear_convection_speed_is_unity(self):
+        model, scales = LinearConvection1D.from_nondimensional(nx=32)
+        assert float(model.params.c) == pytest.approx(1.0)
+        assert scales.kind == "advective"
+
+    def test_linear_convection_2d_speeds_are_unity(self):
+        model, _ = LinearConvection2D.from_nondimensional(nx=16, ny=16)
+        assert float(model.params.cx) == pytest.approx(1.0)
+        assert float(model.params.cy) == pytest.approx(1.0)
+
+
+class TestCflHelper:
+    def test_advective_step(self):
+        scales = Scales.advective(L=2.0, U=1.0)
+        assert scales.dt_from_cfl(0.4, 100) == pytest.approx(0.4 / 100)
+
+    def test_diffusive_step(self):
+        scales = Scales.diffusive(L=2.0, kappa=0.01)
+        assert scales.dt_from_cfl(0.4, 100) == pytest.approx(0.4 / 100**2 / 2)
+
+    def test_mode_can_be_forced(self):
+        scales = Scales.advective(L=1.0, U=1.0)
+        assert scales.dt_from_cfl(0.5, 10, mode="diffusive") == pytest.approx(
+            0.5 * (1 / 10) ** 2 / 2
+        )
+
+    def test_unknown_mode_is_rejected(self):
+        with pytest.raises(ValueError, match=r"advective.*diffusive"):
+            Scales.advective(L=1.0, U=1.0).dt_from_cfl(0.5, 10, mode="nope")
+
+    def test_rejects_non_positive_inputs(self):
+        with pytest.raises(ValueError, match="cfl"):
+            Scales.advective(L=1.0, U=1.0).dt_from_cfl(0.0, 10)
+
+    def test_a_step_from_the_helper_keeps_burgers_finite(self):
+        model, scales = Burgers1D.from_nondimensional(nx=64, reynolds=100.0)
+        dt = scales.dt_from_cfl(0.4, 64)
+        x = jnp.linspace(0.0, 1.0, model.grid.Nx)
+        state = Burgers1DState(u=jnp.sin(2.0 * jnp.pi * x))
+        out = model.integrate(state, t0=0.0, t1=20 * dt, dt=dt).ys
+        assert np.isfinite(np.asarray(out.u)).all()
+
+
+class TestDimensionalEquivalenceBurgers:
+    """A nondimensional Burgers run reproduces its dimensional twin.
+
+    With ``L`` and ``U`` chosen, ``nu = U L / Re``, ``u_dim = U u'`` and
+    ``t_dim = (L/U) t'``.
+    """
+
+    L = 3.0
+    U = 0.25
+    RE = 200.0
+    NX = 64
+
+    def dimensional(self):
+        return Burgers1D.create(
+            nx=self.NX, Lx=self.L, nu=self.U * self.L / self.RE, periodic=True
+        )
+
+    def initial(self, model, amplitude):
+        x = jnp.linspace(0.0, 1.0, model.grid.Nx)
+        return Burgers1DState(u=amplitude * jnp.sin(2.0 * jnp.pi * x))
+
+    def test_viscosity_round_trips(self):
+        dim = self.dimensional()
+        assert self.U * self.L / float(dim.params.nu) == pytest.approx(
+            self.RE, rel=1e-5
+        )
+
+    def test_trajectories_agree_under_the_scales_mapping(self):
+        dim = self.dimensional()
+        nd, _ = Burgers1D.from_nondimensional(
+            nx=self.NX, reynolds=self.RE, periodic=True
+        )
+        scales = Scales.advective(L=self.L, U=self.U)
+
+        state_nd = self.initial(nd, 1.0)
+        state_dim = self.initial(dim, self.U)
+
+        t_nd, n = 0.2, 200
+        sol_nd = nd.integrate(state_nd, t0=0.0, t1=t_nd, dt=t_nd / n).ys
+        sol_dim = dim.integrate(
+            state_dim, t0=0.0, t1=t_nd * scales.T, dt=t_nd * scales.T / n
+        ).ys
+        assert relative_error(np.asarray(sol_nd.u) * self.U, sol_dim.u) < 1e-4
+
+    def test_the_state_actually_evolves(self):
+        dim = self.dimensional()
+        scales = Scales.advective(L=self.L, U=self.U)
+        state = self.initial(dim, self.U)
+        out = dim.integrate(
+            state, t0=0.0, t1=0.2 * scales.T, dt=0.2 * scales.T / 200
+        ).ys
+        change = np.abs(np.asarray(out.u) - np.asarray(state.u)).max()
+        assert change > 0.05 * np.abs(np.asarray(state.u)).max()
+
+
+class TestDimensionalEquivalenceDiffusion:
+    """A diffusive-set run reproduces its dimensional twin."""
+
+    L = 3.0
+    KAPPA = 0.02
+    NX = 64
+
+    def test_trajectories_agree_under_the_scales_mapping(self):
+        dim = Diffusion1D.create(nx=self.NX, Lx=self.L, nu=self.KAPPA, periodic=True)
+        nd, _ = Diffusion1D.from_nondimensional(nx=self.NX, periodic=True)
+        scales = Scales.diffusive(L=self.L, kappa=self.KAPPA)
+
+        x = jnp.linspace(0.0, 1.0, dim.grid.Nx)
+        profile = jnp.sin(2.0 * jnp.pi * x)
+        amplitude = 0.7
+        state_nd = Diffusion1DState(u=profile)
+        state_dim = Diffusion1DState(u=amplitude * profile)
+
+        t_nd, n = 0.02, 400
+        sol_nd = nd.integrate(state_nd, t0=0.0, t1=t_nd, dt=t_nd / n).ys
+        sol_dim = dim.integrate(
+            state_dim, t0=0.0, t1=t_nd * scales.T, dt=t_nd * scales.T / n
+        ).ys
+        # Diffusion is linear, so the amplitude is carried through.
+        assert relative_error(np.asarray(sol_nd.u) * amplitude, sol_dim.u) < 1e-4
+
+    def test_the_state_actually_decays(self):
+        dim = Diffusion1D.create(nx=self.NX, Lx=self.L, nu=self.KAPPA, periodic=True)
+        scales = Scales.diffusive(L=self.L, kappa=self.KAPPA)
+        x = jnp.linspace(0.0, 1.0, dim.grid.Nx)
+        state = Diffusion1DState(u=jnp.sin(2.0 * jnp.pi * x))
+        out = dim.integrate(
+            state, t0=0.0, t1=0.02 * scales.T, dt=0.02 * scales.T / 400
+        ).ys
+        assert (
+            np.abs(np.asarray(out.u)).max() < 0.95 * np.abs(np.asarray(state.u)).max()
+        )


### PR DESCRIPTION
Closes #176. Stacked on #184 (epic #170).

## What this adds

The factory on all nine toy PDE models, plus the two `Scales` pieces they need: a **diffusive** scale set (`T = L**2/kappa`) and `dt_from_cfl`, which returns a step in the set's own time unit for either the advective or diffusive stability limit.

## Decisions worth review

**Only three models have a free dimensionless number.** Burgers (1D, 2D) and incompressible Navier-Stokes take `Re`, mapping to `nu = 1/Re`. The rest have none once rescaled, and the factories say so rather than inventing one:

- **Pure diffusion** has no velocity to build a time scale from, so it takes the diffusive set where the nondimensional diffusivity is exactly 1. Every diffusion problem is the same problem; only the grid and the initial condition remain. The issue suggested `Pe` here, but `Pe` is undefined without advection.
- **Linear convection** scales its wave speed to 1.
- **Inviscid nonlinear convection** has no coefficient at all.

Those three still get the factory so the family presents one interface and reports its scale set.

## Testing

Equivalence is pinned for both non-trivial sets: a nondimensional Burgers run matches its dimensional twin to `1e-4` on the advective mapping, and a diffusion run matches on the diffusive one. Each has a companion test asserting the state really evolved or decayed. A further test confirms a step taken from `dt_from_cfl` keeps Burgers finite.

58 new tests. Full suite 1001 → 1059 passing; lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg)_