### PR TITLE
feat(core): optional somax[flows] extra — flowjax bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --group dev --group sim --group da
+        run: uv sync --group dev --group sim --group da --extra flows
       - name: Run fast tests with coverage
         # Slow + integration tests (grad-through, somax-sim end-to-end)
         # are excluded here and run in the manual `full-tests` workflow.

--- a/.github/workflows/full-tests.yml
+++ b/.github/workflows/full-tests.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: uv sync --group dev --group sim --group da
+        run: uv sync --group dev --group sim --group da --extra flows
       - name: Run full test suite with coverage
         run: |
           if [ -n "${{ inputs.marker }}" ]; then

--- a/content/notes/nondimensional_runs.md
+++ b/content/notes/nondimensional_runs.md
@@ -86,3 +86,26 @@ reported in whatever units the model runs in, and
 `ConservationDriftMonitor` reports relative drift, which is
 scale-invariant, so a nondimensional run gets the same conservation
 signal as a dimensional one.
+
+## Learned priors (optional)
+
+The `flows` extra bridges a `StateAffine` into flowjax, so a normalising
+flow can be composed onto a fixed physical scaling instead of having to
+relearn it:
+
+```python
+from somax.flows import learned_prior
+
+prior = learned_prior(transform, state_example, flow, base_distribution)
+```
+
+The flow models the standardised state; the scaling maps its output back
+to physical units, so the prior is over physical states while the flow
+only ever sees O(1) numbers. `content/tutorials/learned_prior_flowjax.py`
+works through it.
+
+flowjax stays optional. Its own `Affine` forces the scale through a
+trainable softplus parameterisation, which is the opposite of what a
+fixed physical scale wants, and it brings the whole flow stack along.
+The log-determinant only matters when transforming densities; every
+other use of the affine map in somax needs no flow library.

--- a/content/tutorials/learned_prior_flowjax.ipynb
+++ b/content/tutorials/learned_prior_flowjax.ipynb
@@ -1,0 +1,307 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fc3ab419",
+   "metadata": {},
+   "source": [
+    "# Learned priors — composing a flow onto a physical scaling\n",
+    "\n",
+    "A data-assimilation prior has to say which ocean states are plausible. A\n",
+    "Gaussian says \"close to this mean, with this covariance\"; a normalising flow\n",
+    "can say something much richer. But a flow trained directly on a dimensional\n",
+    "ocean state has to spend its capacity learning that thickness is measured in\n",
+    "hundreds of metres and velocity in tenths of a metre per second — facts we\n",
+    "already know.\n",
+    "\n",
+    "`somax.flows` lets you hand the flow that knowledge for free. A\n",
+    "`StateAffine` carries the physical scaling; the flow is composed on top and\n",
+    "learns only the departure from it.\n",
+    "\n",
+    "**Requires the optional extra:** `pip install somax[flows]`, or\n",
+    "`uv sync --extra flows`.\n",
+    "\n",
+    "**What you'll see:**\n",
+    "\n",
+    "1. Building a `StateAffine` from characteristic `Scales`\n",
+    "2. Adapting it to a flowjax bijection with `to_flowjax`\n",
+    "3. Composing it with a flow into a prior over *physical* states\n",
+    "4. Why the log-density picks up a constant from the scaling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c14c756d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T04:58:34.570264Z",
+     "iopub.status.busy": "2026-09-12T04:58:34.570002Z",
+     "iopub.status.idle": "2026-09-12T04:58:37.011765Z",
+     "shell.execute_reply": "2026-09-12T04:58:37.010163Z"
+    },
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import numpy as np\n",
+    "from jax.flatten_util import ravel_pytree\n",
+    "\n",
+    "from somax import Scales, StateAffine\n",
+    "from somax._src.models.swm.nonlinear_2d import NonlinearSW2DState\n",
+    "from somax.flows import learned_prior, to_flowjax"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ea26d78b",
+   "metadata": {},
+   "source": [
+    "## 1. A state and its physical scales\n",
+    "\n",
+    "A shallow-water state whose fields sit four orders of magnitude apart:\n",
+    "thickness around 1000 m, velocities around 0.1 m/s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "9928b4b6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T04:58:37.015285Z",
+     "iopub.status.busy": "2026-09-12T04:58:37.014821Z",
+     "iopub.status.idle": "2026-09-12T04:58:37.132990Z",
+     "shell.execute_reply": "2026-09-12T04:58:37.131073Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "h  ~ 1000.0 m\n",
+      "u  ~ 0.100 m/s\n",
+      "geostrophic height scale = 1.019 m\n"
+     ]
+    }
+   ],
+   "source": [
+    "NY, NX = 8, 8\n",
+    "rng = np.random.RandomState(0)\n",
+    "\n",
+    "scales = Scales.advective(L=1.0e6, U=0.1, f0=1.0e-4, H=1000.0)\n",
+    "state = NonlinearSW2DState(\n",
+    "    h=jnp.asarray(scales.H + rng.randn(NY, NX)),\n",
+    "    u=jnp.asarray(0.1 * rng.randn(NY, NX)),\n",
+    "    v=jnp.asarray(0.1 * rng.randn(NY, NX)),\n",
+    ")\n",
+    "\n",
+    "print(f\"h  ~ {float(jnp.mean(state.h)):.1f} m\")\n",
+    "print(f\"u  ~ {float(jnp.std(state.u)):.3f} m/s\")\n",
+    "print(f\"geostrophic height scale = {scales.eta:.3f} m\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d1d358e",
+   "metadata": {},
+   "source": [
+    "## 2. The transform, as a flowjax bijection\n",
+    "\n",
+    "`StateAffine` already exposes `transform_and_log_det`; `to_flowjax` wraps it\n",
+    "in the flat-array interface flowjax bijections use. The flat layout is the\n",
+    "same one `somax.da` uses, so a single vector feeds both a filter and a flow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "5da2deaa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T04:58:37.136586Z",
+     "iopub.status.busy": "2026-09-12T04:58:37.136259Z",
+     "iopub.status.idle": "2026-09-12T04:58:37.620661Z",
+     "shell.execute_reply": "2026-09-12T04:58:37.618866Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "flat state size      : 192\n",
+      "standardised |h| max : 2.50\n",
+      "log|det J|           : 293.50\n"
+     ]
+    }
+   ],
+   "source": [
+    "transform = StateAffine.from_scales(NonlinearSW2DState, scales)\n",
+    "bijection = to_flowjax(transform, state)\n",
+    "\n",
+    "flat, unravel = ravel_pytree(state)\n",
+    "standardised, log_det = bijection.transform_and_log_det(flat)\n",
+    "\n",
+    "print(f\"flat state size      : {bijection.shape[0]}\")\n",
+    "print(f\"standardised |h| max : {float(jnp.abs(unravel(standardised).h).max()):.2f}\")\n",
+    "print(f\"log|det J|           : {float(log_det):.2f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b685fe6b",
+   "metadata": {},
+   "source": [
+    "The standardised state is O(1) in every field. The log-determinant is a\n",
+    "constant — the Jacobian of a fixed affine map does not depend on where you\n",
+    "evaluate it — and it is exactly what a density has to pick up when it is\n",
+    "pushed through the scaling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ac0a81a",
+   "metadata": {},
+   "source": [
+    "## 3. A prior over physical states\n",
+    "\n",
+    "`learned_prior` composes base → flow → *out of* standardised coordinates, so\n",
+    "the resulting distribution is over physical states while the flow itself\n",
+    "only ever sees O(1) numbers. Any flowjax bijection works as the flow; a\n",
+    "trained `masked_autoregressive_flow` is the realistic choice, and `Identity`\n",
+    "here keeps the arithmetic checkable by hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b1749c30",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T04:58:37.623419Z",
+     "iopub.status.busy": "2026-09-12T04:58:37.623093Z",
+     "iopub.status.idle": "2026-09-12T04:58:39.175397Z",
+     "shell.execute_reply": "2026-09-12T04:58:39.173684Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "sampled h mean   : 1000.0 m   (loc 1000.0)\n",
+      "sampled u spread : 0.100 m/s (scale 0.100)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from flowjax.bijections import Identity\n",
+    "from flowjax.distributions import Normal\n",
+    "\n",
+    "\n",
+    "base = Normal(jnp.zeros(flat.size))\n",
+    "prior = learned_prior(transform, state, Identity((flat.size,)), base)\n",
+    "\n",
+    "draws = jax.vmap(unravel)(prior.sample(jax.random.key(0), (2048,)))\n",
+    "h_mean = float(jnp.mean(draws.h))\n",
+    "u_spread = float(jnp.std(draws.u))\n",
+    "print(f\"sampled h mean   : {h_mean:.1f} m   (loc {transform.loc.h:.1f})\")\n",
+    "print(f\"sampled u spread : {u_spread:.3f} m/s (scale {transform.scale.u:.3f})\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bcc121e",
+   "metadata": {},
+   "source": [
+    "Samples come out in physical units with the right magnitudes, from a base\n",
+    "distribution that is standard normal. That is the scaling doing its job."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0edb2bf",
+   "metadata": {},
+   "source": [
+    "## 4. The density, term by term\n",
+    "\n",
+    "For $\\phi$ the standardising map,\n",
+    "\n",
+    "$$\\log p_X(x) = \\log p_Y(\\phi(x)) + \\log|\\det J_\\phi(x)|.$$\n",
+    "\n",
+    "With an identity flow both terms are computable directly, so the\n",
+    "composition can be checked rather than taken on trust."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "dd505d46",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-09-12T04:58:39.178094Z",
+     "iopub.status.busy": "2026-09-12T04:58:39.177852Z",
+     "iopub.status.idle": "2026-09-12T04:58:39.641656Z",
+     "shell.execute_reply": "2026-09-12T04:58:39.640194Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "prior.log_prob(x)              = 18.2926\n",
+      "log p_base(phi(x)) + log|det J| = 18.2926\n"
+     ]
+    }
+   ],
+   "source": [
+    "lhs = float(prior.log_prob(flat))\n",
+    "rhs = float(base.log_prob(standardised)) + float(log_det)\n",
+    "print(f\"prior.log_prob(x)              = {lhs:.4f}\")\n",
+    "print(f\"log p_base(phi(x)) + log|det J| = {rhs:.4f}\")\n",
+    "assert np.isclose(lhs, rhs, rtol=1e-4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10612a85",
+   "metadata": {},
+   "source": [
+    "## Why flowjax is optional\n",
+    "\n",
+    "flowjax is not a core somax dependency. Its own `Affine` forces the scale\n",
+    "through a trainable softplus parameterisation, which is the opposite of what\n",
+    "a *fixed* physical scale wants, and it brings the whole flow stack with it.\n",
+    "The log-determinant only matters when transforming densities; everywhere\n",
+    "else in somax — the DA flatten bridge, `ScaledModel`, the nondimensional\n",
+    "factories — the affine map is used directly and no flow library is involved."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/content/tutorials/learned_prior_flowjax.py
+++ b/content/tutorials/learned_prior_flowjax.py
@@ -1,0 +1,147 @@
+# ---
+# jupyter:
+#   jupytext:
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#       jupytext_version: 1.16.0
+#   kernelspec:
+#     display_name: Python 3
+#     language: python
+#     name: python3
+# ---
+
+# %% [markdown]
+# # Learned priors — composing a flow onto a physical scaling
+#
+# A data-assimilation prior has to say which ocean states are plausible. A
+# Gaussian says "close to this mean, with this covariance"; a normalising flow
+# can say something much richer. But a flow trained directly on a dimensional
+# ocean state has to spend its capacity learning that thickness is measured in
+# hundreds of metres and velocity in tenths of a metre per second — facts we
+# already know.
+#
+# `somax.flows` lets you hand the flow that knowledge for free. A
+# `StateAffine` carries the physical scaling; the flow is composed on top and
+# learns only the departure from it.
+#
+# **Requires the optional extra:** `pip install somax[flows]`, or
+# `uv sync --extra flows`.
+#
+# **What you'll see:**
+#
+# 1. Building a `StateAffine` from characteristic `Scales`
+# 2. Adapting it to a flowjax bijection with `to_flowjax`
+# 3. Composing it with a flow into a prior over *physical* states
+# 4. Why the log-density picks up a constant from the scaling
+
+# %%
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.flatten_util import ravel_pytree
+
+from somax import Scales, StateAffine
+from somax._src.models.swm.nonlinear_2d import NonlinearSW2DState
+from somax.flows import learned_prior, to_flowjax
+
+
+# %% [markdown]
+# ## 1. A state and its physical scales
+#
+# A shallow-water state whose fields sit four orders of magnitude apart:
+# thickness around 1000 m, velocities around 0.1 m/s.
+
+# %%
+NY, NX = 8, 8
+rng = np.random.RandomState(0)
+
+scales = Scales.advective(L=1.0e6, U=0.1, f0=1.0e-4, H=1000.0)
+state = NonlinearSW2DState(
+    h=jnp.asarray(scales.H + rng.randn(NY, NX)),
+    u=jnp.asarray(0.1 * rng.randn(NY, NX)),
+    v=jnp.asarray(0.1 * rng.randn(NY, NX)),
+)
+
+print(f"h  ~ {float(jnp.mean(state.h)):.1f} m")
+print(f"u  ~ {float(jnp.std(state.u)):.3f} m/s")
+print(f"geostrophic height scale = {scales.eta:.3f} m")
+
+# %% [markdown]
+# ## 2. The transform, as a flowjax bijection
+#
+# `StateAffine` already exposes `transform_and_log_det`; `to_flowjax` wraps it
+# in the flat-array interface flowjax bijections use. The flat layout is the
+# same one `somax.da` uses, so a single vector feeds both a filter and a flow.
+
+# %%
+transform = StateAffine.from_scales(NonlinearSW2DState, scales)
+bijection = to_flowjax(transform, state)
+
+flat, unravel = ravel_pytree(state)
+standardised, log_det = bijection.transform_and_log_det(flat)
+
+print(f"flat state size      : {bijection.shape[0]}")
+print(f"standardised |h| max : {float(jnp.abs(unravel(standardised).h).max()):.2f}")
+print(f"log|det J|           : {float(log_det):.2f}")
+
+# %% [markdown]
+# The standardised state is O(1) in every field. The log-determinant is a
+# constant — the Jacobian of a fixed affine map does not depend on where you
+# evaluate it — and it is exactly what a density has to pick up when it is
+# pushed through the scaling.
+
+# %% [markdown]
+# ## 3. A prior over physical states
+#
+# `learned_prior` composes base → flow → *out of* standardised coordinates, so
+# the resulting distribution is over physical states while the flow itself
+# only ever sees O(1) numbers. Any flowjax bijection works as the flow; a
+# trained `masked_autoregressive_flow` is the realistic choice, and `Identity`
+# here keeps the arithmetic checkable by hand.
+
+# %%
+from flowjax.bijections import Identity
+from flowjax.distributions import Normal
+
+
+base = Normal(jnp.zeros(flat.size))
+prior = learned_prior(transform, state, Identity((flat.size,)), base)
+
+draws = jax.vmap(unravel)(prior.sample(jax.random.key(0), (2048,)))
+h_mean = float(jnp.mean(draws.h))
+u_spread = float(jnp.std(draws.u))
+print(f"sampled h mean   : {h_mean:.1f} m   (loc {transform.loc.h:.1f})")
+print(f"sampled u spread : {u_spread:.3f} m/s (scale {transform.scale.u:.3f})")
+
+# %% [markdown]
+# Samples come out in physical units with the right magnitudes, from a base
+# distribution that is standard normal. That is the scaling doing its job.
+
+# %% [markdown]
+# ## 4. The density, term by term
+#
+# For $\phi$ the standardising map,
+#
+# $$\log p_X(x) = \log p_Y(\phi(x)) + \log|\det J_\phi(x)|.$$
+#
+# With an identity flow both terms are computable directly, so the
+# composition can be checked rather than taken on trust.
+
+# %%
+lhs = float(prior.log_prob(flat))
+rhs = float(base.log_prob(standardised)) + float(log_det)
+print(f"prior.log_prob(x)              = {lhs:.4f}")
+print(f"log p_base(phi(x)) + log|det J| = {rhs:.4f}")
+assert np.isclose(lhs, rhs, rtol=1e-4)
+
+# %% [markdown]
+# ## Why flowjax is optional
+#
+# flowjax is not a core somax dependency. Its own `Affine` forces the scale
+# through a trainable softplus parameterisation, which is the opposite of what
+# a *fixed* physical scale wants, and it brings the whole flow stack with it.
+# The log-determinant only matters when transforming densities; everywhere
+# else in somax — the DA flatten bridge, `ScaledModel`, the nondimensional
+# factories — the affine map is used directly and no flow library is involved.

--- a/myst.yml
+++ b/myst.yml
@@ -18,6 +18,7 @@ project:
         - file: content/notes/basin_data_sources
         - file: content/notes/ecosystem_refactor_plan
         - file: content/notes/forcing_basis
+        - file: content/notes/nondimensional_runs
     - title: "Foundations (Phase 0)"
       children:
         - file: content/tutorials/arakawa_cgrid.ipynb
@@ -40,6 +41,7 @@ project:
         - file: content/tutorials/composable_models_terms_operators_cycles
         - file: content/tutorials/data_assimilation_etkf
         - file: content/tutorials/data_assimilation_4dvar
+        - file: content/tutorials/learned_prior_flowjax.ipynb
     - title: "Double Gyre Gallery"
       children:
         - file: content/tutorials/doublegyre_barotropic_qg.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ Repository = "https://github.com/jejjohnson/somax"
 [project.scripts]
 somax-sim = "somax._src.cli.app:main"
 
+[project.optional-dependencies]
+flows = [
+    "flowjax",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=9.0.3",

--- a/somax/_src/core/flows.py
+++ b/somax/_src/core/flows.py
@@ -1,0 +1,154 @@
+"""Bridge a fixed physical scaling into a flowjax normalising flow.
+
+Optional: requires the ``flows`` extra (``pip install somax[flows]``).
+
+:class:`~somax._src.core.transforms.StateAffine` already carries the
+``transform_and_log_det`` / ``inverse_and_log_det`` pair flowjax
+expects, but it acts on a ``State`` pytree while flowjax bijections act
+on flat arrays of a declared ``shape``. :func:`to_flowjax` closes that
+gap, so composing a learned flow onto a fixed physical scaling is a
+one-liner:
+
+    >>> bijection = Chain([flow, Invert(to_flowjax(transform, state))])
+    >>> prior = Transformed(base_distribution, bijection)
+
+flowjax is deliberately not a core dependency. Its own ``Affine``
+forces the scale through a trainable softplus parameterisation, which
+is the opposite of what a fixed physical scale wants, and the library
+brings the whole flow stack (masked autoregressive layers, splines, a
+training loop) along with it. The log-determinant only matters when
+transforming densities; everywhere else in somax the affine map is
+used directly.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+from jax.flatten_util import ravel_pytree
+from jaxtyping import Array, PyTree
+
+from somax._src.core.transforms import StateAffine
+
+
+try:  # pragma: no cover - exercised by the import-guard test
+    from flowjax.bijections import AbstractBijection
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "somax.flows requires flowjax, which is an optional dependency. "
+        "Install it with `pip install somax[flows]` (or "
+        "`uv sync --extra flows`)."
+    ) from exc
+
+
+class StateAffineBijection(AbstractBijection):
+    """A :class:`StateAffine` as a flat flowjax bijection.
+
+    Wraps the pytree transform in the flat-array interface flowjax
+    bijections use, flattening with the same ``ravel_pytree`` layout as
+    :func:`somax._src.da.flatten.state_to_vector`. That shared layout is
+    what lets one vector feed both a DA filter and a flow.
+
+    The map is fixed, not trainable: ``loc`` and ``scale`` come from
+    physical scales or sample statistics, and a flow composed on top
+    learns the departure from that scaling rather than relearning the
+    scaling itself.
+
+    Attributes:
+        state_transform: The underlying pytree affine map. Named so
+            rather than ``transform`` because ``AbstractBijection``
+            already defines a ``transform()`` method, and a field of
+            that name would shadow it.
+        shape: Flat shape, ``(n_elements,)``.
+        cond_shape: Always ``None`` — the map is unconditional.
+    """
+
+    state_transform: StateAffine
+    shape: tuple[int, ...]
+    cond_shape: tuple[int, ...] | None = None
+    unravel: Any = None
+
+    def __init__(self, transform: StateAffine, state_example: PyTree) -> None:
+        """Build from a transform and an example state.
+
+        Args:
+            transform: The affine map to wrap.
+            state_example: A state with the structure and shapes the
+                bijection will act on. Only its layout is used.
+        """
+        flat, unravel = ravel_pytree(state_example)
+        self.state_transform = transform
+        self.shape = (flat.size,)
+        self.cond_shape = None
+        self.unravel = unravel
+
+    def transform_and_log_det(
+        self, x: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        """Forward map on a flat vector, with the constant log-determinant."""
+        del condition
+        state = self.unravel(x)
+        transformed, log_det = self.state_transform.transform_and_log_det(state)
+        flat, _ = ravel_pytree(transformed)
+        return flat, jnp.asarray(log_det)
+
+    def inverse_and_log_det(
+        self, y: Array, condition: Array | None = None
+    ) -> tuple[Array, Array]:
+        """Inverse map on a flat vector, with the negated log-determinant."""
+        del condition
+        state = self.unravel(y)
+        inverted, log_det = self.state_transform.inverse_and_log_det(state)
+        flat, _ = ravel_pytree(inverted)
+        return flat, jnp.asarray(log_det)
+
+
+def to_flowjax(transform: StateAffine, state_example: PyTree) -> StateAffineBijection:
+    """Adapt a :class:`StateAffine` to the flowjax bijection interface.
+
+    Args:
+        transform: The pytree affine map to wrap.
+        state_example: A state carrying the structure and shapes the
+            bijection will act on.
+
+    Returns:
+        A flowjax-compatible bijection over flat vectors, using the same
+        layout as :func:`somax._src.da.flatten.state_to_vector`.
+    """
+    return StateAffineBijection(transform, state_example)
+
+
+def learned_prior(
+    transform: StateAffine,
+    state_example: PyTree,
+    flow: Any,
+    base: Any,
+) -> Any:
+    """Compose a fixed physical scaling with a learned flow into a prior.
+
+    The flow models the *standardised* state, and the scaling maps its
+    output back to physical units, so the flow learns only the
+    departure from the physical scaling rather than relearning the
+    scaling itself. The resulting log-density accounts for both, the
+    affine part contributing the constant ``-sum(n log scale)``.
+
+    A flowjax ``Transformed`` bijection runs base-to-data and a
+    ``Chain`` applies its first element first, so the affine goes last
+    and inverted: standardised coordinates are what the flow produces,
+    and physical coordinates are what the prior is over.
+
+    Args:
+        transform: The fixed affine scaling.
+        state_example: A state giving the flat layout.
+        flow: A flowjax bijection acting on the flat vector.
+        base: A flowjax distribution over the flat vector.
+
+    Returns:
+        A ``flowjax.distributions.Transformed`` over flat state vectors.
+    """
+    from flowjax.bijections import Chain, Invert
+    from flowjax.distributions import Transformed
+
+    to_physical = Invert(to_flowjax(transform, state_example))
+    return Transformed(base, Chain([flow, to_physical]))

--- a/somax/_src/core/flows.py
+++ b/somax/_src/core/flows.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 from typing import Any
 
 import jax.numpy as jnp
+import paramax
 from jax.flatten_util import ravel_pytree
 from jaxtyping import Array, PyTree
 
@@ -53,7 +54,12 @@ class StateAffineBijection(AbstractBijection):
     The map is fixed, not trainable: ``loc`` and ``scale`` come from
     physical scales or sample statistics, and a flow composed on top
     learns the departure from that scaling rather than relearning the
-    scaling itself.
+    scaling itself. That is enforced rather than merely intended — the
+    transform is held in a ``paramax.NonTrainable``, so when ``loc``
+    and ``scale`` are arrays (which they are for
+    :meth:`StateAffine.from_samples`, and for any array-valued field
+    override) flowjax's training path cannot drift the normalisation
+    along with the flow.
 
     Attributes:
         state_transform: The underlying pytree affine map. Named so
@@ -78,10 +84,15 @@ class StateAffineBijection(AbstractBijection):
                 bijection will act on. Only its layout is used.
         """
         flat, unravel = ravel_pytree(state_example)
-        self.state_transform = transform
+        self.state_transform = paramax.non_trainable(transform)
         self.shape = (flat.size,)
         self.cond_shape = None
         self.unravel = unravel
+
+    @property
+    def _map(self) -> StateAffine:
+        """The affine map, with its non-trainable wrapper removed."""
+        return paramax.unwrap(self.state_transform)
 
     def transform_and_log_det(
         self, x: Array, condition: Array | None = None
@@ -89,7 +100,7 @@ class StateAffineBijection(AbstractBijection):
         """Forward map on a flat vector, with the constant log-determinant."""
         del condition
         state = self.unravel(x)
-        transformed, log_det = self.state_transform.transform_and_log_det(state)
+        transformed, log_det = self._map.transform_and_log_det(state)
         flat, _ = ravel_pytree(transformed)
         return flat, jnp.asarray(log_det)
 
@@ -99,7 +110,7 @@ class StateAffineBijection(AbstractBijection):
         """Inverse map on a flat vector, with the negated log-determinant."""
         del condition
         state = self.unravel(y)
-        inverted, log_det = self.state_transform.inverse_and_log_det(state)
+        inverted, log_det = self._map.inverse_and_log_det(state)
         flat, _ = ravel_pytree(inverted)
         return flat, jnp.asarray(log_det)
 

--- a/somax/flows.py
+++ b/somax/flows.py
@@ -1,0 +1,25 @@
+"""Optional flowjax bridge — requires the ``flows`` extra.
+
+``pip install somax[flows]`` (or ``uv sync --extra flows``) pulls in
+flowjax; importing this module without it raises with that instruction
+rather than a bare ``ModuleNotFoundError`` naming a package the user
+never asked for.
+
+See :mod:`somax._src.core.flows` for what the bridge does and why
+flowjax is not a core dependency.
+"""
+
+from __future__ import annotations
+
+from somax._src.core.flows import (
+    StateAffineBijection,
+    learned_prior,
+    to_flowjax,
+)
+
+
+__all__ = [
+    "StateAffineBijection",
+    "learned_prior",
+    "to_flowjax",
+]

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -1,0 +1,240 @@
+"""Tests for the optional flowjax bridge.
+
+Skipped entirely when the ``flows`` extra is not installed, which is
+itself part of the contract: importing somax must not require flowjax.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.flatten_util import ravel_pytree
+
+from somax._src.core.scales import Scales
+from somax._src.core.transforms import StateAffine
+from somax._src.da.flatten import state_to_vector
+from somax._src.models.swm.nonlinear_2d import NonlinearSW2DState
+
+
+HAS_FLOWJAX = importlib.util.find_spec("flowjax") is not None
+
+pytestmark = pytest.mark.skipif(
+    not HAS_FLOWJAX, reason="requires the optional 'flows' extra (flowjax)"
+)
+
+NY, NX = 4, 5
+
+
+@pytest.fixture
+def scales():
+    return Scales.advective(L=1e6, U=0.1, f0=1e-4, H=1000.0)
+
+
+@pytest.fixture
+def state(scales):
+    rng = np.random.RandomState(0)
+    return NonlinearSW2DState(
+        h=jnp.asarray(scales.H + rng.randn(NY, NX)),
+        u=jnp.asarray(0.1 * rng.randn(NY, NX)),
+        v=jnp.asarray(0.1 * rng.randn(NY, NX)),
+    )
+
+
+@pytest.fixture
+def transform(scales):
+    return StateAffine.from_scales(NonlinearSW2DState, scales)
+
+
+@pytest.fixture
+def bijection(transform, state):
+    from somax.flows import to_flowjax
+
+    return to_flowjax(transform, state)
+
+
+class TestAdapter:
+    def test_shape_is_the_flat_state_size(self, bijection, state):
+        flat, _ = ravel_pytree(state)
+        assert bijection.shape == (flat.size,)
+
+    def test_is_unconditional(self, bijection):
+        assert bijection.cond_shape is None
+
+    def test_forward_matches_the_pytree_transform(self, bijection, transform, state):
+        flat, _ = ravel_pytree(state)
+        got, _ = bijection.transform_and_log_det(flat)
+        expected, _ = ravel_pytree(transform.forward(state))
+        np.testing.assert_allclose(got, expected, rtol=1e-6)
+
+    def test_log_det_matches_the_pytree_transform(self, bijection, transform, state):
+        flat, _ = ravel_pytree(state)
+        _, got = bijection.transform_and_log_det(flat)
+        assert float(got) == pytest.approx(float(transform.log_det(state)), rel=1e-6)
+
+    def test_round_trip(self, bijection, state):
+        flat, _ = ravel_pytree(state)
+        forward, _ = bijection.transform_and_log_det(flat)
+        back, _ = bijection.inverse_and_log_det(forward)
+        np.testing.assert_allclose(back, flat, rtol=1e-5)
+
+    def test_inverse_log_det_negates_forward(self, bijection, state):
+        flat, _ = ravel_pytree(state)
+        _, forward = bijection.transform_and_log_det(flat)
+        _, inverse = bijection.inverse_and_log_det(flat)
+        assert float(forward) == pytest.approx(-float(inverse), rel=1e-6)
+
+    def test_layout_matches_the_da_bridge(self, bijection, transform, state):
+        """One vector must feed both a DA filter and a flow."""
+        from_da, _ = state_to_vector(state, transform)
+        flat, _ = ravel_pytree(state)
+        from_flow, _ = bijection.transform_and_log_det(flat)
+        np.testing.assert_allclose(from_flow, from_da, rtol=1e-6)
+
+    def test_is_a_flowjax_bijection(self, bijection):
+        from flowjax.bijections import AbstractBijection
+
+        assert isinstance(bijection, AbstractBijection)
+
+    def test_flowjax_convenience_methods_work(self, bijection, transform, state):
+        """``transform`` / ``inverse`` come from the base class."""
+        flat, _ = ravel_pytree(state)
+        expected, _ = ravel_pytree(transform.forward(state))
+        np.testing.assert_allclose(bijection.transform(flat), expected, rtol=1e-6)
+
+    def test_usable_under_jit(self, bijection, state):
+        flat, _ = ravel_pytree(state)
+        jitted = jax.jit(bijection.transform_and_log_det)
+        got, _ = jitted(flat)
+        expected, _ = bijection.transform_and_log_det(flat)
+        np.testing.assert_allclose(got, expected, rtol=1e-6)
+
+
+class TestChaining:
+    def test_chaining_with_an_identity_flow_is_the_affine_alone(
+        self, bijection, transform, state
+    ):
+        from flowjax.bijections import Chain, Identity
+
+        flat, _ = ravel_pytree(state)
+        chained = Chain([bijection, Identity(bijection.shape)])
+        got, got_ld = chained.transform_and_log_det(flat)
+        expected, expected_ld = bijection.transform_and_log_det(flat)
+        np.testing.assert_allclose(got, expected, rtol=1e-6)
+        assert float(got_ld) == pytest.approx(float(expected_ld), rel=1e-6)
+
+    def test_chaining_accumulates_log_dets(self, bijection, state):
+        from flowjax.bijections import Affine, Chain
+
+        flat, _ = ravel_pytree(state)
+        doubling = Affine(
+            loc=jnp.zeros(bijection.shape), scale=jnp.full(bijection.shape, 2.0)
+        )
+        chained = Chain([bijection, doubling])
+        _, chained_ld = chained.transform_and_log_det(flat)
+        _, affine_ld = bijection.transform_and_log_det(flat)
+        _, doubling_ld = doubling.transform_and_log_det(flat)
+        assert float(chained_ld) == pytest.approx(
+            float(affine_ld) + float(doubling_ld), rel=1e-5
+        )
+
+
+class TestLearnedPrior:
+    def test_density_accounts_for_the_affine_jacobian(self, transform, state):
+        """log p_X(x) = log p_Y(phi(x)) + log|det J|."""
+        from flowjax.bijections import Identity
+        from flowjax.distributions import Normal
+
+        from somax.flows import learned_prior, to_flowjax
+
+        flat, _ = ravel_pytree(state)
+        base = Normal(jnp.zeros(flat.size))
+        prior = learned_prior(transform, state, Identity((flat.size,)), base)
+
+        bijection = to_flowjax(transform, state)
+        transformed, log_det = bijection.transform_and_log_det(flat)
+        expected = float(base.log_prob(transformed)) + float(log_det)
+        assert float(prior.log_prob(flat)) == pytest.approx(expected, rel=1e-4)
+
+    def test_prior_is_a_flowjax_distribution(self, transform, state):
+        from flowjax.bijections import Identity
+        from flowjax.distributions import AbstractDistribution, Normal
+
+        from somax.flows import learned_prior
+
+        flat, _ = ravel_pytree(state)
+        prior = learned_prior(
+            transform, state, Identity((flat.size,)), Normal(jnp.zeros(flat.size))
+        )
+        assert isinstance(prior, AbstractDistribution)
+
+    def test_sampling_lands_in_physical_magnitudes(self, transform, state):
+        """A standard-normal base maps back to states of the right size."""
+        from flowjax.bijections import Identity
+        from flowjax.distributions import Normal
+
+        from somax.flows import learned_prior
+
+        flat, unravel = ravel_pytree(state)
+        prior = learned_prior(
+            transform, state, Identity((flat.size,)), Normal(jnp.zeros(flat.size))
+        )
+        # The prior is over *physical* states already: the bijection
+        # maps the base through the flow and then back out of
+        # standardised coordinates, so a draw only needs unravelling.
+        draws = prior.sample(jax.random.key(0), (1024,))
+        physical = jax.vmap(unravel)(draws)
+        # h is centred on H with a spread of order the geostrophic scale.
+        assert float(jnp.mean(physical.h)) == pytest.approx(transform.loc.h, rel=0.2)
+        assert float(jnp.std(physical.u)) == pytest.approx(
+            float(transform.scale.u), rel=0.2
+        )
+
+
+class TestPackaging:
+    def test_importing_somax_does_not_require_flowjax(self):
+        """The core import path must stay free of the optional dep."""
+        import subprocess
+        import sys
+
+        code = (
+            "import sys\n"
+            "sys.modules['flowjax'] = None\n"
+            "import somax\n"
+            "assert 'somax' in sys.modules\n"
+            "print('ok')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=False
+        )
+        assert result.returncode == 0, result.stderr
+        assert "ok" in result.stdout
+
+    def test_public_module_exports_the_bridge(self):
+        import somax.flows as flows
+
+        assert set(flows.__all__) == {
+            "StateAffineBijection",
+            "learned_prior",
+            "to_flowjax",
+        }
+
+    def test_flows_extra_is_declared(self):
+        import tomllib
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        config = tomllib.loads(pyproject.read_text())
+        extras = config["project"]["optional-dependencies"]
+        assert any("flowjax" in dep for dep in extras["flows"])
+
+    def test_flowjax_is_not_a_core_dependency(self):
+        import tomllib
+        from pathlib import Path
+
+        pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
+        config = tomllib.loads(pyproject.read_text())
+        assert not any("flowjax" in dep for dep in config["project"]["dependencies"])

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 import importlib.util
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+import paramax
 import pytest
 from jax.flatten_util import ravel_pytree
 
@@ -238,3 +240,97 @@ class TestPackaging:
         pyproject = Path(__file__).resolve().parent.parent / "pyproject.toml"
         config = tomllib.loads(pyproject.read_text())
         assert not any("flowjax" in dep for dep in config["project"]["dependencies"])
+
+
+class TestTheAffineIsNotTrainable:
+    """The scaling must survive training the flow on top of it.
+
+    ``loc`` and ``scale`` are arrays whenever they come from
+    ``from_samples`` or an array-valued override. Left as ordinary
+    fields they are trainable leaves, so fitting the ``Transformed``
+    distribution would drift the physical normalisation along with the
+    learned flow — silently changing what the prior means.
+    """
+
+    def bijection(self):
+        from somax._src.core.flows import to_flowjax
+
+        rng = np.random.RandomState(0)
+        shape = (4, 4)
+        samples = NonlinearSW2DState(
+            h=jnp.asarray(100.0 + rng.randn(6, *shape)),
+            u=jnp.asarray(rng.randn(6, *shape)),
+            v=jnp.asarray(rng.randn(6, *shape)),
+        )
+        transform = StateAffine.from_samples(samples, per_gridpoint=True)
+        example = jax.tree_util.tree_map(lambda leaf: leaf[0], samples)
+        return to_flowjax(transform, example)
+
+    def test_the_statistics_really_are_arrays(self):
+        """Otherwise there would be nothing for an optimiser to move."""
+        bijection = self.bijection()
+        loc = paramax.unwrap(bijection.state_transform).loc
+        assert jnp.ndim(loc.h) > 0
+
+    def test_every_statistic_leaf_is_wrapped_non_trainable(self):
+        """``paramax.non_trainable`` wraps the leaves, not the module."""
+        leaves = jax.tree_util.tree_leaves(
+            self.bijection().state_transform,
+            is_leaf=lambda x: isinstance(x, paramax.NonTrainable),
+        )
+        assert leaves
+        assert all(isinstance(leaf, paramax.NonTrainable) for leaf in leaves)
+
+    def test_its_gradients_are_exactly_zero(self):
+        bijection = self.bijection()
+
+        def loss(bij):
+            bij = paramax.unwrap(bij)
+            return jnp.sum(bij.transform_and_log_det(jnp.ones(bij.shape))[0] ** 2)
+
+        grads = eqx.filter_grad(loss)(bijection)
+        leaves = jax.tree_util.tree_leaves(eqx.filter(grads, eqx.is_inexact_array))
+        assert leaves
+        assert all(float(jnp.abs(leaf).max()) == 0.0 for leaf in leaves)
+
+    def test_the_map_still_works(self):
+        """Wrapping must not change what the bijection computes."""
+        bijection = self.bijection()
+        x = jnp.linspace(-1.0, 1.0, bijection.shape[0])
+        y, _ = bijection.transform_and_log_det(x)
+        back, _ = bijection.inverse_and_log_det(y)
+        np.testing.assert_allclose(np.asarray(back), np.asarray(x), atol=1e-4)
+
+    def test_the_log_determinant_is_unchanged(self):
+        bijection = self.bijection()
+        x = jnp.zeros(bijection.shape)
+        _, forward = bijection.transform_and_log_det(x)
+        y, _ = bijection.transform_and_log_det(x)
+        _, inverse = bijection.inverse_and_log_det(y)
+        assert float(forward) == pytest.approx(-float(inverse), rel=1e-5)
+
+
+class TestOptionalExtraIsExercisedInCi:
+    """These tests must actually run somewhere.
+
+    The module-level marker skips every one of them when flowjax is
+    absent, so a CI job that does not install the extra would stay
+    green while the bridge rots.
+    """
+
+    def workflows(self):
+        from pathlib import Path
+
+        root = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+        return [root / "ci.yml", root / "full-tests.yml"]
+
+    def test_the_workflows_exist(self):
+        for path in self.workflows():
+            assert path.exists(), path
+
+    def test_every_test_job_installs_the_flows_extra(self):
+        for path in self.workflows():
+            text = path.read_text()
+            for line in text.splitlines():
+                if "uv sync" in line and "--group dev" in line:
+                    assert "--extra flows" in line, f"{path.name}: {line.strip()}"


### PR DESCRIPTION
Closes #178. Stacked on #186 (epic #170). Marked optional in the epic — reasonable to defer or close unmerged if the extra is not wanted.

## What this adds

A `flows` extra that adapts a `StateAffine` to the flowjax bijection interface, so a normalising flow can be composed onto a fixed physical scaling instead of relearning it.

`StateAffine` already carries `transform_and_log_det` (shipped in #180 for exactly this); the adapter supplies the flat-array shape flowjax wants, flattening with the same `ravel_pytree` layout the DA bridge uses so one vector feeds both a filter and a flow.

## Two things the first pass got wrong

Both caught by tests, both worth knowing about:

**The wrapped transform is stored as `state_transform`.** `AbstractBijection` already defines a `transform()` method, and a field of that name shadows it — `bijection.transform(x)` failed until it was renamed.

**`learned_prior` composes `Chain([flow, Invert(affine)])`.** A flowjax `Transformed` bijection runs base-to-data and `Chain` applies its first element *first*, so the affine goes last and inverted. Composed the other way the prior samples came out at roughly twice the mean thickness. A test now checks the density term by term against `log p_Y(phi(x)) + log|det J|` rather than trusting the composition.

## Why flowjax stays optional

Its own `Affine` forces the scale through a trainable softplus parameterisation, which is the opposite of what a *fixed* physical scale wants, and it brings the whole flow stack along. The log-determinant only matters when transforming densities; every other use of the affine map in somax needs no flow library.

Tests assert importing somax works with flowjax unavailable, and that flowjax is absent from the core dependency list.

## Testing

19 new tests, skipped entirely when the extra is not installed. `content/tutorials/learned_prior_flowjax.py` works the whole thing through and runs end to end. Full suite 1095 → 1114 passing with the extra installed; lint, format and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg)_