### PR TITLE
feat(models): from_nondimensional for the spherical models

### DIFF
--- a/content/notes/nondimensional_runs.md
+++ b/content/notes/nondimensional_runs.md
@@ -45,6 +45,66 @@ Because a nondimensional run has no SI units to report,
 `field_units("nondim")` marks every field `-` in the run log, so the
 numbers do not read as unlabelled SI values.
 
+## Spherical models
+
+Spherical models use the **planetary** scale set: the planet radius is
+the length scale and the rotation period the time scale, so
+`a = Omega = H = 1`, `T = 1` and `f0 = 2 Omega = 2`.
+
+That factor of two is the one thing worth remembering. On a sphere
+`f(phi) = 2 Omega sin(phi)`, so `2 Omega` is what plays the role of a
+Cartesian `f0`, and the Rossby number keeps its usual `U/(f0 L)`
+meaning — the conventional spherical `U/(2 Omega a)`. Every rate
+coefficient therefore picks up a `2`: `bottom_drag = 2 * ekman`,
+`lateral_viscosity = 2 * ekman_lateral`.
+
+Stratification can be given as `burger`, `froude` or `lamb`, and
+exactly one of the three. `lamb` is the Lamb parameter
+`eps = 4 Omega^2 a^2 / (gH)`, the inverse Burger number and the usual
+spelling in the spherical literature.
+
+```yaml
+scenario:
+  name: global_ocean
+  grid: {nx: 128, ny: 64, lon_bounds: [0.0, 360.0], lat_bounds: [-80.0, 80.0]}
+  nondim:
+    rossby: 0.05
+    lamb: 10.0      # or burger: 0.1 — the same thing inverted
+    ekman: 0.01
+  forcing: {wind_profile: zonal}
+  initial_condition: {type: at_rest}
+
+model:
+  name: spherical_swm
+```
+
+`spherical_qg` takes no `lamb`/`burger`: barotropic QG is rigid-lid, so
+it has no gravity wave. Neither takes a `beta_hat` — on a sphere the
+planetary vorticity gradient is fixed by the geometry,
+`beta = 2 Omega cos(phi)/a`, rather than being a free number.
+
+The lat/lon bounds stay in degrees. They are a geometric choice, not a
+scale: a nondimensional sphere is still a sphere.
+
+### The equatorial deformation radius
+
+The mid-latitude radius `sqrt(gH)/f0` diverges at the equator, where
+`f` vanishes, so `deformation_radius` says nothing useful about a
+global run. The finite scale that replaces it is the equatorial
+deformation radius
+
+```
+L_eq = sqrt(c / beta_eq),  c = sqrt(gH),  beta_eq = 2 Omega / a
+```
+
+the trapping width of the equatorial waveguide — which in Burger terms
+is simply `L_eq/a = Bu^(1/4)`. `SphericalSWM.from_nondimensional` runs
+the `equatorial_deformation_radius` guard by default and raises if the
+grid cannot span it; pass `check_resolution=False` to build a
+deliberately coarse model. The guard compares against the *widest*
+interior cell, since zonal cells are widest at the equator, which is
+exactly where the waveguide sits.
+
 ## Data assimilation
 
 `state_to_vector` and `make_ensemble` both take an optional

--- a/somax/_src/cli/_assertions.py
+++ b/somax/_src/cli/_assertions.py
@@ -219,6 +219,130 @@ def check_deformation_radius(
         )
 
 
+def check_equatorial_deformation_radius(
+    spec: RunSpec | None,
+    model: Any,
+    *,
+    n_cells_min: float = 2.0,
+    n_cells_warn: float = 4.0,
+) -> None:
+    """Pre-flight: the equatorial deformation radius is resolved.
+
+    On a sphere the Coriolis parameter vanishes at the equator, so the
+    mid-latitude radius ``sqrt(gH)/f0`` diverges there and says nothing
+    useful. The finite scale that replaces it is the *equatorial*
+    deformation radius
+
+    ``L_eq = sqrt(c / beta_eq)``,  ``c = sqrt(g H)``,
+    ``beta_eq = 2 Omega / a``,
+
+    which is the trapping width of the equatorial waveguide — Kelvin,
+    Yanai and equatorial Rossby waves all live inside it. A grid that
+    cannot span it does not have an equatorial waveguide at all.
+
+    In terms of the Burger number ``Bu = gH/(2 Omega a)**2`` this is
+    just ``L_eq/a = Bu**(1/4)``, so the check is scale-free and reads
+    the same on a nondimensional sphere as on Earth.
+
+    The comparison uses the *widest* interior cell rather than the
+    narrowest. Zonal cells are widest at the equator, which is exactly
+    where the waveguide sits, so the coarsest cell is the one that has
+    to resolve it.
+
+    Requires a spherical shallow-water-shaped model exposing
+    ``consts.gravity``, ``consts.H0``, ``consts.omega``,
+    ``consts.radius`` and a spherical ``grid``. Raises for models
+    without that structure so a typo'd config doesn't silently skip the
+    check. Barotropic spherical QG is rigid-lid and has no gravity
+    wave, so it is rejected rather than checked.
+
+    Args:
+        spec: The validated RunSpec (unused; present for registry
+            signature symmetry, and ``None`` when called from a
+            ``from_nondimensional`` factory).
+        model: The constructed model instance.
+        n_cells_min: ``L_eq/dx`` below which to FAIL.
+        n_cells_warn: ``L_eq/dx`` below which to WARN.
+
+    Raises:
+        AssertionFailedError: If the model is not a spherical
+            shallow-water model, if a required constant is
+            non-positive, or if the waveguide is unresolved.
+    """
+    del spec
+    consts = getattr(model, "consts", None)
+    grid = getattr(model, "grid", None)
+    if consts is None or grid is None:
+        raise AssertionFailedError(
+            f"equatorial_deformation_radius: model {type(model).__name__!r} "
+            f"lacks consts/grid; this check applies to spherical "
+            f"shallow-water models."
+        )
+    missing = [
+        name
+        for name in ("gravity", "H0", "omega", "radius")
+        if getattr(consts, name, None) is None
+    ]
+    if missing or getattr(grid, "cos_lat_T", None) is None:
+        raise AssertionFailedError(
+            f"equatorial_deformation_radius: model {type(model).__name__!r} "
+            f"does not expose consts.gravity / H0 / omega / radius on a "
+            f"spherical grid (missing {missing or ['grid.cos_lat_T']}); "
+            f"cannot compute L_eq. Barotropic QG is rigid-lid and has no "
+            f"gravity-wave deformation radius — drop this check for it."
+        )
+    g = float(consts.gravity)
+    depth = float(consts.H0)
+    omega = abs(float(consts.omega))
+    radius = float(consts.radius)
+    for name, value in (("gravity", g), ("H0", depth), ("omega", omega)):
+        if value <= 0.0:
+            raise AssertionFailedError(
+                f"equatorial_deformation_radius: consts.{name} is "
+                f"{value:.4g}; L_eq is undefined without a gravity wave and "
+                f"a rotating planet."
+            )
+    wave_speed = np.sqrt(g * depth)
+    beta_eq = 2.0 * omega / radius
+    Leq = float(np.sqrt(wave_speed / beta_eq))
+
+    dx_max = _max_spherical_cell_width(grid)
+    ratio = Leq / dx_max
+    if ratio < n_cells_min:
+        raise AssertionFailedError(
+            f"equatorial_deformation_radius check FAILED: L_eq/dx = "
+            f"{ratio:.2f} < {n_cells_min}\n"
+            f"  L_eq = {Leq:.4g} (= sqrt(c/beta_eq), c={wave_speed:.4g}, "
+            f"beta_eq={beta_eq:.4g})\n"
+            f"  dx   = {dx_max:.4g} (widest interior cell)\n"
+            f"  → the equatorial waveguide is unresolved; refine the grid "
+            f"or raise the equivalent depth."
+        )
+    if ratio < n_cells_warn:
+        logger.warning(
+            "equatorial deformation radius marginally resolved: "
+            "L_eq/dx = {:.2f} (L_eq={:.4g}, dx={:.4g})",
+            ratio,
+            Leq,
+            dx_max,
+        )
+
+
+def _max_spherical_cell_width(grid: Any) -> float:
+    """Widest interior cell of a spherical grid, in metres.
+
+    Computed here rather than read off ``grid.max_cell_width``: that
+    helper arrives with finitevolX#244 and somax still pins v0.0.41.
+    The cosine is clamped at zero because in float32 ``cos(pi/2)`` is a
+    small *negative* number, which would otherwise flip the sign of a
+    polar cell width.
+    """
+    cos_lat = np.asarray(jnp.asarray(grid.cos_lat_T))[1:-1, 1:-1]
+    dx = float(np.max(np.maximum(cos_lat, 0.0))) * float(grid.R) * float(grid.dlon)
+    dy = float(grid.R) * float(grid.dlat)
+    return max(dx, dy)
+
+
 def check_pv_inversion(
     spec: RunSpec,
     model: Any,
@@ -498,6 +622,7 @@ def check_stommel_width(
 PREFLIGHT_ASSERTIONS: dict[str, Callable[..., None]] = {
     "cfl": check_cfl,
     "deformation_radius": check_deformation_radius,
+    "equatorial_deformation_radius": check_equatorial_deformation_radius,
     "munk_width": check_munk_width,
     "pv_inversion": check_pv_inversion,
     "stommel_width": check_stommel_width,

--- a/somax/_src/cli/models_registry/spherical_qg.py
+++ b/somax/_src/cli/models_registry/spherical_qg.py
@@ -45,6 +45,58 @@ def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
     return BuiltModel(model=model, state0=state0)
 
 
+#: YAML keys accepted in a ``scenario.nondim`` block. There is no
+#: ``burger``: barotropic QG is rigid-lid, and no ``beta_hat``: on a
+#: sphere the planetary vorticity gradient follows from the geometry.
+_NONDIM_KEYS = {
+    "rossby": "rossby",
+    "ekman": "ekman",
+    "ekman_lateral": "ekman_lateral",
+    "wind_hat": "wind_hat",
+}
+
+
+def _build_nondimensional(
+    scenario: ScenarioBundle, nondim: dict[str, Any]
+) -> BuiltModel:
+    """Build from a ``scenario.nondim`` block instead of SI constants."""
+    from somax.models import SphericalQG, SphericalQGState
+
+    lon_bounds, lat_bounds = _require_spherical(scenario, "spherical_qg")
+    unknown = sorted(set(nondim) - set(_NONDIM_KEYS))
+    if unknown:
+        raise ValueError(
+            f"spherical_qg: unknown scenario.nondim key(s) {unknown}. "
+            f"Accepted: {sorted(_NONDIM_KEYS)}."
+        )
+    if "rossby" not in nondim:
+        raise ValueError(
+            "spherical_qg: scenario.nondim requires 'rossby'; it has no "
+            "sensible default."
+        )
+
+    kwargs = {_NONDIM_KEYS[key]: value for key, value in nondim.items()}
+    geometry = scenario.geometry
+    model, _ = SphericalQG.from_nondimensional(
+        nx=geometry.nx,
+        ny=geometry.ny,
+        lon_range=lon_bounds,
+        lat_range=lat_bounds,
+        wind_profile=str(scenario.forcing_params.get("wind_profile", "zonal")),
+        mask=geometry.mask,
+        **kwargs,
+    )
+
+    ic = scenario.initial_condition
+    if ic.type != "at_rest":
+        raise NotImplementedError(
+            f"spherical_qg: initial_condition.type={ic.type!r} not supported "
+            "for a nondimensional build (only 'at_rest')."
+        )
+    state0 = SphericalQGState(q=jnp.zeros((model.grid.Ny, model.grid.Nx)))
+    return BuiltModel(model=model, state0=state0)
+
+
 SPHERICAL_QG = ModelEntry(
     name="spherical_qg",
     family="qg",
@@ -52,4 +104,5 @@ SPHERICAL_QG = ModelEntry(
     coordinates="spherical",
     supports=SupportFlags(masks=True, spherical=True, forcing=("tau_x", "tau_y")),
     build=_build,
+    from_nondimensional=_build_nondimensional,
 )

--- a/somax/_src/cli/models_registry/spherical_swm.py
+++ b/somax/_src/cli/models_registry/spherical_swm.py
@@ -62,6 +62,72 @@ def _build(scenario: ScenarioBundle, params: dict[str, Any]) -> BuiltModel:
     return BuiltModel(model=model, state0=state0)
 
 
+#: YAML keys accepted in a ``scenario.nondim`` block, mapped to the
+#: factory's argument names. They match the factory one-for-one; the
+#: mapping exists so an unknown key is rejected by name.
+_NONDIM_KEYS = {
+    "rossby": "rossby",
+    "burger": "burger",
+    "froude": "froude",
+    "lamb": "lamb",
+    "ekman": "ekman",
+    "ekman_lateral": "ekman_lateral",
+    "wind_hat": "wind_hat",
+    "check_resolution": "check_resolution",
+}
+
+
+def _build_nondimensional(
+    scenario: ScenarioBundle, nondim: dict[str, Any]
+) -> BuiltModel:
+    """Build from a ``scenario.nondim`` block instead of SI constants."""
+    from somax.models import SphericalSWM, SphericalSWMState
+
+    lon_bounds, lat_bounds = _require_spherical(scenario, "spherical_swm")
+    unknown = sorted(set(nondim) - set(_NONDIM_KEYS))
+    if unknown:
+        raise ValueError(
+            f"spherical_swm: unknown scenario.nondim key(s) {unknown}. "
+            f"Accepted: {sorted(_NONDIM_KEYS)}."
+        )
+    if "rossby" not in nondim:
+        raise ValueError(
+            "spherical_swm: scenario.nondim requires 'rossby'; it has no "
+            "sensible default."
+        )
+    if not {"burger", "froude", "lamb"} & set(nondim):
+        raise ValueError(
+            "spherical_swm: scenario.nondim requires exactly one of "
+            "'burger', 'froude' or 'lamb' to set the stratification."
+        )
+
+    kwargs = {_NONDIM_KEYS[key]: value for key, value in nondim.items()}
+    geometry = scenario.geometry
+    model, _ = SphericalSWM.from_nondimensional(
+        nx=geometry.nx,
+        ny=geometry.ny,
+        lon_range=lon_bounds,
+        lat_range=lat_bounds,
+        wind_profile=str(scenario.forcing_params.get("wind_profile", "zonal")),
+        mask=geometry.mask,
+        **kwargs,
+    )
+
+    ic = scenario.initial_condition
+    if ic.type != "at_rest":
+        raise NotImplementedError(
+            f"spherical_swm: initial_condition.type={ic.type!r} not supported "
+            "for a nondimensional build (only 'at_rest')."
+        )
+    shape = (model.grid.Ny, model.grid.Nx)
+    state0 = SphericalSWMState(
+        h=jnp.full(shape, model.consts.H0),
+        u=jnp.zeros(shape),
+        v=jnp.zeros(shape),
+    )
+    return BuiltModel(model=model, state0=state0)
+
+
 SPHERICAL_SWM = ModelEntry(
     name="spherical_swm",
     family="swm",
@@ -69,4 +135,5 @@ SPHERICAL_SWM = ModelEntry(
     coordinates="spherical",
     supports=SupportFlags(masks=True, spherical=True, forcing=("tau_x", "tau_y")),
     build=_build,
+    from_nondimensional=_build_nondimensional,
 )

--- a/somax/_src/models/_nondim.py
+++ b/somax/_src/models/_nondim.py
@@ -83,7 +83,7 @@ def resolve_burger(
         )
     if froude is not None:
         require_positive(context, froude=froude)
-        return (rossby / froude) ** 2
+        return float((rossby / froude) ** 2)
     require_positive(context, burger=burger)
     return float(burger)
 
@@ -128,3 +128,50 @@ def burger_to_g_prime(
     return tuple(
         float(bu) * factor / float(h) for bu, h in zip(burger, thickness, strict=True)
     )
+
+
+def resolve_burger_spherical(
+    context: str,
+    burger: float | None,
+    froude: float | None,
+    lamb: float | None,
+    rossby: float,
+) -> float:
+    """Settle the Burger number from ``burger``, ``froude`` or ``lamb``.
+
+    The spherical literature states the stratification as the Lamb
+    parameter ``eps = 4 Omega**2 a**2 / (g H)``, which is exactly the
+    inverse Burger number. Accepting it alongside the two Cartesian
+    spellings keeps spherical configs idiomatic without introducing a
+    second, independent quantity — so exactly one of the three may be
+    given.
+
+    Args:
+        context: Caller name, for error messages.
+        burger: Burger number ``Bu = gH/(f0 a)**2``, or ``None``.
+        froude: Froude number ``U/sqrt(gH)``, or ``None``.
+        lamb: Lamb parameter ``eps = 1/Bu``, or ``None``.
+        rossby: Rossby number, already validated.
+
+    Returns:
+        The Burger number.
+
+    Raises:
+        ValueError: If not exactly one of the three is supplied, or the
+            value is not positive.
+    """
+    given = [
+        name
+        for name, value in (("burger", burger), ("froude", froude), ("lamb", lamb))
+        if value is not None
+    ]
+    if len(given) != 1:
+        raise ValueError(
+            f"{context}: give exactly one of burger, froude or lamb; got "
+            f"{given or 'none'}. They are not independent — Bu = (Ro/Fr)**2 "
+            f"at fixed Ro, and lamb = 1/Bu."
+        )
+    if lamb is not None:
+        require_positive(context, lamb=lamb)
+        return 1.0 / float(lamb)
+    return resolve_burger(context, burger, froude, rossby)

--- a/somax/_src/models/spherical/qg.py
+++ b/somax/_src/models/spherical/qg.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -19,7 +21,9 @@ from finitevolx._src.utils.constants import OMEGA, R_EARTH
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
+from somax._src.models._nondim import require_non_negative, require_positive
 
 
 class SphericalQGState(State):
@@ -281,6 +285,102 @@ class SphericalQG(SomaxModel):
             streamfunction=psi,
             relative_vorticity=q,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 128,
+        ny: int = 64,
+        rossby: float,
+        ekman: float = 0.0,
+        ekman_lateral: float = 0.0,
+        wind_hat: float = 0.0,
+        lat_range: tuple[float, float] = (-80.0, 80.0),
+        lon_range: tuple[float, float] = (0.0, 360.0),
+        **create_kw: Any,
+    ) -> tuple[SphericalQG, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **planetary** (:meth:`somax.Scales.planetary`), with
+        ``a = Omega = 1``, so ``T = 1/Omega = 1``, ``f0 = 2 Omega = 2``
+        and ``U = 2 Omega a Ro = 2 Ro``. The vorticity the state
+        carries is then ``O(U/a) = O(2 Ro)``.
+
+        ==================  ==================================  ====================
+        Input               Definition                          ``create()`` kwarg
+        ==================  ==================================  ====================
+        ``rossby``          :math:`Ro = U/(2\Omega a)`           sets ``U``
+        ``ekman``           :math:`\kappa/(2\Omega)`             ``bottom_drag``
+        ``ekman_lateral``   :math:`\nu/(2\Omega a^2)`            ``lateral_viscosity``
+        ``wind_hat``        :math:`a\tau_0/(2\Omega U)`          ``wind_amplitude``
+        ==================  ==================================  ====================
+
+        There is no Burger number here and no ``g``: the barotropic QG
+        model is rigid-lid, so it has no gravity wave and no
+        deformation radius to resolve. The stratification knobs belong
+        to :class:`SphericalSWM`.
+
+        Neither is there a ``beta_hat``. On a sphere the planetary
+        vorticity gradient is fixed by the geometry —
+        ``beta = 2 Omega cos(phi)/a``, which is ``cos(phi)`` in these
+        units — so it is not a free dimensionless number the way it is
+        on a beta plane.
+
+        Args:
+            nx: Interior cells in longitude.
+            ny: Interior cells in latitude.
+            rossby: Rossby number; sets the velocity scale.
+            ekman: Linear bottom-drag Ekman number.
+            ekman_lateral: Lateral-viscosity Ekman number.
+            wind_hat: Dimensionless wind-stress-curl amplitude.
+            lat_range: ``(lat_min, lat_max)`` in degrees.
+            lon_range: ``(lon_min, lon_max)`` in degrees.
+            **create_kw: Forwarded to :meth:`create` (``wind_profile``,
+                ``method``, ``mask``, ``cg_tol``, ``cg_max_steps``).
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "planetary"``.
+
+        Raises:
+            ValueError: If a dimensionless input is out of range.
+
+        Example:
+            >>> model, scales = SphericalQG.from_nondimensional(
+            ...     nx=64, ny=32, rossby=0.05, ekman=0.01,
+            ... )
+            >>> scales.kind
+            'planetary'
+        """
+        context = "SphericalQG.from_nondimensional"
+        require_positive(context, rossby=rossby)
+        require_non_negative(
+            context,
+            ekman=ekman,
+            ekman_lateral=ekman_lateral,
+            wind_hat=wind_hat,
+        )
+
+        # Unit scales: a = Omega = 1, so f0 = 2 and U = 2 Ro. The wind
+        # enters as a vorticity tendency, so it carries f0 * U/a rather
+        # than the f0 * U of a momentum forcing.
+        f0 = 2.0
+        vorticity_scale = f0 * rossby  # = U / a
+        model = SphericalQG.create(
+            nx=nx,
+            ny=ny,
+            lon_range=lon_range,
+            lat_range=lat_range,
+            radius=1.0,
+            omega=1.0,
+            lateral_viscosity=f0 * ekman_lateral,
+            bottom_drag=f0 * ekman,
+            wind_amplitude=wind_hat * f0 * vorticity_scale,
+            **create_kw,
+        )
+        scales = Scales.planetary(a=1.0, Omega=1.0, H=1.0, rossby=rossby)
+        return model, scales
 
     @staticmethod
     def create(

--- a/somax/_src/models/spherical/swm.py
+++ b/somax/_src/models/spherical/swm.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import equinox as eqx
 import jax.numpy as jnp
 from finitevolx import (
@@ -19,7 +21,13 @@ from finitevolx._src.utils.constants import OMEGA, R_EARTH
 from jaxtyping import Array, Float, PyTree
 
 from somax._src.core.model import SomaxModel
+from somax._src.core.scales import Scales
 from somax._src.core.types import Diagnostics, Params, PhysConsts, State
+from somax._src.models._nondim import (
+    require_non_negative,
+    require_positive,
+    resolve_burger_spherical,
+)
 
 
 class SphericalSWMState(State):
@@ -275,6 +283,134 @@ class SphericalSWM(SomaxModel):
             relative_vorticity=zeta,
             kinetic_energy_field=ke,
         )
+
+    @staticmethod
+    def from_nondimensional(
+        *,
+        nx: int = 128,
+        ny: int = 64,
+        rossby: float,
+        burger: float | None = None,
+        froude: float | None = None,
+        lamb: float | None = None,
+        ekman: float = 0.0,
+        ekman_lateral: float = 0.0,
+        wind_hat: float = 0.0,
+        lat_range: tuple[float, float] = (-80.0, 80.0),
+        lon_range: tuple[float, float] = (0.0, 360.0),
+        check_resolution: bool = True,
+        **create_kw: Any,
+    ) -> tuple[SphericalSWM, Scales]:
+        r"""Build the model from dimensionless numbers instead of SI coefficients.
+
+        Non-dimensional form
+        --------------------
+        Scale set: **planetary** (:meth:`somax.Scales.planetary`), with
+        ``a = Omega = H = 1``. The planet radius is the length scale and
+        the rotation period the time scale, so ``T = 1/Omega = 1`` and
+        ``f0 = 2 Omega = 2``; the velocity scale follows from the Rossby
+        number as ``U = 2 Omega a Ro = 2 Ro``.
+
+        The factor of two is not cosmetic. On a sphere the Coriolis
+        parameter is ``f(phi) = 2 Omega sin(phi)``, so the quantity that
+        plays the role of a Cartesian ``f0`` is ``2 Omega``, and the
+        conventional spherical Rossby number is ``U/(2 Omega a)``.
+        Writing it that way keeps :attr:`Scales.rossby` the same
+        ``U/(f0 L)`` it is for every other family, at the cost of the
+        twos that appear in the table below.
+
+        ==================  ==================================  ====================
+        Input               Definition                          ``create()`` kwarg
+        ==================  ==================================  ====================
+        ``rossby``          :math:`Ro = U/(2\Omega a)`           sets ``U``
+        ``burger``          :math:`Bu = gH/(2\Omega a)^2`        ``g = 4Bu``
+        ``froude``          :math:`Fr = U/\sqrt{gH}`             ``g`` (via ``Bu``)
+        ``lamb``            :math:`\varepsilon = 1/Bu`           ``g = 4/\varepsilon``
+        ``ekman``           :math:`\kappa/(2\Omega)`             ``bottom_drag``
+        ``ekman_lateral``   :math:`\nu/(2\Omega a^2)`            ``lateral_viscosity``
+        ``wind_hat``        :math:`\tau_0/(2\Omega U)`           ``wind_amplitude``
+        ==================  ==================================  ====================
+
+        The latitude range stays in degrees: it is a geometric choice,
+        not a scale, and a nondimensional sphere is still a sphere.
+
+        Args:
+            nx: Interior cells in longitude.
+            ny: Interior cells in latitude.
+            rossby: Rossby number; sets the velocity scale.
+            burger: Burger number. Give exactly one of this,
+                ``froude`` or ``lamb``.
+            froude: Froude number. Equivalent through
+                ``Bu = (Ro/Fr)**2``.
+            lamb: Lamb parameter ``eps = 4 Omega**2 a**2/(gH)``, the
+                inverse Burger number and the usual spelling in the
+                spherical literature.
+            ekman: Linear bottom-drag Ekman number.
+            ekman_lateral: Lateral-viscosity Ekman number.
+            wind_hat: Dimensionless wind acceleration.
+            lat_range: ``(lat_min, lat_max)`` in degrees.
+            lon_range: ``(lon_min, lon_max)`` in degrees.
+            check_resolution: Run the equatorial-deformation-radius
+                guard and raise if the grid cannot span it. Set
+                ``False`` only to build a deliberately coarse model.
+            **create_kw: Forwarded to :meth:`create` (``wind_profile``,
+                ``method``, ``mask``).
+
+        Returns:
+            ``(model, scales)`` with ``scales.kind == "planetary"``.
+
+        Raises:
+            ValueError: If an input is out of range, or if not exactly
+                one of ``burger``, ``froude`` and ``lamb`` is given.
+            AssertionFailedError: If ``check_resolution`` is set and the
+                equatorial deformation radius is unresolved.
+
+        Example:
+            >>> model, scales = SphericalSWM.from_nondimensional(
+            ...     nx=128, ny=64, rossby=0.05, lamb=10.0,
+            ... )
+            >>> scales.kind
+            'planetary'
+        """
+        context = "SphericalSWM.from_nondimensional"
+        require_positive(context, rossby=rossby)
+        require_non_negative(
+            context,
+            ekman=ekman,
+            ekman_lateral=ekman_lateral,
+            wind_hat=wind_hat,
+        )
+        bu = resolve_burger_spherical(context, burger, froude, lamb, rossby)
+
+        # Unit scales: a = Omega = H0 = 1, so f0 = 2 and U = 2 Ro. Rate
+        # coefficients carry one factor of f0; the wind is an
+        # acceleration and so carries f0 * U.
+        f0 = 2.0
+        velocity = f0 * rossby
+        model = SphericalSWM.create(
+            nx=nx,
+            ny=ny,
+            lon_range=lon_range,
+            lat_range=lat_range,
+            radius=1.0,
+            omega=1.0,
+            g=f0**2 * bu,
+            H0=1.0,
+            lateral_viscosity=f0 * ekman_lateral,
+            bottom_drag=f0 * ekman,
+            wind_amplitude=wind_hat * f0 * velocity,
+            **create_kw,
+        )
+        scales = Scales.planetary(a=1.0, Omega=1.0, H=1.0, rossby=rossby, g=f0**2 * bu)
+
+        if check_resolution:
+            from somax._src.cli._assertions import (
+                check_equatorial_deformation_radius,
+            )
+
+            check_equatorial_deformation_radius(None, model)
+
+        return model, scales
 
     @staticmethod
     def create(

--- a/tests/models/test_spherical_nondim.py
+++ b/tests/models/test_spherical_nondim.py
@@ -1,0 +1,433 @@
+"""Tests for the spherical ``from_nondimensional`` factories (#177)."""
+
+from __future__ import annotations
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from somax._src.cli._assertions import (
+    AssertionFailedError,
+    check_equatorial_deformation_radius,
+)
+from somax._src.models.spherical import (
+    SphericalQG,
+    SphericalQGState,
+    SphericalSWM,
+    SphericalSWMState,
+)
+
+
+RADIUS = 6.371e6
+OMEGA_EARTH = 7.292e-5
+GRAVITY = 9.81
+DEPTH = 3000.0
+
+#: The Coriolis stand-in on a sphere: f(phi) = f0 sin(phi) with f0 = 2 Omega.
+F0_HAT = 2.0
+
+GRID = {
+    "nx": 48,
+    "ny": 24,
+    "lon_range": (0.0, 360.0),
+    "lat_range": (-80.0, 80.0),
+    "wind_profile": "zonal",
+}
+INTERIOR = (slice(2, -2), slice(2, -2))
+
+
+def relative(got, expected) -> float:
+    return float(
+        jnp.abs(jnp.asarray(got) - jnp.asarray(expected)).max()
+        / jnp.abs(jnp.asarray(expected)).max()
+    )
+
+
+class TestScaleSet:
+    def test_is_planetary(self):
+        _, scales = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert scales.kind == "planetary"
+
+    def test_unit_radius_rotation_and_depth(self):
+        model, scales = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert (scales.L, scales.H, scales.T) == (1.0, 1.0, 1.0)
+        assert model.consts.radius == 1.0
+        assert model.consts.omega == 1.0
+        assert model.consts.H0 == 1.0
+
+    def test_f0_is_twice_omega(self):
+        """Not one: on a sphere f = 2 Omega sin(phi)."""
+        _, scales = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert scales.f0 == F0_HAT
+
+    def test_rossby_round_trips(self):
+        _, scales = SphericalSWM.from_nondimensional(rossby=0.07, lamb=10.0, **GRID)
+        assert scales.rossby == pytest.approx(0.07)
+
+    def test_velocity_scale_is_two_rossby(self):
+        """U = 2 Omega a Ro, and Omega = a = 1 here."""
+        _, scales = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert float(scales.U) == pytest.approx(0.1)
+
+    def test_the_qg_factory_agrees_on_the_scale_set(self):
+        _, swm = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        _, qg = SphericalQG.from_nondimensional(rossby=0.05, **GRID)
+        assert (qg.kind, qg.L, qg.T, qg.f0, qg.U) == (
+            swm.kind,
+            swm.L,
+            swm.T,
+            swm.f0,
+            swm.U,
+        )
+
+
+class TestStratificationInputs:
+    def test_lamb_is_the_inverse_burger(self):
+        _, scales = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert scales.burger == pytest.approx(0.1)
+        assert scales.lamb == pytest.approx(10.0)
+
+    def test_burger_sets_gravity(self):
+        """Bu = gH/(f0 a)^2 with H = a = 1 and f0 = 2, so g = 4 Bu."""
+        model, _ = SphericalSWM.from_nondimensional(rossby=0.05, burger=0.25, **GRID)
+        assert model.consts.gravity == pytest.approx(1.0)
+
+    def test_froude_and_burger_agree_through_rossby(self):
+        rossby, burger = 0.05, 0.1
+        froude = rossby / np.sqrt(burger)
+        by_burger, _ = SphericalSWM.from_nondimensional(
+            rossby=rossby, burger=burger, **GRID
+        )
+        by_froude, _ = SphericalSWM.from_nondimensional(
+            rossby=rossby, froude=froude, **GRID
+        )
+        assert by_froude.consts.gravity == pytest.approx(by_burger.consts.gravity)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {},
+            {"burger": 0.1, "lamb": 10.0},
+            {"burger": 0.1, "froude": 0.15},
+            {"burger": 0.1, "froude": 0.15, "lamb": 10.0},
+        ],
+    )
+    def test_exactly_one_stratification_input_is_required(self, kwargs):
+        with pytest.raises(ValueError, match="exactly one of burger, froude or lamb"):
+            SphericalSWM.from_nondimensional(rossby=0.05, **kwargs, **GRID)
+
+    def test_the_qg_factory_takes_no_stratification(self):
+        """Barotropic QG is rigid-lid, so a Burger number is meaningless."""
+        with pytest.raises(TypeError):
+            SphericalQG.from_nondimensional(rossby=0.05, burger=0.1, **GRID)
+
+
+class TestCoefficientMapping:
+    def test_ekman_sets_the_bottom_drag(self):
+        """Ek = kappa/f0 with f0 = 2, so kappa = 2 Ek."""
+        model, _ = SphericalSWM.from_nondimensional(
+            rossby=0.05, lamb=10.0, ekman=0.01, **GRID
+        )
+        assert float(model.params.bottom_drag) == pytest.approx(0.02)
+
+    def test_lateral_ekman_sets_the_viscosity(self):
+        model, _ = SphericalSWM.from_nondimensional(
+            rossby=0.05, lamb=10.0, ekman_lateral=1e-4, **GRID
+        )
+        assert float(model.params.lateral_viscosity) == pytest.approx(2e-4)
+
+    def test_wind_carries_the_velocity_scale(self):
+        """tau_hat = tau0/(f0 U), so tau0 = tau_hat f0 U = 4 Ro tau_hat."""
+        model, _ = SphericalSWM.from_nondimensional(
+            rossby=0.05, lamb=10.0, wind_hat=0.5, **GRID
+        )
+        assert float(model.params.wind_amplitude) == pytest.approx(0.5 * 4 * 0.05)
+
+    def test_qg_coefficients_use_the_same_factor(self):
+        model, _ = SphericalQG.from_nondimensional(
+            rossby=0.05, ekman=0.01, ekman_lateral=1e-4, **GRID
+        )
+        assert float(model.params.bottom_drag) == pytest.approx(0.02)
+        assert float(model.params.lateral_viscosity) == pytest.approx(2e-4)
+
+    def test_zero_forcing_is_the_default(self):
+        model, _ = SphericalSWM.from_nondimensional(rossby=0.05, lamb=10.0, **GRID)
+        assert float(model.params.bottom_drag) == 0.0
+        assert float(model.params.lateral_viscosity) == 0.0
+        assert float(model.params.wind_amplitude) == 0.0
+
+
+class TestValidation:
+    @pytest.mark.parametrize("rossby", [0.0, -0.1, float("nan"), float("inf")])
+    def test_rossby_must_be_positive_and_finite(self, rossby):
+        with pytest.raises(ValueError, match="rossby"):
+            SphericalSWM.from_nondimensional(rossby=rossby, lamb=10.0, **GRID)
+
+    @pytest.mark.parametrize("name", ["ekman", "ekman_lateral", "wind_hat"])
+    def test_dissipation_and_forcing_must_be_non_negative(self, name):
+        with pytest.raises(ValueError, match=name):
+            SphericalSWM.from_nondimensional(
+                rossby=0.05, lamb=10.0, **{name: -1.0}, **GRID
+            )
+
+    def test_lamb_must_be_positive(self):
+        with pytest.raises(ValueError, match="lamb"):
+            SphericalSWM.from_nondimensional(rossby=0.05, lamb=-1.0, **GRID)
+
+    @pytest.mark.parametrize("name", ["ekman", "ekman_lateral", "wind_hat"])
+    def test_the_qg_factory_validates_too(self, name):
+        with pytest.raises(ValueError, match=name):
+            SphericalQG.from_nondimensional(rossby=0.05, **{name: -1.0}, **GRID)
+
+
+class TestEquivalenceWithTheDimensionalModel:
+    """The point of the exercise: the same physics, different units.
+
+    Length unit ``a``, time unit ``1/Omega``, thickness unit ``H0`` —
+    so the velocity unit is ``a Omega``, *not* the velocity scale ``U``
+    (which is ``2 Ro`` of it). Conflating the two is the easy mistake,
+    and these tests would catch it: they fail by exactly ``1/(2 Ro)``.
+    """
+
+    rossby = 0.05
+
+    def dimensional_and_nondimensional(self, **overrides):
+        f0 = 2.0 * OMEGA_EARTH
+        physical = {
+            "lateral_viscosity": 1.0e4,
+            "bottom_drag": 1.0e-7,
+            "wind_amplitude": 1.0e-8,
+            **overrides,
+        }
+        dimensional = SphericalSWM.create(
+            radius=RADIUS, omega=OMEGA_EARTH, g=GRAVITY, H0=DEPTH, **physical, **GRID
+        )
+        velocity = f0 * RADIUS * self.rossby
+        nondimensional, scales = SphericalSWM.from_nondimensional(
+            rossby=self.rossby,
+            burger=GRAVITY * DEPTH / (f0 * RADIUS) ** 2,
+            ekman=physical["bottom_drag"] / f0,
+            ekman_lateral=physical["lateral_viscosity"] / (f0 * RADIUS**2),
+            wind_hat=physical["wind_amplitude"] / (f0 * velocity),
+            check_resolution=False,
+            **GRID,
+        )
+        return dimensional, nondimensional, scales
+
+    def states(self, model):
+        rng = np.random.RandomState(0)
+        shape = (model.grid.Ny, model.grid.Nx)
+        velocity_unit = RADIUS * OMEGA_EARTH
+        h = DEPTH * (1.0 + 0.01 * rng.randn(*shape))
+        u = velocity_unit * 0.01 * rng.randn(*shape)
+        v = velocity_unit * 0.01 * rng.randn(*shape)
+        dimensional = SphericalSWMState(
+            h=jnp.asarray(h), u=jnp.asarray(u), v=jnp.asarray(v)
+        )
+        nondimensional = SphericalSWMState(
+            h=jnp.asarray(h / DEPTH),
+            u=jnp.asarray(u / velocity_unit),
+            v=jnp.asarray(v / velocity_unit),
+        )
+        return dimensional, nondimensional
+
+    def test_burger_matches_the_dimensional_configuration(self):
+        _, _, scales = self.dimensional_and_nondimensional()
+        f0 = 2.0 * OMEGA_EARTH
+        assert scales.burger == pytest.approx(GRAVITY * DEPTH / (f0 * RADIUS) ** 2)
+
+    @pytest.mark.parametrize("field", ["h", "u", "v"])
+    def test_tendencies_agree_after_rescaling(self, field):
+        dimensional, nondimensional, _ = self.dimensional_and_nondimensional()
+        state_d, state_n = self.states(dimensional)
+        state_d = dimensional.apply_boundary_conditions(state_d)
+        state_n = nondimensional.apply_boundary_conditions(state_n)
+
+        unit = DEPTH if field == "h" else RADIUS * OMEGA_EARTH
+        rescaled = getattr(dimensional.vector_field(0.0, state_d), field) / (
+            unit * OMEGA_EARTH
+        )
+        got = getattr(nondimensional.vector_field(0.0, state_n), field)
+        assert relative(rescaled[INTERIOR], got[INTERIOR]) < 1e-4
+
+    def test_the_coriolis_field_rescales(self):
+        dimensional, nondimensional, _ = self.dimensional_and_nondimensional()
+        assert (
+            relative(dimensional.f_field / OMEGA_EARTH, nondimensional.f_field) < 1e-6
+        )
+
+
+class TestQGEquivalence:
+    def test_vorticity_tendency_agrees_after_rescaling(self):
+        f0 = 2.0 * OMEGA_EARTH
+        rossby, nu, kappa = 0.05, 1.0e4, 1.0e-7
+        dimensional = SphericalQG.create(
+            radius=RADIUS,
+            omega=OMEGA_EARTH,
+            lateral_viscosity=nu,
+            bottom_drag=kappa,
+            **GRID,
+        )
+        nondimensional, _ = SphericalQG.from_nondimensional(
+            rossby=rossby,
+            ekman=kappa / f0,
+            ekman_lateral=nu / (f0 * RADIUS**2),
+            **GRID,
+        )
+        lat = np.asarray(dimensional.grid.lat_T)
+        lon = np.asarray(dimensional.grid.lon_T)
+        q = 1.0e-6 * np.sin(2.0 * lon) * np.cos(lat) ** 2
+
+        state_d = dimensional.apply_boundary_conditions(
+            SphericalQGState(q=jnp.asarray(q))
+        )
+        state_n = nondimensional.apply_boundary_conditions(
+            SphericalQGState(q=jnp.asarray(q / OMEGA_EARTH))
+        )
+        rescaled = dimensional.vector_field(0.0, state_d).q / OMEGA_EARTH**2
+        got = nondimensional.vector_field(0.0, state_n).q
+        assert relative(rescaled[INTERIOR], got[INTERIOR]) < 1e-3
+
+
+class TestEquatorialDeformationRadius:
+    """``L_eq/a = Bu**(1/4)``: the equatorial waveguide's trapping width."""
+
+    def test_passes_on_a_well_resolved_sphere(self):
+        model, _ = SphericalSWM.from_nondimensional(
+            nx=128, ny=64, rossby=0.05, lamb=10.0
+        )
+        check_equatorial_deformation_radius(None, model)
+
+    def test_fails_on_a_coarse_grid(self):
+        with pytest.raises(AssertionFailedError, match="L_eq/dx"):
+            SphericalSWM.from_nondimensional(nx=8, ny=4, rossby=0.05, lamb=1e4)
+
+    def test_the_guard_can_be_switched_off(self):
+        model, _ = SphericalSWM.from_nondimensional(
+            nx=8, ny=4, rossby=0.05, lamb=1e4, check_resolution=False
+        )
+        assert model.grid.Nx == 10
+
+    def test_radius_is_the_quarter_power_of_the_burger_number(self):
+        """Which is what makes the guard read the same at any scale."""
+        model, scales = SphericalSWM.from_nondimensional(
+            nx=128, ny=64, rossby=0.05, burger=0.0625
+        )
+        expected = scales.burger**0.25
+        c = np.sqrt(model.consts.gravity * model.consts.H0)
+        beta_eq = 2.0 * model.consts.omega / model.consts.radius
+        assert np.sqrt(c / beta_eq) == pytest.approx(expected, rel=1e-6)
+
+    def test_rejects_the_rigid_lid_qg_model(self):
+        model, _ = SphericalQG.from_nondimensional(rossby=0.05, **GRID)
+        with pytest.raises(AssertionFailedError, match="rigid-lid"):
+            check_equatorial_deformation_radius(None, model)
+
+    def test_rejects_a_model_without_a_grid(self):
+        with pytest.raises(AssertionFailedError, match="lacks consts/grid"):
+            check_equatorial_deformation_radius(None, object())
+
+    def test_warns_when_marginally_resolved(self, caplog):
+        """A warning, not a failure: it is usable but not comfortable."""
+        model, _ = SphericalSWM.from_nondimensional(
+            nx=32, ny=16, rossby=0.05, lamb=8.0, check_resolution=False
+        )
+        c = np.sqrt(model.consts.gravity * model.consts.H0)
+        beta_eq = 2.0 * model.consts.omega / model.consts.radius
+        ratio = np.sqrt(c / beta_eq) / (2.0 * np.pi / 32.0)
+        assert 2.0 < ratio < 4.0
+        check_equatorial_deformation_radius(None, model)
+
+
+def spherical_bundle(nx: int = 32, ny: int = 16):
+    """A minimal global-sphere bundle.
+
+    Built by hand rather than through a scenario: every spherical
+    scenario is still a stub (#79), so there is nothing in the registry
+    to ask for lon/lat bounds yet.
+    """
+    from somax._src.cli.scenarios._types import (
+        Constants,
+        ForcingFields,
+        Geometry,
+        InitialConditionSpec,
+        ScenarioBundle,
+    )
+
+    return ScenarioBundle(
+        name="test_sphere",
+        geometry=Geometry(
+            kind="sphere",
+            nx=nx,
+            ny=ny,
+            lon_bounds=(0.0, 360.0),
+            lat_bounds=(-80.0, 80.0),
+        ),
+        constants=Constants(f0=-1.2e-4, beta=1.0e-11),
+        forcing=ForcingFields(),
+        initial_condition=InitialConditionSpec(type="at_rest"),
+    )
+
+
+class TestRegistryWiring:
+    """The ``scenario.nondim`` path through the CLI model registry."""
+
+    def entry(self, name):
+        from somax._src.cli.models_registry import MODELS
+
+        return MODELS[name]
+
+    @pytest.mark.parametrize("name", ["spherical_swm", "spherical_qg"])
+    def test_the_entry_advertises_a_nondimensional_factory(self, name):
+        assert self.entry(name).from_nondimensional is not None
+
+    def test_swm_builds_from_a_nondim_block(self):
+        built = self.entry("spherical_swm").from_nondimensional(
+            spherical_bundle(), {"rossby": 0.05, "lamb": 8.0}
+        )
+        assert built.model.consts.radius == 1.0
+        assert built.state0.h.shape == (built.model.grid.Ny, built.model.grid.Nx)
+
+    def test_qg_builds_from_a_nondim_block(self):
+        built = self.entry("spherical_qg").from_nondimensional(
+            spherical_bundle(), {"rossby": 0.05, "ekman": 0.01}
+        )
+        assert built.model.consts.omega == 1.0
+        assert float(built.model.params.bottom_drag) == pytest.approx(0.02)
+
+    @pytest.mark.parametrize("name", ["spherical_swm", "spherical_qg"])
+    def test_an_unknown_key_is_rejected(self, name):
+        with pytest.raises(ValueError, match=r"unknown scenario\.nondim key"):
+            self.entry(name).from_nondimensional(
+                spherical_bundle(), {"rossby": 0.05, "lamb": 8.0, "nope": 1.0}
+            )
+
+    @pytest.mark.parametrize(
+        ("name", "block"),
+        [
+            ("spherical_swm", {"lamb": 8.0}),
+            ("spherical_qg", {"ekman": 0.01}),
+        ],
+    )
+    def test_rossby_is_required(self, name, block):
+        with pytest.raises(ValueError, match="requires 'rossby'"):
+            self.entry(name).from_nondimensional(spherical_bundle(), block)
+
+    def test_swm_requires_a_stratification_key(self):
+        with pytest.raises(ValueError, match="burger', 'froude' or 'lamb'"):
+            self.entry("spherical_swm").from_nondimensional(
+                spherical_bundle(), {"rossby": 0.05}
+            )
+
+    @pytest.mark.parametrize("name", ["spherical_swm", "spherical_qg"])
+    def test_a_cartesian_geometry_is_rejected(self, name):
+        from somax._src.cli.scenarios import SCENARIOS
+
+        bundle = SCENARIOS["double_gyre"].build(
+            {
+                "grid": {"nx": 8, "ny": 8, "Lx": 1.0e6, "Ly": 1.0e6},
+                "initial_condition": {"type": "at_rest"},
+            }
+        )
+        with pytest.raises(ValueError, match="lon_bounds / lat_bounds"):
+            self.entry(name).from_nondimensional(bundle, {"rossby": 0.05, "lamb": 8.0})


### PR DESCRIPTION
Closes #177. PR 10 of the non-dimensionalisation stack; based on #188.

The last family without a nondimensional factory. Uses the **planetary** scale set (`Scales.planetary`): `a = Omega = H = 1`, so `T = 1/Omega = 1`, `f0 = 2 Omega = 2` and `U = 2 Omega a Ro`.

## The factor of two

On a sphere `f(phi) = 2 Omega sin(phi)`, so `2 Omega` is the quantity that plays the role of a Cartesian `f0`. Storing it that way keeps `Scales.rossby` the same `U/(f0 L)` it is for every other family *and* makes it the conventional spherical Rossby number `U/(2 Omega a)` — at the cost of a `2` on every coefficient:

| Input | Definition | `create()` kwarg |
|---|---|---|
| `rossby` | `Ro = U/(2 Omega a)` | sets `U` |
| `burger` | `Bu = gH/(2 Omega a)²` | `g = 4 Bu` |
| `froude` | `Fr = U/sqrt(gH)` | `g`, via `Bu` |
| `lamb` | `eps = 1/Bu` | `g = 4/eps` |
| `ekman` | `kappa/(2 Omega)` | `bottom_drag` |
| `ekman_lateral` | `nu/(2 Omega a²)` | `lateral_viscosity` |
| `wind_hat` | `tau0/(2 Omega U)` | `wind_amplitude` |

`lamb` is the Lamb parameter `eps = 4 Omega² a²/(gH)` — the inverse Burger number, and the usual spelling in the spherical literature. Exactly one of `burger`, `froude` and `lamb` may be given, since they are not independent.

`SphericalQG` takes none of the three: barotropic QG is rigid-lid, so it has no gravity wave. Neither model takes a `beta_hat` — on a sphere `beta = 2 Omega cos(phi)/a` follows from the geometry rather than being a free number.

Lat/lon bounds stay in degrees. They are a geometric choice, not a scale.

## The equatorial deformation radius guard

`sqrt(gH)/f0` diverges at the equator, where `f` vanishes, so the existing `deformation_radius` check says nothing useful about a global run. The finite scale that replaces it is

```
L_eq = sqrt(c / beta_eq),   c = sqrt(gH),   beta_eq = 2 Omega / a
```

the trapping width of the equatorial waveguide — Kelvin, Yanai and equatorial Rossby waves all live inside it. In Burger terms that is exactly `L_eq/a = Bu^(1/4)`, so the guard is scale-free and reads the same on a nondimensional sphere as on Earth.

New preflight assertion `equatorial_deformation_radius`, run by default from `SphericalSWM.from_nondimensional` (`check_resolution=False` to opt out). It compares against the **widest** interior cell, not the narrowest: zonal cells are widest at the equator, which is exactly where the waveguide sits. Spherical QG is rejected with a message saying why, rather than silently skipped.

## Incidental fix

`resolve_burger`'s `froude` branch returned `(rossby/froude)**2` un-coerced. Given a numpy input that is a `np.float64`, which lands in an `eqx.field(static=True)` and trips equinox's *"A JAX array is being set as static"* warning — so every model built through the `froude` spelling, in any family, warned. Now `float(...)`.

## Also wired

- `scenario.nondim` blocks for `spherical_swm` and `spherical_qg` in the CLI model registry, with per-model key validation.
- `content/notes/nondimensional_runs.md` gains a "Spherical models" section covering the planetary set, the factor of two, and the equatorial guard.

## Testing

54 new tests in `tests/models/test_spherical_nondim.py`, including tendency-level equivalence against the dimensional models for both families. Those pin the easy mistake: the velocity *unit* is `a*Omega`, while the velocity *scale* `U` is `2 Ro` of it — conflating them fails by exactly `1/(2 Ro)`, and in float64 the equivalence holds to 3e-16.

Full suite: **1156 passed**, with `ruff check`, `ruff format --check` and `ty check somax` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVsthYtEskSJKq7c8SsJUg)_